### PR TITLE
fix(component): modify list margin

### DIFF
--- a/packages/components/src/templates/next/components/native/Heading/Heading.tsx
+++ b/packages/components/src/templates/next/components/native/Heading/Heading.tsx
@@ -10,7 +10,7 @@ export const Heading = ({
     return (
       <h2
         id={id}
-        className="prose-display-sm text-base-content-strong [&:not(:first-child)]:mt-14"
+        className="prose-display-sm text-base-content-strong [&:not(:first-child)]:mt-14 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
       >
         {getTextAsHtml({
@@ -25,7 +25,7 @@ export const Heading = ({
     return (
       <h3
         id={id}
-        className="prose-display-xs text-base-content-strong [&:not(:first-child)]:mt-9"
+        className="prose-display-xs text-base-content-strong [&:not(:first-child)]:mt-9 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
       >
         {getTextAsHtml({
@@ -40,7 +40,7 @@ export const Heading = ({
     return (
       <h4
         id={id}
-        className="prose-title-md-semibold text-base-content-strong [&:not(:first-child)]:mt-8"
+        className="prose-title-md-semibold text-base-content-strong [&:not(:first-child)]:mt-8 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
       >
         {getTextAsHtml({
@@ -55,7 +55,7 @@ export const Heading = ({
     return (
       <h5
         id={id}
-        className="prose-headline-lg-semibold text-base-content-strong [&:not(:first-child)]:mt-7"
+        className="prose-headline-lg-semibold text-base-content-strong [&:not(:first-child)]:mt-7 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
       >
         {getTextAsHtml({
@@ -69,7 +69,7 @@ export const Heading = ({
   return (
     <h6
       id={id}
-      className="prose-headline-base-semibold text-base-content-strong [&:not(:first-child)]:mt-6"
+      className="prose-headline-base-semibold text-base-content-strong [&:not(:first-child)]:mt-6 [&:not(:last-child)]:mb-6"
       dir={dir ?? undefined}
     >
       {getTextAsHtml({

--- a/packages/components/src/templates/next/components/native/ListItem/ListItem.tsx
+++ b/packages/components/src/templates/next/components/native/ListItem/ListItem.tsx
@@ -6,7 +6,7 @@ import { UnorderedList } from "../UnorderedList"
 
 export const ListItem = ({ content, level, site }: ListItemProps) => {
   return (
-    <li className="my-[15px] pl-2 sm:my-5 [&_>_p]:inline">
+    <li className="my-3 pl-2 [&_>_p]:inline">
       {content.map((item, index) => {
         if (item.type === "paragraph") {
           return <Paragraph key={index} {...item} site={site} />

--- a/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
+++ b/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
@@ -20,11 +20,11 @@ export const OrderedList = ({
   site,
 }: OrderedListProps) => {
   return (
-    // `mt-3` matches the item rhythm (`my-3` on ListItem) so a nested sublist
-    // sits in the same vertical rhythm as its siblings. Above a top-level list
-    // the preceding block's bottom margin collapses over this and wins.
+    // Nested sublists (level set) use `mt-3` to match the item rhythm (`my-3`
+    // on ListItem). Top-level lists keep `mt-6` because preceding blocks like
+    // Table or Callout have no bottom margin to collapse over a smaller value.
     <ol
-      className={`mt-3 ps-9 marker:text-base-content ${getOrderedListType(level)}`}
+      className={`${level ? "mt-3" : "mt-6"} ps-9 marker:text-base-content ${getOrderedListType(level)}`}
       start={attrs?.start}
     >
       {content.map((item, index) => (

--- a/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
+++ b/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
@@ -20,8 +20,11 @@ export const OrderedList = ({
   site,
 }: OrderedListProps) => {
   return (
+    // `mt-3` matches the item rhythm (`my-3` on ListItem) so a nested sublist
+    // sits in the same vertical rhythm as its siblings. Above a top-level list
+    // the preceding block's bottom margin collapses over this and wins.
     <ol
-      className={`mt-6 ps-9 marker:text-base-content ${getOrderedListType(level)}`}
+      className={`mt-3 ps-9 marker:text-base-content ${getOrderedListType(level)}`}
       start={attrs?.start}
     >
       {content.map((item, index) => (

--- a/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
+++ b/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
@@ -15,8 +15,11 @@ const getUnorderedListType = (level?: number) => {
 
 export const UnorderedList = ({ content, level, site }: UnorderedListProps) => {
   return (
+    // `mt-3` matches the item rhythm (`my-3` on ListItem) so a nested sublist
+    // sits in the same vertical rhythm as its siblings. Above a top-level list
+    // the preceding block's bottom margin collapses over this and wins.
     <ul
-      className={`mt-6 ps-9 marker:text-base-content ${getUnorderedListType(level)}`}
+      className={`mt-3 ps-9 marker:text-base-content ${getUnorderedListType(level)}`}
     >
       {content.map((item, index) => (
         <ListItem key={index} {...item} level={level} site={site} />

--- a/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
+++ b/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
@@ -15,11 +15,11 @@ const getUnorderedListType = (level?: number) => {
 
 export const UnorderedList = ({ content, level, site }: UnorderedListProps) => {
   return (
-    // `mt-3` matches the item rhythm (`my-3` on ListItem) so a nested sublist
-    // sits in the same vertical rhythm as its siblings. Above a top-level list
-    // the preceding block's bottom margin collapses over this and wins.
+    // Nested sublists (level set) use `mt-3` to match the item rhythm (`my-3`
+    // on ListItem). Top-level lists keep `mt-6` because preceding blocks like
+    // Table or Callout have no bottom margin to collapse over a smaller value.
     <ul
-      className={`mt-3 ps-9 marker:text-base-content ${getUnorderedListType(level)}`}
+      className={`${level ? "mt-3" : "mt-6"} ps-9 marker:text-base-content ${getUnorderedListType(level)}`}
     >
       {content.map((item, index) => (
         <ListItem key={index} {...item} level={level} site={site} />

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1087,6 +1087,36 @@ export const Default: Story = {
             ],
           },
           {
+            type: "unorderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "List item directly below a table",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      { type: "text", text: "Second item to show the rhythm" },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
             type: "paragraph",
             content: [{ type: "text", text: "This is yet another paragraph" }],
           },
@@ -1104,6 +1134,47 @@ export const Default: Story = {
               {
                 type: "text",
                 text: "In the realm of human cognition, irrationality often reigns supreme, defying the logic that ostensibly governs our decisions and actions. It manifests in myriad ways, from the subtle biases that influence our perceptions to the outright contradictions that confound our rational minds. We find ourselves ensnared in cognitive dissonance, grappling with conflicting beliefs and emotions that lead us astray from the path of reason. Despite our best intentions, we succumb to the allure of irrationality, surrendering to the whims of impulse and emotion. Our choices become a tangled web of contradictions, driven by instinct rather than careful deliberation. We cling to superstitions and fallacies, seeking comfort in the irrationality that offers solace amidst life's uncertainties. It is a paradoxical dance, where the irrational often masquerades as wisdom, leading us down paths fraught with confusion and folly. Yet, in embracing our irrationality, we find a peculiar sort of freedom, liberated from the constraints of logic and reason. We navigate the world with a blend of intuition and irrationality, embracing the chaos that defines the human experience. And so, in the tapestry of existence, irrationality weaves its intricate threads, adding depth and complexity to the fabric of our lives.",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "image",
+        src: "https://images.unsplash.com/photo-1527436826045-8805c615a6df?w=1280",
+        alt: "Two rhinos. A rhino is peacefully grazing on grass in a field in front of the other rhino.",
+        caption: "An image directly followed by a list",
+      },
+      {
+        type: "prose",
+        content: [
+          {
+            type: "unorderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "List item directly below an image",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      { type: "text", text: "Second item to show the rhythm" },
+                    ],
+                  },
+                ],
               },
             ],
           },


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +14 | -8 |
| 🧪 Test | 1 | +71 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Bulleted and numbered lists (ul/ol) currently use a high line-gap between items. This was originally set for readability/accessibility, but the visual result hurts the list's gestalt — with too much space between items, list items no longer read as a cohesive, related group; each item looks visually disconnected from the others.

Closes [ISOM-2495]

## Solution

* Reduced to my-3
* Adjusted spacing on headings too

## Before & After

Before:
<img width="417" height="421" alt="image" src="https://github.com/user-attachments/assets/eff6b4c1-54c5-43f6-9339-a08d08fcf3f2" />

After:
<img width="360" height="349" alt="image" src="https://github.com/user-attachments/assets/cd45ef8a-3274-462e-a34d-93adab3a46cf" />

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces spacing between list items while preserving larger top margins for top-level lists and adds consistent spacing after headings.
- Changes list-item spacing to `my-3`.
- Uses `mt-3` for nested lists and retains `mt-6` for top-level lists.
- Adds bottom margins to headings and Storybook examples for lists following tables and images.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/components/native/Heading/Heading.tsx | Adds a consistent bottom margin to non-final headings. |
| packages/components/src/templates/next/components/native/ListItem/ListItem.tsx | Reduces list-item vertical spacing to improve visual grouping. |
| packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx | Preserves top-level spacing while tightening nested ordered-list spacing. |
| packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx | Preserves top-level spacing while tightening nested unordered-list spacing. |
| packages/components/src/templates/next/layouts/Content/Content.stories.tsx | Adds representative table-to-list and image-to-list spacing scenarios. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: margin should not collapse below so..."](https://github.com/opengovsg/isomer/commit/33b47810d8a64a2444ae319540de9d9757182b09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54233207)</sub>

<!-- /greptile_comment -->