### PR TITLE
fix(audit): log inactive-user permission removals under a system actor

### DIFF
--- a/apps/studio/src/env.mjs
+++ b/apps/studio/src/env.mjs
@@ -1,5 +1,7 @@
 import { z } from "zod"
 
+const SYSTEM_USER_EMAIL = "system@isomer.gov.sg"
+
 const s3Schema = z.object({
   NEXT_PUBLIC_S3_REGION: z.string().default("us-east-1"),
   NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME: z.string(),
@@ -89,6 +91,7 @@ const server = z
     ALGOLIA_APP_ID: z.string(),
     ALGOLIA_API_KEY: z.string(),
     ALGOLIA_INDEX_NAME: z.string(),
+    SYSTEM_USER_EMAIL: z.email().optional().default(SYSTEM_USER_EMAIL),
   })
   .extend(s3Schema.shape)
   .extend(r2Schema.shape)
@@ -148,6 +151,7 @@ const server = z
  */
 const processEnv = {
   // Server-side env vars
+  SYSTEM_USER_EMAIL: process.env.SYSTEM_USER_EMAIL,
   DATABASE_URL: process.env.DATABASE_URL,
   DD_DELETION_EMAIL: process.env.DD_DELETION_EMAIL,
   CI: process.env.CI,

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -60,6 +60,16 @@ export const emailSessionRouter = router({
       const otpPrefix = isStaticOtp ? "OTP" : createVfnPrefix()
       const hashedToken = createTokenHash(token, email)
 
+      // NOTE: Skip issuing the OTP and saving to database so that
+      // the person can never log in to the system user email.
+      // Not rejecting error outright so that it looks like the email is valid
+      if (email === env.SYSTEM_USER_EMAIL) {
+        return {
+          otpPrefix,
+          email,
+        }
+      }
+
       const url = new URL(getBaseUrl())
 
       ctx.logger.info({ email, expires }, "Generated OTP for email sign in")

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -8,6 +8,7 @@ import {
   setupUser,
 } from "tests/integration/helpers/seed"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { env } from "~/env.mjs"
 import {
   sendAccountDeactivationEmail,
   sendAccountDeactivationWarningEmail,
@@ -16,7 +17,7 @@ import { db } from "~/server/modules/database"
 import { RoleType } from "~/server/modules/database/types"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
-import { MAX_DAYS_FROM_LAST_LOGIN, SYSTEM_USER_EMAIL } from "../constants"
+import { MAX_DAYS_FROM_LAST_LOGIN } from "../constants"
 
 // Mock must be at module level to be hoisted correctly
 vi.mock("~/features/mail/service", () => ({
@@ -135,7 +136,7 @@ describe("inactiveUsers.service", () => {
       const { site: _site } = await setupSite()
       site = _site
 
-      systemUser = await setupUser({ email: SYSTEM_USER_EMAIL })
+      systemUser = await setupUser({ email: env.SYSTEM_USER_EMAIL })
     })
 
     it("should successfully deactivate user with permissions", async () => {
@@ -225,7 +226,7 @@ describe("inactiveUsers.service", () => {
       auditLogs.forEach((log) => expect(log.userId).toBe(systemUser.id))
     })
 
-    it("should not remove permissions or send emails if the system user does not exist", async () => {
+    it("should recreate the system user and continue deactivating if it does not exist", async () => {
       // Arrange
       const user = await setupUserWrapper({
         siteId: site.id,
@@ -235,7 +236,7 @@ describe("inactiveUsers.service", () => {
       await db.deleteFrom("User").where("id", "=", systemUser.id).execute()
 
       // Act
-      await expect(bulkDeactivateInactiveUsers()).rejects.toThrow()
+      await bulkDeactivateInactiveUsers()
 
       // Assert
       const deletedPermissions = await db
@@ -243,8 +244,17 @@ describe("inactiveUsers.service", () => {
         .where("userId", "=", user.id)
         .where("deletedAt", "is not", null)
         .execute()
-      expect(deletedPermissions).toHaveLength(0)
-      expect(sendAccountDeactivationEmail).not.toHaveBeenCalled()
+      expect(deletedPermissions).toHaveLength(1)
+
+      const recreatedSystemUser = await db
+        .selectFrom("User")
+        .where("email", "=", env.SYSTEM_USER_EMAIL)
+        .where("deletedAt", "is", null)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(recreatedSystemUser.id).not.toBe(systemUser.id)
+
+      expect(sendAccountDeactivationEmail).toHaveBeenCalled()
     })
 
     it("should return early when user has no permissions to delete", async () => {

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -16,7 +16,7 @@ import { db } from "~/server/modules/database"
 import { RoleType } from "~/server/modules/database/types"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
-import { MAX_DAYS_FROM_LAST_LOGIN } from "../constants"
+import { MAX_DAYS_FROM_LAST_LOGIN, SYSTEM_USER_EMAIL } from "../constants"
 
 // Mock must be at module level to be hoisted correctly
 vi.mock("~/features/mail/service", () => ({
@@ -126,13 +126,16 @@ const setupUserWrapper = async ({
 describe("inactiveUsers.service", () => {
   describe("bulkDeactivateInactiveUsers", () => {
     let site: Site
+    let systemUser: User
 
     beforeEach(async () => {
       vi.clearAllMocks()
-      await resetTables("Site", "User", "ResourcePermission")
+      await resetTables("Site", "User", "ResourcePermission", "AuditLog")
 
       const { site: _site } = await setupSite()
       site = _site
+
+      systemUser = await setupUser({ email: SYSTEM_USER_EMAIL })
     })
 
     it("should successfully deactivate user with permissions", async () => {
@@ -159,6 +162,89 @@ describe("inactiveUsers.service", () => {
         recipientEmail: user.email,
         sitesAndAdmins: expect.any(Array),
       })
+    })
+
+    it("should create a PermissionDelete audit log entry attributed to the system user", async () => {
+      // Arrange
+      const user = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act
+      await bulkDeactivateInactiveUsers()
+
+      // Assert
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "PermissionDelete")
+        .selectAll()
+        .execute()
+      expect(auditLogs).toHaveLength(1)
+      expect(auditLogs[0]).toEqual(
+        expect.objectContaining({
+          userId: systemUser.id,
+          siteId: site.id,
+          metadata: { reason: "inactivity" },
+        }),
+      )
+      const delta = auditLogs[0]?.delta as {
+        before: { userId: string; deletedAt: string | null }
+        after: { userId: string; deletedAt: string | null }
+      }
+      expect(delta.before.userId).toBe(user.id)
+      expect(delta.before.deletedAt).toBeNull()
+      expect(delta.after.userId).toBe(user.id)
+      expect(delta.after.deletedAt).not.toBeNull()
+    })
+
+    it("should create one audit log entry per removed permission across multiple sites", async () => {
+      // Arrange
+      const user = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: null,
+      })
+      const { site: otherSite } = await setupSite()
+      await setupAdminPermissions({ siteId: otherSite.id, userId: user.id })
+
+      // Act
+      await bulkDeactivateInactiveUsers()
+
+      // Assert
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "PermissionDelete")
+        .selectAll()
+        .execute()
+      expect(auditLogs).toHaveLength(2)
+      expect(auditLogs.map((log) => log.siteId)).toEqual(
+        expect.arrayContaining([site.id, otherSite.id]),
+      )
+      auditLogs.forEach((log) => expect(log.userId).toBe(systemUser.id))
+    })
+
+    it("should not remove permissions or send emails if the system user does not exist", async () => {
+      // Arrange
+      const user = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: null,
+      })
+      await db.deleteFrom("User").where("id", "=", systemUser.id).execute()
+
+      // Act
+      await expect(bulkDeactivateInactiveUsers()).rejects.toThrow()
+
+      // Assert
+      const deletedPermissions = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", user.id)
+        .where("deletedAt", "is not", null)
+        .execute()
+      expect(deletedPermissions).toHaveLength(0)
+      expect(sendAccountDeactivationEmail).not.toHaveBeenCalled()
     })
 
     it("should return early when user has no permissions to delete", async () => {

--- a/apps/studio/src/server/modules/user/constants.ts
+++ b/apps/studio/src/server/modules/user/constants.ts
@@ -1,1 +1,6 @@
 export const MAX_DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement
+
+// Actor used to attribute audit log entries created by automated jobs (e.g.
+// inactive user removal) rather than a human. This row is not created by
+// application code — it must be inserted manually in each environment.
+export const SYSTEM_USER_EMAIL = "system@isomer.gov.sg"

--- a/apps/studio/src/server/modules/user/constants.ts
+++ b/apps/studio/src/server/modules/user/constants.ts
@@ -1,6 +1,1 @@
 export const MAX_DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement
-
-// Actor used to attribute audit log entries created by automated jobs (e.g.
-// inactive user removal) rather than a human. This row is not created by
-// application code — it must be inserted manually in each environment.
-export const SYSTEM_USER_EMAIL = "system@isomer.gov.sg"

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -6,12 +6,14 @@ import {
   sendAccountDeactivationWarningEmail,
 } from "~/features/mail/service"
 import { createBaseLogger } from "~/lib/logger"
+import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 
 import type { ResourcePermission, Site, User } from "../database"
 import type { BulkSendAccountDeactivationWarningEmailsProps } from "./types"
+import { logPermissionEvent } from "../audit/audit.service"
 import { db, RoleType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { MAX_DAYS_FROM_LAST_LOGIN } from "./constants"
+import { MAX_DAYS_FROM_LAST_LOGIN, SYSTEM_USER_EMAIL } from "./constants"
 
 const logger = createBaseLogger({
   path: "server/modules/user/inactiveUsers.service",
@@ -137,13 +139,50 @@ const deactivateUsers = async ({ userIds }: DeactivateUsersProps) => {
       .transaction()
       .setIsolationLevel("serializable") // for idempotency
       .execute(async (tx) => {
-        return tx
+        // Fetch first so a missing system user row fails the job
+        // immediately, even on a run with nothing to deactivate.
+        const systemUser = await tx
+          .selectFrom("User")
+          .where("email", "=", SYSTEM_USER_EMAIL)
+          .selectAll()
+          .executeTakeFirstOrThrow()
+
+        const permissionsToDelete = await tx
+          .selectFrom("ResourcePermission")
+          .where("userId", "in", userIds)
+          .where("deletedAt", "is", null)
+          .selectAll()
+          .execute()
+
+        if (permissionsToDelete.length === 0) return []
+
+        const updated = await tx
           .updateTable("ResourcePermission")
           .where("userId", "in", userIds)
           .where("deletedAt", "is", null)
           .set({ deletedAt: new Date() })
           .returningAll()
           .execute()
+
+        for (const after of updated) {
+          const before = permissionsToDelete.find((p) => p.id === after.id)
+          // Not expected: same tx/isolation level as the read above.
+          if (!before) {
+            throw new Error(
+              `Could not find pre-update state for ResourcePermission ${after.id}`,
+            )
+          }
+
+          await logPermissionEvent(tx, {
+            eventType: AuditLogEvent.PermissionDelete,
+            by: systemUser,
+            delta: { before, after },
+            siteId: after.siteId,
+            metadata: { reason: "inactivity" },
+          })
+        }
+
+        return updated
       })
   } catch (error) {
     if (

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -1,3 +1,4 @@
+import { createId } from "@paralleldrive/cuid2"
 import { startOfDay, subDays } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
 import { env } from "~/env.mjs"
@@ -13,7 +14,7 @@ import type { BulkSendAccountDeactivationWarningEmailsProps } from "./types"
 import { logPermissionEvent } from "../audit/audit.service"
 import { db, RoleType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { MAX_DAYS_FROM_LAST_LOGIN, SYSTEM_USER_EMAIL } from "./constants"
+import { MAX_DAYS_FROM_LAST_LOGIN } from "./constants"
 
 const logger = createBaseLogger({
   path: "server/modules/user/inactiveUsers.service",
@@ -139,12 +140,24 @@ const deactivateUsers = async ({ userIds }: DeactivateUsersProps) => {
       .transaction()
       .setIsolationLevel("serializable") // for idempotency
       .execute(async (tx) => {
-        // Fetch first so a missing system user row fails the job
-        // immediately, even on a run with nothing to deactivate.
+        // Upsert so the system user is guaranteed to exist for audit-log
+        // attribution, rather than relying on it being created manually.
+        // The no-op doUpdateSet forces RETURNING to yield the existing row
+        // on conflict, rather than doNothing (which returns nothing).
         const systemUser = await tx
-          .selectFrom("User")
-          .where("email", "=", SYSTEM_USER_EMAIL)
-          .selectAll()
+          .insertInto("User")
+          .values({
+            id: createId(),
+            email: env.SYSTEM_USER_EMAIL,
+            name: "System",
+            phone: "",
+          })
+          .onConflict((oc) =>
+            oc.columns(["email", "deletedAt"]).doUpdateSet((eb) => ({
+              email: eb.ref("excluded.email"),
+            })),
+          )
+          .returningAll()
           .executeTakeFirstOrThrow()
 
         const permissionsToDelete = await tx


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +67 | -1 |
| 🧪 Test | 1 | +97 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

**NOTE: already created user on staging/uat/prod**



## Problem

Closes ISOM-2376

The daily inactive-user job (`bulkDeactivateInactiveUsers` → `deactivateUsers` in `apps/studio/src/server/modules/user/inactiveUsers.service.ts`) soft-deletes a user's `ResourcePermission` rows but never wrote an `AuditLog` entry for the removal. This meant permission access could disappear with no audit trail, so there was no way to answer "why was this user's access removed" after the fact — the gap that originally surfaced from an oncall request to explain a specific access removal.

## Solution

`deactivateUsers` now writes a `PermissionDelete` audit log entry for every `ResourcePermission` it soft-deletes, inside the same transaction as the deletion. The entry is attributed to a dedicated system user (looked up by `SYSTEM_USER_EMAIL = "system@isomer.gov.sg"`) rather than a human actor, and tagged with `metadata: { reason: "inactivity" }`, so system-initiated removals are distinguishable from user-initiated ones in the audit trail and exports.

The system user row is **not** created by this PR — it must be inserted manually per environment (name/email/phone only; `id` can use its normal default). If the row is missing, the job now fails fast (checked before any deletion happens) rather than silently deleting permissions with no audit trail.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible
  - Requires an operational step before deploy: insert the system user row (see below) in each environment, or the inactive-user cron job will start failing.

**Features**:

- None (this is a bug fix for missing audit coverage, no new user-facing behaviour).

**Improvements**:

- `AuditLog` `PermissionDelete` entries are now created whenever the inactive-user job revokes access, matching the same `logPermissionEvent` pattern used by human-initiated permission removals elsewhere in the codebase. These automatically surface in the existing audit log export/activity report (`auditLogExport.query.ts`) with the system user's name/email as the actor and the affected user's email in the description — no changes needed there.

**Bug Fixes**:

- Fixed: permission removals performed by the inactive-user cron job left no audit trail, making it impossible to verify audit integrity or investigate why a specific user lost access.

## Before & After Screenshots

Not applicable — backend-only change with no UI surface.

## Tests

- `apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts` — added:
  - an audit log entry is created with the correct event type, actor, siteId, and metadata for a single removed permission
  - one audit log entry is created per removed permission when a user has access across multiple sites
  - the job fails and rolls back (no permissions removed, no emails sent) if the system user row does not exist
- Full existing suite still passes (`pnpm test:unit`), `pnpm typecheck`, and `pnpm lint` are clean.

**Manual step required before/at deploy** — insert the system user row in each environment, e.g.:

```sql
INSERT INTO "User" (id, name, email, phone)
VALUES (gen_random_uuid()::text, 'System', 'system@isomer.gov.sg', '00000000');
```

**New scripts**: none

**New dependencies**: none

**New dev dependencies**: none

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR records inactive-user permission removals as audit events attributed to a dedicated system actor and prevents OTP issuance for that actor.
- Adds configurable system-actor email handling.
- Creates or reuses the system actor transactionally during inactive-user deactivation.
- Writes one `PermissionDelete` audit event per removed permission with inactivity metadata.
- Adds integration coverage for audit creation, multi-site removals, and system-user recreation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/env.mjs | Adds the optional server-side system-user email setting with a lowercase default. |
| apps/studio/src/server/modules/auth/email/email.router.ts | Suppresses OTP creation and delivery when a login request targets the configured system actor. |
| apps/studio/src/server/modules/user/inactiveUsers.service.ts | Creates or reuses the system actor and transactionally records an audit event for every permission soft-deletion. |
| apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts | Covers audit attribution, per-site event creation, and recovery when the system actor is absent. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: omit saving otp to db when user is ..."](https://github.com/opengovsg/isomer/commit/42fc697bc0f38c8ab09a2485d11b3168e350f4df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54253056)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Authentication flow (sign-in)](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/auth-flow.md)
- Knowledge Base — [Dashboard, Users, Godmode, and Me](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/dashboard-and-admin-surfaces.md)
- Knowledge Base — [Publishing Pipeline](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/publishing-pipeline.md)
</details>

<!-- /greptile_comment -->