### PR TITLE
fix(studio): show correct empty-state error for collection link

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
@@ -132,7 +132,10 @@ export function BaseLinkControl({
           </Flex>
           {required && (
             <FormErrorMessage>
-              {label} {getCustomErrorMessage(errors)}
+              {/* AJV sees an empty string as present, so pattern mismatch (not "required") fires here — check data directly to show the empty-state copy */}
+              {!data
+                ? `${label} cannot be empty.`
+                : `${label} ${getCustomErrorMessage(errors)}`}
             </FormErrorMessage>
           )}
         </LinkErrorBoundary>


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +4 | -1 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

When a Collection Link item's "Link" field is left empty, the validation error shown is "Link is not in the correct format" — a confusing message for an empty field, since it implies the value entered is malformed rather than missing.

## Solution

The `ref` field's JSON Schema (`packages/components/src/types/page.ts`) marks Link as required and pattern-validated, but an empty string still satisfies AJV's "required" check (the key is present, just empty). This means an empty Link fails the `pattern` rule instead of the `required` rule, which is why `getCustomErrorMessage` mapped it to "is not in the correct format" instead of "cannot be empty".

`BaseLinkControl` now checks the field's actual value directly: if it's empty, it shows "Link cannot be empty." (matching the copy convention used elsewhere, e.g. "Option name cannot be empty."); otherwise it falls back to the existing format-mismatch message for genuinely malformed values.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Show "Link cannot be empty." instead of "Link is not in the correct format" when a required Link field (e.g. on a Collection Link item) is left empty.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Go to a Collection, create or edit a Collection Link item.
- [ ] Leave the "Link" field empty and attempt to save (or trigger validation, e.g. via the raw JSON editor toggling back).
- [ ] Confirm the error message reads "Link cannot be empty." (not "Link is not in the correct format").
- [ ] Set the Link to a valid page/file link, then clear it again — confirm the same "cannot be empty" message still appears.
- [ ] As a regression check, confirm any other Link-format validation errors unrelated to emptiness still display correctly (this fix should not affect those).

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects required-link validation copy by distinguishing empty values from malformed non-empty links.
- Empty required links now display “Link cannot be empty.”
- Non-empty invalid links continue using the existing AJV-derived format error.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed validation behavior.

The control receives string or cleared values, so the new branch correctly selects empty-state copy while preserving format feedback for malformed non-empty links.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx | The validation message now checks the link value directly for emptiness while preserving existing error mapping for non-empty values. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(studio): show &quot;Link cannot be empty&quot;..."](https://github.com/opengovsg/isomer/commit/ad65372d34b09f8585a9f55bf4fe9e243dcfd7c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54256388)</sub>

<!-- /greptile_comment -->