### PR TITLE
fix(studio): validate resource moves before submitting, not after

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -125,8 +125,6 @@ const MoveResourceContent = withSuspense(
       sourceId: movedItem?.id,
       destinationId: curResourceId ?? null,
     })
-    // movedResourceId: movedItem.id,
-    // destinationResourceId: curResourceId ?? null,
 
     const [shouldCreateRedirect, setShouldCreateRedirect] = useState(true)
     const [{ fullPermalink: movedFullPermalink }] =
@@ -188,11 +186,13 @@ const MoveResourceContent = withSuspense(
               existingResource={movedItem ?? undefined}
               onChange={(resourceId) => setCurResourceId(resourceId)}
             />
-            {curResourceId !== undefined && errorMessage && (
-              <Infobox variant="error" size="sm" w="full">
-                {errorMessage}
-              </Infobox>
-            )}
+            {curResourceId !== undefined &&
+              errorMessage &&
+              !isValidMoveLoading && (
+                <Infobox variant="error" size="sm" w="full">
+                  {errorMessage}
+                </Infobox>
+              )}
             {showUrlChangeNotice && (
               <VStack alignItems="flex-start" spacing="0.75rem" w="full">
                 <Box

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import { moveResourceAtom } from "../../atoms"
+import { useValidateResourceMove } from "../../hooks/useValidateResourceMove"
 
 export const MoveResourceModal = () => {
   // NOTE: This is what we are trying to move
@@ -116,6 +117,13 @@ const MoveResourceContent = withSuspense(
     })
 
     const movedItem = useAtomValue(moveResourceAtom)
+    const { isLoading: isValidMoveLoading, isValidMove } =
+      useValidateResourceMove({
+        sourceId: movedItem?.id,
+        destinationId: curResourceId ?? null,
+      })
+    // movedResourceId: movedItem.id,
+    // destinationResourceId: curResourceId ?? null,
 
     const [shouldCreateRedirect, setShouldCreateRedirect] = useState(true)
     const [{ fullPermalink: movedFullPermalink }] =
@@ -242,9 +250,12 @@ const MoveResourceContent = withSuspense(
               ability.cannot("move", {
                 parentId: curResourceId ?? null,
               }) ||
-              ability.cannot("move", { parentId: movedItem?.parentId ?? null })
+              ability.cannot("move", {
+                parentId: movedItem?.parentId ?? null,
+              }) ||
+              !isValidMove
             }
-            isLoading={isPending}
+            isLoading={isPending || isValidMoveLoading}
             onClick={() =>
               movedItem?.id &&
               mutate({

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -117,11 +117,14 @@ const MoveResourceContent = withSuspense(
     })
 
     const movedItem = useAtomValue(moveResourceAtom)
-    const { isLoading: isValidMoveLoading, isValidMove } =
-      useValidateResourceMove({
-        sourceId: movedItem?.id,
-        destinationId: curResourceId ?? null,
-      })
+    const {
+      isLoading: isValidMoveLoading,
+      isValidMove,
+      errorMessage,
+    } = useValidateResourceMove({
+      sourceId: movedItem?.id,
+      destinationId: curResourceId ?? null,
+    })
     // movedResourceId: movedItem.id,
     // destinationResourceId: curResourceId ?? null,
 
@@ -185,6 +188,11 @@ const MoveResourceContent = withSuspense(
               existingResource={movedItem ?? undefined}
               onChange={(resourceId) => setCurResourceId(resourceId)}
             />
+            {curResourceId !== undefined && errorMessage && (
+              <Infobox variant="error" size="sm" w="full">
+                {errorMessage}
+              </Infobox>
+            )}
             {showUrlChangeNotice && (
               <VStack alignItems="flex-start" spacing="0.75rem" w="full">
                 <Box
@@ -253,7 +261,7 @@ const MoveResourceContent = withSuspense(
               ability.cannot("move", {
                 parentId: movedItem?.parentId ?? null,
               }) ||
-              !isValidMove
+              isValidMove !== true
             }
             isLoading={isPending || isValidMoveLoading}
             onClick={() =>

--- a/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
@@ -1,0 +1,58 @@
+import { skipToken } from "@tanstack/react-query"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { sitePageSchema } from "~/pages/sites/[siteId]"
+import { isResourceMoveValid } from "~/utils/resources"
+import { trpc } from "~/utils/trpc"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+export const useValidateResourceMove = ({
+  sourceId,
+  destinationId,
+}: {
+  sourceId?: string
+  // NOTE: null if moving to root
+  destinationId: string | null
+}) => {
+  const { siteId } = useQueryParse(sitePageSchema)
+  const { data: source, isLoading: isSourceLoading } =
+    trpc.resource.getMetadataById.useQuery(
+      sourceId ? { siteId, resourceId: sourceId } : skipToken,
+    )
+  const { data: destination, isLoading: isDestinationLoading } =
+    trpc.resource.getMetadataById.useQuery(
+      destinationId !== null
+        ? { siteId, resourceId: destinationId }
+        : skipToken,
+    )
+
+  const { data: rootPage, isLoading: isRootPageLoading } =
+    trpc.page.getRootPage.useQuery(
+      destinationId === null ? { siteId } : skipToken,
+    )
+
+  // NOTE: getRootPage only selects a minimal projection (id/title/draftBlobId)
+  // since it's shared with unrelated previews. Its `id` is the only field
+  // isResourceMoveValid actually reads off the destination when moving to
+  // root — the rest are structurally required but functionally unused, so
+  // they're safe to fill in as the known constants for the root resource.
+  const destinationResource =
+    destinationId === null
+      ? rootPage && {
+          id: rootPage.id,
+          type: ResourceType.RootPage,
+          siteId,
+          permalink: "/",
+          parentId: null,
+        }
+      : destination
+
+  const isValidMove =
+    !!source &&
+    !!destinationResource &&
+    isResourceMoveValid(source, destinationResource)
+
+  return {
+    isLoading: isSourceLoading || isDestinationLoading || isRootPageLoading,
+    isValidMove,
+  }
+}

--- a/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
@@ -51,8 +51,16 @@ export const useValidateResourceMove = ({
     !!destinationResource &&
     isResourceMoveValid(source, destinationResource)
 
+  const errorMessage =
+    isValidMove instanceof Error
+      ? isValidMove.message
+      : !isValidMove
+        ? "Invalid resource move"
+        : undefined
+
   return {
     isLoading: isSourceLoading || isDestinationLoading || isRootPageLoading,
     isValidMove,
+    errorMessage,
   }
 }

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1486,7 +1486,7 @@ describe("resource.router", async () => {
       expect(auditSpy).not.toHaveBeenCalled()
       await expect(result).rejects.toThrow(
         new TRPCError({
-          code: "FORBIDDEN",
+          code: "BAD_REQUEST",
           message: "You cannot move a resource to a different site",
         }),
       )

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -28,6 +28,7 @@ import {
   searchWithResourceIdsSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
+import { isResourceMoveValid } from "~/utils/resources"
 import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 
 import type { PermissionsProps } from "../permissions/permissions.type"
@@ -388,18 +389,6 @@ export const resourceRouter = router({
               throw new TRPCError({ code: "BAD_REQUEST" })
             }
 
-            // Prevent users from moving the search page (permalink /search, no parent)
-            // This is a special page that is used to display the SearchSG results
-            if (
-              toMove.permalink === SEARCH_PAGE_PERMALINK &&
-              toMove.parentId === null
-            ) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message: "The search page cannot be moved",
-              })
-            }
-
             let query = tx.selectFrom("Resource")
             query = !!destinationResourceId
               ? query.where("id", "=", destinationResourceId)
@@ -407,17 +396,10 @@ export const resourceRouter = router({
                   .where("type", "=", ResourceType.RootPage)
                   .where("siteId", "=", siteId)
             const parent = await query
-              .select(["id", "type", "siteId"])
+              .select(["id", "type", "siteId", "permalink", "parentId"])
               .executeTakeFirst()
 
-            if (
-              !parent ||
-              // NOTE: we only allow moves to folders/root.
-              // for moves to root, we only allow this for admin
-              (parent.type !== ResourceType.RootPage &&
-                parent.type !== ResourceType.Folder &&
-                parent.type !== ResourceType.Collection)
-            ) {
+            if (!parent) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
                 message:
@@ -425,46 +407,11 @@ export const resourceRouter = router({
               })
             }
 
-            if (toMove.parentId === parent.id) {
+            const moveValidity = isResourceMoveValid(toMove, parent)
+            if (moveValidity instanceof Error) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
-                message: "You cannot move a resource to the same folder",
-              })
-            }
-
-            // NOTE: If the users are trying to move into a collection,
-            // check that the resource first belongs to a collection
-            if (
-              parent.type !== ResourceType.Collection &&
-              (toMove.type === ResourceType.CollectionPage ||
-                toMove.type === ResourceType.CollectionLink)
-            ) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message:
-                  "Collection items can only be moved to another collection",
-              })
-            }
-
-            if (
-              parent.type === ResourceType.Collection &&
-              toMove.type !== ResourceType.CollectionPage &&
-              toMove.type !== ResourceType.CollectionLink
-            ) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message: "Folder items can only be moved to another folder",
-              })
-            }
-
-            if (movedResourceId === destinationResourceId) {
-              throw new TRPCError({ code: "BAD_REQUEST" })
-            }
-
-            if (toMove.siteId !== parent.siteId) {
-              throw new TRPCError({
-                code: "FORBIDDEN",
-                message: "You cannot move a resource to a different site",
+                message: moveValidity.message,
               })
             }
 

--- a/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
+++ b/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
@@ -7,7 +7,9 @@ import SitePage from "~/pages/sites/[siteId]"
 
 import { ADMIN_HANDLERS } from "../handlers"
 
-const SHARED_HANDLERS = [
+// Split out so the move-validation stories can swap in their own
+// `getMetadataById` mock instead of the generic `content()` one.
+const SHARED_HANDLERS_WITHOUT_METADATA = [
   ...ADMIN_HANDLERS,
   pageHandlers.listWithoutRoot.default(),
   pageHandlers.getRootPage.default(),
@@ -18,6 +20,10 @@ const SHARED_HANDLERS = [
   resourceHandlers.getChildrenOf.default(),
   resourceHandlers.getWithFullPermalink.default(),
   resourceHandlers.getAncestryStack.default(),
+]
+
+const SHARED_HANDLERS = [
+  ...SHARED_HANDLERS_WITHOUT_METADATA,
   resourceHandlers.getMetadataById.content(),
 ]
 
@@ -177,5 +183,51 @@ export const RedirectShadowWarning: Story = {
   },
   play: async (context) => {
     await SingleClick.play?.(context)
+  },
+}
+
+// Collection items (CollectionPage/CollectionLink) may only be moved to
+// another collection — isResourceMoveValid rejects a plain folder as the
+// destination, and the modal should surface that error instead of allowing
+// the move.
+export const CollectionItemInvalidDestination: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...SHARED_HANDLERS_WITHOUT_METADATA,
+        resourceHandlers.getBatchAncestryWithSelf.foldersOnly(),
+        // "Test page 1" (id 4) is mocked as a CollectionPage here so it can
+        // be moved via the ordinary root dashboard listing without a real
+        // collection fixture; "Folder 1" (id 1) is the invalid destination.
+        resourceHandlers.getMetadataById.byId({
+          "4": {
+            id: "4",
+            type: "CollectionPage",
+            title: "Test page 1",
+            permalink: "test-page-1",
+            parentId: null,
+            siteId: 1,
+            publishedVersionId: null,
+          },
+          "1": {
+            id: "1",
+            type: "Folder",
+            title: "Folder 1",
+            permalink: "folder-1",
+            parentId: null,
+            siteId: 1,
+            publishedVersionId: null,
+          },
+        }),
+      ],
+    },
+  },
+  play: async (context) => {
+    const { canvasElement } = context
+    await SingleClick.play?.(context)
+
+    await within(canvasElement.ownerDocument.body).findByText(
+      "Collection items can only be moved to another collection",
+    )
   },
 }

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -9,6 +9,7 @@ import {
   BiLink,
   BiSort,
 } from "react-icons/bi"
+import { SEARCH_PAGE_PERMALINK } from "~/constants/sitemap"
 import { env } from "~/env.mjs"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
@@ -79,4 +80,66 @@ export const getStudioResourceUrl = (resource: Resource): string => {
       const exhaustiveCheck: never = resource.type
       return exhaustiveCheck
   }
+}
+
+type BareResource = Pick<
+  Resource,
+  "type" | "id" | "siteId" | "permalink" | "parentId"
+>
+
+// NOTE: Assumes that both source and destination already exist
+export const isResourceMoveValid = (
+  source: BareResource,
+  destination: BareResource,
+) => {
+  // Prevent users from moving the search page (permalink /search, no parent)
+  // This is a special page that is used to display the SearchSG results
+  if (source.permalink === SEARCH_PAGE_PERMALINK && source.parentId === null) {
+    return new Error("The search page cannot be moved")
+  }
+
+  if (
+    !destination ||
+    // NOTE: we only allow moves to folders/root.
+    // for moves to root, we only allow this for admin
+    (destination.type !== ResourceType.RootPage &&
+      destination.type !== ResourceType.Folder &&
+      destination.type !== ResourceType.Collection)
+  ) {
+    return new Error(
+      "Please ensure that you are trying to move your resource into a valid destination",
+    )
+  }
+
+  if (source.parentId === destination.id) {
+    return new Error("You cannot move a resource to the same folder")
+  }
+
+  // NOTE: If the users are trying to move into a collection,
+  // check that the resource first belongs to a collection
+  if (
+    destination.type !== ResourceType.Collection &&
+    (source.type === ResourceType.CollectionPage ||
+      source.type === ResourceType.CollectionLink)
+  ) {
+    return new Error("Collection items can only be moved to another collection")
+  }
+
+  if (
+    destination.type === ResourceType.Collection &&
+    source.type !== ResourceType.CollectionPage &&
+    source.type !== ResourceType.CollectionLink
+  ) {
+    return new Error("Folder items can only be moved to another folder")
+  }
+
+  if (source.id === destination.id) {
+    return new Error("You cannot move a resource to the same folder")
+  }
+
+  if (source.siteId !== destination.siteId) {
+    return new Error("You cannot move a resource to a different site")
+  }
+
+  return true
 }

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -100,8 +100,6 @@ export const isResourceMoveValid = (
 
   if (
     !destination ||
-    // NOTE: we only allow moves to folders/root.
-    // for moves to root, we only allow this for admin
     (destination.type !== ResourceType.RootPage &&
       destination.type !== ResourceType.Folder &&
       destination.type !== ResourceType.Collection)
@@ -134,7 +132,7 @@ export const isResourceMoveValid = (
   }
 
   if (source.id === destination.id) {
-    return new Error("You cannot move a resource to the same folder")
+    return new Error("You cannot move a folder into itself")
   }
 
   if (source.siteId !== destination.siteId) {

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -1,3 +1,5 @@
+import type { RouterOutput } from "~/utils/trpc"
+
 import { trpcMsw } from "../mockTrpc"
 import { DEFAULT_COLLECTION_ITEMS } from "./collection"
 import { DEFAULT_PAGE_ITEMS } from "./page"
@@ -258,6 +260,22 @@ export const resourceHandlers = {
           siteId: 1,
           publishedVersionId: null,
         }
+      }),
+    // Resolves the mocked metadata by the requested `resourceId`, so a story
+    // can give the moved resource and the picked destination distinct types
+    // (e.g. a Page moved onto a Collection) to exercise move validation.
+    byId: (
+      resourcesById: Record<
+        string,
+        RouterOutput["resource"]["getMetadataById"]
+      >,
+    ) =>
+      trpcMsw.resource.getMetadataById.query(({ input: { resourceId } }) => {
+        const resource = resourcesById[resourceId]
+        if (!resource) {
+          throw new Error(`No mocked resource for id ${resourceId}`)
+        }
+        return resource
       }),
   },
   search: {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +154 | -61 |
| 🧪 Test | 3 | +72 | -2 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The move-resource modal only validated a move on the server, after the user had already picked a destination and clicked "Move here". Invalid moves — e.g. moving a collection item into a plain folder, moving the special search page, moving a resource into its current folder, or moving across sites — only surfaced as a failed mutation after submission, instead of being caught while picking a destination.

Closes [ISOM-2503]

## Solution

- Extracted the move-validity rules out of `resource.router.ts`'s `move` mutation (where they were inline `TRPCError` throws) into a shared, pure `isResourceMoveValid(source, destination)` in `~/utils/resources.ts`. It's a plain function over `{type, id, siteId, permalink, parentId}` with no server-only dependencies (no `db`, `TRPCError`, Kysely types), so it's safe to import from both the server router and client components.
- Added `useValidateResourceMove` — a client hook that fetches metadata for the source and currently-selected destination (or synthesizes the root-page case, since the root resource is fetched via a separate, minimal `page.getRootPage` query) and runs `isResourceMoveValid` against them.
- Wired the hook into `MoveResourceModal`: an inline `Infobox` now shows the validation error as soon as an invalid destination is picked, and "Move here" stays disabled until the move is valid — instead of only failing after submission.
- The server `move` mutation now calls the same shared `isResourceMoveValid` instead of its own duplicated checks, so client and server can no longer drift apart on what counts as a valid move.
- Added a Storybook story (`CollectionItemInvalidDestination`) demonstrating the validation, plus a `resourceHandlers.getMetadataById.byId(...)` MSW mock that resolves metadata per-`resourceId` so a story can give the moved resource and the picked destination distinct types.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Move destination is now validated client-side as soon as it's picked, instead of only after submitting.
- Move validation logic is now shared between client and server instead of duplicated.

**Bug Fixes**:

- None

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

- New Storybook story: `Pages/Site Management/Move Resource Modal` → `Collection Item Invalid Destination`, which opens the move modal and asserts the validation error renders when an invalid destination is picked.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extracts resource-move validity rules into a shared validator and uses them before submission in the move modal as well as in the server mutation.
- Fetches source and destination metadata to validate selected destinations in the client.
- Displays an inline validation error and disables submission for invalid moves.
- Reuses the shared validator in the move endpoint and adds Storybook/MSW coverage.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR does not yet appear safe to merge because cross-site moves return the wrong API status and metadata-query failures are misreported as invalid destinations.

Cross-site validation still maps an authorization failure to BAD_REQUEST, while failed source, destination, or root metadata queries still become a generic invalid-move state that disables submission without exposing the actual error.

**Files Needing Attention:** apps/studio/src/server/modules/resource/resource.router.ts; apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx | Integrates pre-submit move validation, displays validation feedback, and gates the move action. |
| apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts | Fetches move metadata and runs the shared validator, but query failures remain indistinguishable from invalid destinations. |
| apps/studio/src/server/modules/resource/resource.router.ts | Reuses the shared validator in the move mutation, while cross-site failures remain mapped to the wrong transport status. |
| apps/studio/src/utils/resources.ts | Centralizes the existing move-domain constraints in a client-safe pure validator. |
| apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts | Updates cross-site error expectations, although the asserted status no longer matches the test’s stated 403 contract. |
| apps/studio/src/stories/Page/MoveResourceModal.stories.tsx | Adds an interaction story covering an invalid collection-item destination. |
| apps/studio/tests/msw/handlers/resource.ts | Adds resource-ID-specific metadata mocks to support move-validation stories. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Editor
  participant Modal as MoveResourceModal
  participant Metadata as Metadata queries
  participant Validator as isResourceMoveValid
  participant Router as resource.move
  Editor->>Modal: Select destination
  Modal->>Metadata: Fetch source and destination
  Metadata-->>Modal: Resource metadata
  Modal->>Validator: Validate move
  Validator-->>Modal: true or validation error
  alt Valid move
    Editor->>Modal: Click Move here
    Modal->>Router: Submit move
    Router->>Validator: Revalidate move
  else Invalid move
    Modal-->>Editor: Show error and disable submission
  end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["chore: fix error code"](https://github.com/opengovsg/isomer/commit/a68cf947d932d0b2a657fae8fa2ebe5c70012890) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54236306)</sub>

<!-- /greptile_comment -->