### PR TITLE
fix(studio): hide default Search page and block its custom blocks

### DIFF
--- a/apps/studio/src/constants/sitemap.ts
+++ b/apps/studio/src/constants/sitemap.ts
@@ -1,1 +1,5 @@
 export const INDEX_PAGE_PERMALINK = "_index"
+
+// The system-managed Search page sits at the root of every site under this
+// permalink, so it is only that page when `parentId === null` as well.
+export const SEARCH_PAGE_PERMALINK = "search"

--- a/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebarContent.tsx
+++ b/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebarContent.tsx
@@ -55,6 +55,7 @@ export const DirectorySidebarContent = ({
         resourceId,
         siteId,
         limit: 25,
+        includeSearchPage: false,
       },
       {
         getNextPageParam: (lastPage) => lastPage.nextOffset,

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -28,39 +28,6 @@ interface ResourceTableMenuProps {
   parentId: ResourceTableData["parentId"]
 }
 
-// The default Search page (permalink /search, no parent) is a system-managed
-// page used to render SearchSG results. Its slug is hardcoded into the site
-// renderer, so users must not be able to edit its settings, move it, or
-// delete it — any of those would break search on the published site.
-const SearchPageMenuItems = () => {
-  return (
-    <>
-      <MenuItem
-        isDisabled
-        icon={<BiCog fontSize="1rem" />}
-        tooltip="This is a default page and its settings cannot be edited."
-      >
-        Edit settings
-      </MenuItem>
-      <MenuItem
-        isDisabled
-        icon={<BiFolderOpen fontSize="1rem" />}
-        tooltip="This is a default page that cannot be moved."
-      >
-        Move to...
-      </MenuItem>
-      <MenuItem
-        isDisabled
-        colorScheme="critical"
-        icon={<BiTrash fontSize="1rem" />}
-        tooltip="This is a default page that cannot be removed."
-      >
-        Delete
-      </MenuItem>
-    </>
-  )
-}
-
 export const ResourceTableMenu = ({
   resourceId,
   title,
@@ -75,7 +42,6 @@ export const ResourceTableMenu = ({
   const setResourceModalState = useSetAtom(deleteResourceModalAtom)
   const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
   const setPageSettingsModalState = useSetAtom(pageSettingsModalAtom)
-  const isSearchPage = permalink === "search" && parentId === null
 
   return (
     <Menu isLazy size="sm">
@@ -88,73 +54,67 @@ export const ResourceTableMenu = ({
       />
       <Portal>
         <MenuList minWidth="8rem">
-          {isSearchPage ? (
-            <SearchPageMenuItems />
-          ) : (
-            <>
-              {/* TODO: Open edit modal depending on resource  */}
-              {(type === ResourceType.Page ||
-                type === ResourceType.CollectionPage ||
-                type === ResourceType.CollectionLink) && (
-                <MenuItem
-                  onClick={() =>
-                    setPageSettingsModalState({
-                      pageId: resourceId,
-                      type,
-                    })
-                  }
-                  icon={<BiCog fontSize="1rem" />}
-                >
-                  Edit settings
-                </MenuItem>
-              )}
-              {type === ResourceType.Folder && (
-                <MenuItem
-                  onClick={() =>
-                    setFolderSettingsModalState({
-                      folderId: resourceId,
-                    })
-                  }
-                  icon={<BiCog fontSize="1rem" />}
-                >
-                  Edit folder settings
-                </MenuItem>
-              )}
-              {(type === ResourceType.Page ||
-                type === ResourceType.CollectionPage ||
-                type === ResourceType.CollectionLink ||
-                type === ResourceType.Folder ||
-                type === ResourceType.Collection) && (
-                // TODO: we need to change the resourceid next time when we implement root level permissions
-                <Can do="move" on={{ parentId }}>
-                  <MenuItem
-                    as="button"
-                    onClick={handleMoveResourceClick}
-                    icon={<BiFolderOpen fontSize="1rem" />}
-                    aria-label={`Move resource to another location for ${title}`}
-                  >
-                    Move to...
-                  </MenuItem>
-                </Can>
-              )}
-              {resourceType !== ResourceType.RootPage && (
-                <Can do="delete" on={{ parentId }}>
-                  <MenuItem
-                    onClick={() => {
-                      setResourceModalState({
-                        title,
-                        resourceId,
-                        resourceType,
-                      })
-                    }}
-                    colorScheme="critical"
-                    icon={<BiTrash fontSize="1rem" />}
-                  >
-                    Delete
-                  </MenuItem>
-                </Can>
-              )}
-            </>
+          {/* TODO: Open edit modal depending on resource  */}
+          {(type === ResourceType.Page ||
+            type === ResourceType.CollectionPage ||
+            type === ResourceType.CollectionLink) && (
+            <MenuItem
+              onClick={() =>
+                setPageSettingsModalState({
+                  pageId: resourceId,
+                  type,
+                })
+              }
+              icon={<BiCog fontSize="1rem" />}
+            >
+              Edit settings
+            </MenuItem>
+          )}
+          {type === ResourceType.Folder && (
+            <MenuItem
+              onClick={() =>
+                setFolderSettingsModalState({
+                  folderId: resourceId,
+                })
+              }
+              icon={<BiCog fontSize="1rem" />}
+            >
+              Edit folder settings
+            </MenuItem>
+          )}
+          {(type === ResourceType.Page ||
+            type === ResourceType.CollectionPage ||
+            type === ResourceType.CollectionLink ||
+            type === ResourceType.Folder ||
+            type === ResourceType.Collection) && (
+            // TODO: we need to change the resourceid next time when we implement root level permissions
+            <Can do="move" on={{ parentId }}>
+              <MenuItem
+                as="button"
+                onClick={handleMoveResourceClick}
+                icon={<BiFolderOpen fontSize="1rem" />}
+                aria-label={`Move resource to another location for ${title}`}
+              >
+                Move to...
+              </MenuItem>
+            </Can>
+          )}
+          {resourceType !== ResourceType.RootPage && (
+            <Can do="delete" on={{ parentId }}>
+              <MenuItem
+                onClick={() => {
+                  setResourceModalState({
+                    title,
+                    resourceId,
+                    resourceType,
+                  })
+                }}
+                colorScheme="critical"
+                icon={<BiTrash fontSize="1rem" />}
+              >
+                Delete
+              </MenuItem>
+            </Can>
           )}
         </MenuList>
       </Portal>

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -16,6 +16,7 @@ import { DragDropContext, Droppable } from "@hello-pangea/dnd"
 import { Infobox, useToast } from "@opengovsg/design-system-react"
 import {
   getComponentSchema,
+  ISOMER_PAGE_LAYOUTS,
   ISOMER_USABLE_PAGE_LAYOUTS,
   schema,
 } from "@opengovsg/isomer-components"
@@ -380,12 +381,10 @@ export default function RootStateDrawer() {
       .map(Number),
   )
 
-  // NOTE: if a page has either of these `layouts`,
-  // we should disable them from adding blocks
-  // because folder index pages aren't intended to have
-  // content yet and components don't render content
-  // for collection index pages
-  const canAddBlocks = pageLayout !== "collection"
+  // Collection and system-managed Search pages do not render custom content.
+  const canAddBlocks =
+    pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
+    pageLayout !== ISOMER_PAGE_LAYOUTS.Search
 
   const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
 
@@ -528,7 +527,7 @@ export default function RootStateDrawer() {
                 <VStack gap="1.5rem" w="100%">
                   <VStack w="100%" h="100%" gap="1rem">
                     <Flex flexDirection="row" w="100%">
-                      {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection && (
+                      {canAddBlocks && (
                         <VStack gap="0.25rem" align="start" flex={1}>
                           <Text textStyle="subhead-1">Custom blocks</Text>
                           <Text

--- a/apps/studio/src/features/editing-experience/components/Drawer/__tests__/RootStateDrawer.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/__tests__/RootStateDrawer.browser.test.tsx
@@ -1,0 +1,118 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
+import { theme } from "~/theme"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import RootStateDrawer from "../RootStateDrawer"
+
+const noop = vi.hoisted(() => vi.fn())
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { pageId: "1", siteId: "1" } }),
+}))
+
+vi.mock("posthog-js", () => ({ default: { capture: noop } }))
+
+vi.mock("~/hooks/useIsUserIsomerAdmin", () => ({
+  useIsUserIsomerAdmin: () => ({ isAdmin: false, isLoading: false }),
+}))
+
+vi.mock("~/hooks/useNewCollectionTagsManagement", () => ({
+  useNewCollectionTagsManagement: () => false,
+}))
+
+vi.mock("~/utils/trpc", () => ({
+  trpc: {
+    page: {
+      readPage: {
+        useSuspenseQuery: () => [{ scheduledAt: null }],
+      },
+      reorderBlock: {
+        useMutation: () => ({ mutate: noop }),
+      },
+      updatePageBlob: {
+        useMutation: () => ({ mutate: noop, isPending: false }),
+      },
+    },
+    useUtils: () => ({
+      page: {
+        readPage: { invalidate: noop },
+        readPageAndBlob: { invalidate: noop },
+      },
+      collection: {
+        countTagOptionsUsage: { invalidate: noop },
+      },
+    }),
+  },
+}))
+
+const SEARCH_PAGE: IsomerSchema = {
+  page: { title: "Search", description: "Search results" },
+  layout: "search",
+  content: [],
+  version: "0.1.0",
+}
+
+const CONTENT_PAGE: IsomerSchema = {
+  page: { title: "About us", description: "About us" },
+  layout: "content",
+  content: [],
+  version: "0.1.0",
+}
+
+const renderDrawer = ({
+  pageState,
+  permalink,
+  title,
+}: {
+  pageState: IsomerSchema
+  permalink: string
+  title: string
+}) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <EditorDrawerProvider
+        initialPageState={pageState}
+        type={ResourceType.Page}
+        permalink={permalink}
+        siteId={1}
+        pageId={1}
+        updatedAt={new Date()}
+        title={title}
+      >
+        <RootStateDrawer />
+      </EditorDrawerProvider>
+    </ThemeProvider>,
+  )
+
+describe("RootStateDrawer", () => {
+  it("does not allow adding blocks on the system Search page", () => {
+    // Arrange / Act
+    renderDrawer({
+      pageState: SEARCH_PAGE,
+      permalink: "search",
+      title: "Search",
+    })
+
+    // Assert
+    expect(screen.queryByRole("button", { name: "Add block" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Add a new block" })).toBeNull()
+    expect(screen.queryByText("Custom blocks")).toBeNull()
+  })
+
+  it("allows adding blocks on a regular content page", () => {
+    // Arrange / Act
+    renderDrawer({
+      pageState: CONTENT_PAGE,
+      permalink: "about-us",
+      title: "About us",
+    })
+
+    // Assert
+    expect(screen.queryByRole("button", { name: "Add block" })).not.toBeNull()
+    expect(screen.queryByText("Custom blocks")).not.toBeNull()
+  })
+})

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -21,6 +21,7 @@ export const getChildrenSchema = z
   .object({
     resourceId: z.union([bigIntSchema, z.null()]),
     siteId: z.string().min(0),
+    includeSearchPage: z.boolean().optional().default(true),
   })
   .merge(infiniteOffsetPaginationSchema)
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -12,7 +12,10 @@ import {
 import { TRPCError } from "@trpc/server"
 import { format, isBefore } from "date-fns"
 import { get, isEmpty, isEqual, pick } from "lodash-es"
-import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
+import {
+  INDEX_PAGE_PERMALINK,
+  SEARCH_PAGE_PERMALINK,
+} from "~/constants/sitemap"
 import {
   sendCancelSchedulePageEmail,
   sendScheduledPageEmail,
@@ -820,7 +823,10 @@ export const pageRouter = router({
 
           // The search page (permalink /search, no parent) is a default page
           // whose settings cannot be edited.
-          if (resource.permalink === "search" && resource.parentId === null) {
+          if (
+            resource.permalink === SEARCH_PAGE_PERMALINK &&
+            resource.parentId === null
+          ) {
             throw new TRPCError({
               code: "BAD_REQUEST",
               message: "The search page settings cannot be edited",

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -594,6 +594,47 @@ describe("resource.router", async () => {
       expect(result).toMatchObject(expected)
     })
 
+    it("should only hide the default Search page when requested", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        permalink: "search",
+        title: "Search",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        permalink: "about",
+        title: "About",
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const linkPickerResult = await caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: null,
+      })
+      const directorySidebarResult = await caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: null,
+        includeSearchPage: false,
+      })
+
+      // Assert
+      expect(linkPickerResult.items.map(({ permalink }) => permalink)).toEqual([
+        "about",
+        "search",
+      ])
+      expect(
+        directorySidebarResult.items.map(({ permalink }) => permalink),
+      ).toEqual(["about"])
+    })
+
     it("should not return FolderMeta, CollectionMeta, and CollectionLink as children", async () => {
       // Arrange
       const { site } = await setupSite()
@@ -2299,6 +2340,33 @@ describe("resource.router", async () => {
       expect(result).toEqual(numberOfPages + numberOfFolders)
     })
 
+    it("should exclude the default Search page from the root count", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupPageResource({
+        siteId: site.id,
+        permalink: "search",
+        title: "Search",
+        resourceType: "Page",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        permalink: "about",
+        title: "About",
+        resourceType: "Page",
+      })
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.countWithoutRoot({ siteId: site.id })
+
+      // Assert
+      expect(result).toBe(1)
+    })
+
     it("should return count of resources nested inside the resourceId", async () => {
       // Arrange
       const { folder: folderToUse, site } = await setupFolder({
@@ -2584,6 +2652,33 @@ describe("resource.router", async () => {
         .sort(testListComparable)
         .slice(0, 10)
       expect(expected).toMatchObject(result)
+    })
+
+    it("should exclude the default Search page from the root resource list", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupPageResource({
+        siteId: site.id,
+        permalink: "search",
+        title: "Search",
+        resourceType: "Page",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        permalink: "about",
+        title: "About",
+        resourceType: "Page",
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = await caller.listWithoutRoot({ siteId: site.id })
+
+      // Assert
+      expect(result.map(({ permalink }) => permalink)).toEqual(["about"])
     })
 
     it("should return resources (respecting the limit) nested inside the resourceId", async () => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -208,7 +208,10 @@ export const resourceRouter = router({
     .input(getChildrenSchema)
     .output(getChildrenOutputSchema)
     .query(
-      async ({ ctx, input: { resourceId, siteId, cursor: offset, limit } }) => {
+      async ({
+        ctx,
+        input: { resourceId, siteId, cursor: offset, limit, includeSearchPage },
+      }) => {
         await bulkValidateUserPermissionsForResources({
           action: "read",
           resourceIds: [resourceId],
@@ -249,6 +252,9 @@ export const resourceRouter = router({
 
         if (resourceId === null) {
           query = query.where("parentId", "is", null)
+          if (!includeSearchPage) {
+            query = query.where("Resource.permalink", "!=", "search")
+          }
         } else {
           query = query.where("Resource.parentId", "=", String(resourceId))
         }
@@ -646,7 +652,9 @@ export const resourceRouter = router({
       if (resourceId) {
         query = query.where("Resource.parentId", "=", String(resourceId))
       } else {
-        query = query.where("Resource.parentId", "is", null)
+        query = query
+          .where("Resource.parentId", "is", null)
+          .where("Resource.permalink", "!=", "search")
       }
 
       const result = await query.executeTakeFirst()
@@ -678,7 +686,9 @@ export const resourceRouter = router({
         if (resourceId) {
           query = query.where("Resource.parentId", "=", String(resourceId))
         } else {
-          query = query.where("Resource.parentId", "is", null)
+          query = query
+            .where("Resource.parentId", "is", null)
+            .where("Resource.permalink", "!=", "search")
         }
 
         query = applyResourceOrderBy(query, orderBy)

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server"
 import { jsonObjectFrom } from "kysely/helpers/postgres"
 import { get } from "lodash-es"
 import { USER_LINKABLE_RESOURCE_TYPES } from "~/constants/resources"
+import { SEARCH_PAGE_PERMALINK } from "~/constants/sitemap"
 import {
   countResourceSchema,
   deleteResourceSchema,
@@ -253,7 +254,11 @@ export const resourceRouter = router({
         if (resourceId === null) {
           query = query.where("parentId", "is", null)
           if (!includeSearchPage) {
-            query = query.where("Resource.permalink", "!=", "search")
+            query = query.where(
+              "Resource.permalink",
+              "!=",
+              SEARCH_PAGE_PERMALINK,
+            )
           }
         } else {
           query = query.where("Resource.parentId", "=", String(resourceId))
@@ -385,7 +390,10 @@ export const resourceRouter = router({
 
             // Prevent users from moving the search page (permalink /search, no parent)
             // This is a special page that is used to display the SearchSG results
-            if (toMove.permalink === "search" && toMove.parentId === null) {
+            if (
+              toMove.permalink === SEARCH_PAGE_PERMALINK &&
+              toMove.parentId === null
+            ) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
                 message: "The search page cannot be moved",
@@ -654,7 +662,7 @@ export const resourceRouter = router({
       } else {
         query = query
           .where("Resource.parentId", "is", null)
-          .where("Resource.permalink", "!=", "search")
+          .where("Resource.permalink", "!=", SEARCH_PAGE_PERMALINK)
       }
 
       const result = await query.executeTakeFirst()
@@ -688,7 +696,7 @@ export const resourceRouter = router({
         } else {
           query = query
             .where("Resource.parentId", "is", null)
-            .where("Resource.permalink", "!=", "search")
+            .where("Resource.permalink", "!=", SEARCH_PAGE_PERMALINK)
         }
 
         query = applyResourceOrderBy(query, orderBy)
@@ -751,7 +759,10 @@ export const resourceRouter = router({
 
         // Prevent users from deleting the search page (permalink /search, no parent)
         // This is a special page that is used to display the SearchSG results
-        if (before.permalink === "search" && before.parentId === null) {
+        if (
+          before.permalink === SEARCH_PAGE_PERMALINK &&
+          before.parentId === null
+        ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "The search page cannot be deleted",

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -1,6 +1,7 @@
 import type { IsomerSiteConfigProps } from "@opengovsg/isomer-components"
 import type { Notification } from "~/schemas/site"
 import { TRPCError } from "@trpc/server"
+import { SEARCH_PAGE_PERMALINK } from "~/constants/sitemap"
 import { ResourceState, ResourceType } from "~/server/modules/database"
 
 import type {
@@ -380,7 +381,7 @@ export const createSite = async ({ siteName, userId }: CreateSiteProps) => {
       .insertInto("Resource")
       .values({
         draftBlobId: String(blobId),
-        permalink: "search",
+        permalink: SEARCH_PAGE_PERMALINK,
         siteId,
         type: ResourceType.Page,
         title: "Search",


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 8 | +109 | -116 |
| 🧪 Test | 2 | +213 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The default Search page (permalink `/search`, no parent) is created automatically for every site and is not user-editable, but it was still listed in the site root resource table and in the directory sidebar. Clicking into it and pressing "Add block" crashed Studio: `ComponentSelector` throws `Unsupported page layout: search` because the `search` layout has no allowed-blocks entry for `ResourceType.Page`. This is a follow-up to #2080, which locked down edit/move/delete for the same page but left it reachable and its block editor unguarded.

Closes [ISOM-2511](https://linear.app/ogp/issue/ISOM-2511/studio-search-page-is-clickable-and-crashes-studio-when-add-block-is)

## Solution

Hide the page from the two lists that present the site's own content tree, and make the drawer treat `search` the same way it already treats `collection`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- `resource.getChildrenOf` accepts a new optional `includeSearchPage` input (defaults to `true`, so existing callers are unaffected). The directory sidebar passes `false`; the link editor and redirect destination pickers keep listing `/search` so editors can still link to it.
- The reserved `search` permalink is now a single `SEARCH_PAGE_PERMALINK` constant in `~/constants/sitemap`, next to the existing `INDEX_PAGE_PERMALINK`, replacing the literal across site creation, the move/delete/settings guards, and the new listing filters. Tests keep the literal on purpose so a rename has to be acknowledged.
- Removed `SearchPageMenuItems` and the `isSearchPage` branch from `ResourceTableMenu`. Hiding the page from `listWithoutRoot` makes that branch unreachable — `ResourceTable` is its only consumer and inside a folder `parentId` is never `null` — so this is the same cleanup #2080 applied to `CollectionTableMenu`. The server-side guards on move, delete, and `updateSettings` are untouched and remain the real enforcement.

**Bug Fixes**:

- Pressing "Add block" on the Search page no longer crashes Studio. `canAddBlocks` in `RootStateDrawer` now excludes the `search` layout as well as `collection`, which hides both the "Add block" button and the empty-state "Add a new block" button.
- The Search page no longer appears in the site root resource table or the directory sidebar. `resource.countWithoutRoot` and `resource.listWithoutRoot` exclude `permalink = 'search'` when listing the site root only, so identically-named resources nested inside folders are untouched.
- The drawer's "Custom blocks — Use blocks to display your content." heading is now gated on `canAddBlocks`, so layouts that cannot take custom blocks no longer show an empty section inviting the user to add them. Previously this affected the Search page; `collection` was already excluded.

## Tests

- `pnpm test:unit -- src/server/modules/resource/__tests__/resource.router.test.ts` — 157 passed, 14 skipped, including three new cases covering `getChildrenOf` with and without `includeSearchPage`, and the Search page's exclusion from `countWithoutRoot` and `listWithoutRoot`.
- `pnpm exec vitest run --project browser src/features/editing-experience/components/Drawer/__tests__/RootStateDrawer.browser.test.tsx` — 2 passed. New browser test asserting the Search page hides the add-block affordances and the "Custom blocks" heading, plus a `content` layout case asserting they are still shown.
- After the review follow-up: `pnpm test:unit` over `resource.router.test.ts`, `page.router.test.ts`, and `site/__tests__` — 373 passed, 21 skipped; the full browser project — 8 files, 47 passed; `pnpm typecheck` and `pnpm lint` clean on every touched file.

**Manual Verification Steps**:

- [ ] Open a site in Studio and confirm the root resource table no longer has a "Search" row, and that the pagination count dropped by one accordingly.
- [ ] Confirm the left directory sidebar no longer lists `/search` under Home, and that folders, collections, and pages still appear and expand normally.
- [ ] Edit any page, add a link via the link editor, and confirm `/search` is still selectable in the resource picker.
- [ ] Go to Settings → Redirects, add a redirect, and confirm `/search` is still selectable as a destination page.
- [ ] Open the Search page's editor directly via its URL (`/sites/<siteId>/pages/<searchPageId>`) and confirm the drawer shows "Fixed blocks" but no "Custom blocks" section, no "Add block" button, and no crash.
- [ ] Open a regular content page and confirm "Custom blocks" and "Add block" still work as before.
- [ ] On the root resource table and inside a folder, open the "..." menu on a page, a folder, and a collection, and confirm "Edit settings" / "Edit folder settings", "Move to...", and "Delete" all still appear and work (the dead Search-page menu branch was removed).

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR hides the system-managed root Search page from Studio’s content-tree surfaces while preserving it in link-oriented resource pickers, and prevents Search pages from exposing unsupported custom-block controls.

- Adds root-only Search-page filtering to resource list and count procedures.
- Adds an opt-out flag so the directory sidebar hides Search while existing picker callers continue including it.
- Reuses a shared Search permalink constant across creation and mutation guards.
- Extends drawer tests and resource-router tests for the new behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/resource/resource.router.ts | Applies the Search-page exclusion only to root queries while preserving nested resources and default picker behavior. |
| apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx | Consistently gates the custom-block heading and both add-block affordances for collection and Search layouts. |
| apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebarContent.tsx | Explicitly opts the navigation tree out of receiving the system Search page. |
| apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx | Removes a menu branch rendered unreachable by the root resource query, while server-side mutation guards remain. |
| apps/studio/src/schemas/resource.ts | Adds a backward-compatible includeSearchPage input whose default preserves existing callers. |
| apps/studio/src/features/editing-experience/components/Drawer/__tests__/RootStateDrawer.browser.test.tsx | Covers hidden Search-page controls and retained controls for ordinary content pages. |
| apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts | Covers picker/sidebar inclusion behavior and root list/count exclusion. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Root[Root resource request] --> Surface{Calling surface}
    Surface -->|Resource table| Filter[Exclude root /search]
    Surface -->|Directory sidebar| Flag[includeSearchPage=false]
    Surface -->|Link or redirect picker| Default[includeSearchPage=true]
    Filter --> Content[Show editable content]
    Flag --> Content
    Default --> Search[Keep /search selectable]
    Search --> Editor[Direct Search editor]
    Editor --> Guard[Hide custom-block controls]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(studio): extract SEARCH\_PAGE\_PE..."](https://github.com/opengovsg/isomer/commit/ef94fa85238a916592292be469145f19d57338df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54227073)</sub>

<!-- /greptile_comment -->