### PR TITLE
RTE: link bubble menu (Edit/Remove) + fix empty-link validation & link colour (ISOM-2363)

### DIFF
--- a/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
@@ -27,6 +27,25 @@ describe("linkEditorSchema", () => {
     expect(result.success).toBe(false)
   })
 
+  it("trims stray leading/trailing whitespace from a valid linkHref", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "  https://isomer.gov.sg  ",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.linkHref).toBe("https://isomer.gov.sg")
+    }
+  })
+
+  it("rejects a linkHref that is only whitespace", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "   ",
+    })
+    expect(result.success).toBe(false)
+  })
+
   it("does not reject a valid link containing internal whitespace-like characters", () => {
     const result = linkEditorSchema.safeParse({
       linkText: "Isomer",

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
@@ -27,6 +27,14 @@ describe("linkEditorSchema", () => {
     expect(result.success).toBe(false)
   })
 
+  it("does not reject a valid link containing internal whitespace-like characters", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "https://example.com/foo\tbar\nbaz",
+    })
+    expect(result.success).toBe(true)
+  })
+
   it("rejects a bare https:// scheme with no domain", () => {
     const result = linkEditorSchema.safeParse({
       linkText: "Isomer",
@@ -49,6 +57,12 @@ describe("linkEditorSchema", () => {
     "data:text/html,<script>alert(1)</script>",
     "vbscript:msgbox(1)",
     "  javascript:alert(1)",
+    // Browsers strip internal tabs/newlines/CRs before parsing the URL
+    // scheme, so these are all equivalent to "javascript:alert(1)".
+    "java\tscript:alert(1)",
+    "java\nscript:alert(1)",
+    "java\rscript:alert(1)",
+    "\tjavascript:alert(1)",
   ])("rejects a disallowed href scheme: %s", (linkHref) => {
     const result = linkEditorSchema.safeParse({
       linkText: "Isomer",

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
@@ -70,6 +70,53 @@ describe("linkEditorSchema", () => {
     expect(result.success).toBe(false)
   })
 
+  it("rejects an external link with a malformed host", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "https://exa mple.com",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts a well-formed mailto: link", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "mailto:foo@example.com",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts a Page-type reference link, unaffected by the URL check", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "[resource:1:2]",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts a File-type link, unaffected by the URL check", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "/123/550e8400-e29b-41d4-a716-446655440000/file.pdf",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  // Known limitation, accepted as a tradeoff: these are benign patterns
+  // (protocol-relative / bare-domain), but our External input always
+  // auto-prepends "https://" (LinkHrefEditor.tsx), so neither reaches this
+  // schema through the actual UI today.
+  it.each(["//example.com", "example.com"])(
+    "rejects an unprefixed external-looking href: %s (known limitation)",
+    (linkHref) => {
+      const result = linkEditorSchema.safeParse({
+        linkText: "Isomer",
+        linkHref,
+      })
+      expect(result.success).toBe(false)
+    },
+  )
+
   it.each([
     "javascript:alert(1)",
     "JavaScript:alert(1)",

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+
+import { linkEditorSchema } from "./LinkEditorModal"
+
+describe("linkEditorSchema", () => {
+  it("accepts a valid external link", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "https://isomer.gov.sg",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects an empty linkText", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "",
+      linkHref: "https://isomer.gov.sg",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects an empty linkHref", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects a bare https:// scheme with no domain", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "https://",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects a bare mailto: scheme with no address", () => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref: "mailto:",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it.each([
+    "javascript:alert(1)",
+    "JavaScript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "  javascript:alert(1)",
+  ])("rejects a disallowed href scheme: %s", (linkHref) => {
+    const result = linkEditorSchema.safeParse({
+      linkText: "Isomer",
+      linkHref,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -46,6 +46,31 @@ import { AttachmentData } from "../AttachmentData"
 import { ResourceSelector } from "../ResourceSelector"
 import { FileAttachment } from "./FileAttachment"
 
+// Explicit, tested backstop alongside Tiptap's own `isAllowedUri` link-mark
+// guard — keeps the allowlist visible here rather than relying solely on
+// upstream library defaults.
+const DISALLOWED_HREF_SCHEMES = ["javascript:", "data:", "vbscript:"]
+
+export const linkEditorSchema = z.object({
+  linkText: z.string().min(1, "Link text cannot be empty."),
+  linkHref: z
+    .string()
+    .min(1, "Link destination cannot be empty.")
+    // A cleared External/Email field still lands here as a bare scheme
+    // ("https://"/"mailto:"), not "", so `.min(1)` alone won't catch it.
+    .refine(
+      (href) => !["https://", "mailto:"].includes(href),
+      "Link destination cannot be empty.",
+    )
+    .refine(
+      (href) =>
+        !DISALLOWED_HREF_SCHEMES.some((scheme) =>
+          href.trim().toLowerCase().startsWith(scheme),
+        ),
+      "Link destination is not allowed.",
+    ),
+})
+
 interface PageLinkElementProps {
   value: string
   onChange: (value: string) => void
@@ -98,18 +123,7 @@ const LinkEditorModalContent = ({
     formState: { errors },
   } = useZodForm({
     mode: "onChange",
-    schema: z.object({
-      linkText: z.string().min(1, "Link text cannot be empty."),
-      linkHref: z
-        .string()
-        .min(1, "Link destination cannot be empty.")
-        // A cleared External/Email field still lands here as a bare scheme
-        // ("https://"/"mailto:"), not "", so `.min(1)` alone won't catch it.
-        .refine(
-          (href) => !["https://", "mailto:"].includes(href),
-          "Link destination cannot be empty.",
-        ),
-    }),
+    schema: linkEditorSchema,
     defaultValues: {
       linkText: strippedLinkText,
       linkHref,

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -67,7 +67,19 @@ export const linkEditorSchema = z.object({
     .refine(
       (href) => DOMPurify.isValidAttribute("a", "href", href),
       "Link destination is not allowed.",
-    ),
+    )
+    // Page/File hrefs aren't real URLs ([resource:...], /uuid/path) -- only
+    // External/Email are expected to be well-formed URLs. Catches
+    // malformed-but-scheme-safe input (e.g. a stray space in the host)
+    // that DOMPurify doesn't check, since it only validates scheme safety,
+    // not URL structure.
+    .refine((href) => {
+      const type = getLinkHrefType(href)
+      if (type === LINK_TYPES.External || type === LINK_TYPES.Email) {
+        return z.url().safeParse(href).success
+      }
+      return true
+    }, "Link destination is not a valid URL."),
 })
 
 interface PageLinkElementProps {

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -51,6 +51,19 @@ import { FileAttachment } from "./FileAttachment"
 // upstream library defaults.
 const DISALLOWED_HREF_SCHEMES = ["javascript:", "data:", "vbscript:"]
 
+// Browsers strip C0 control chars (tabs, newlines, CRs) and various unicode
+// whitespace from URLs before parsing the scheme, so "java\tscript:" is
+// interpreted as "javascript:". Same char class Tiptap's own isAllowedUri
+// uses (borrowed from DOMPurify) — must strip it too or this check is a
+// no-op against that bypass.
+const URL_WHITESPACE_REGEX =
+  /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
+
+const hasDisallowedHrefScheme = (href: string) => {
+  const normalized = href.replace(URL_WHITESPACE_REGEX, "").toLowerCase()
+  return DISALLOWED_HREF_SCHEMES.some((scheme) => normalized.startsWith(scheme))
+}
+
 export const linkEditorSchema = z.object({
   linkText: z.string().min(1, "Link text cannot be empty."),
   linkHref: z
@@ -63,10 +76,7 @@ export const linkEditorSchema = z.object({
       "Link destination cannot be empty.",
     )
     .refine(
-      (href) =>
-        !DISALLOWED_HREF_SCHEMES.some((scheme) =>
-          href.trim().toLowerCase().startsWith(scheme),
-        ),
+      (href) => !hasDisallowedHrefScheme(href),
       "Link destination is not allowed.",
     ),
 })

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -3,12 +3,14 @@ import type { LinkTypes } from "~/features/editing-experience/components/LinkEdi
 import {
   Box,
   FormControl,
+  HStack,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Spacer,
 } from "@chakra-ui/react"
 import {
   Button,
@@ -71,7 +73,7 @@ const PageLinkElement = ({ value, onChange }: PageLinkElementProps) => {
 
 type LinkEditorModalContentProps = Pick<
   LinkEditorModalProps,
-  "linkText" | "linkHref" | "showLinkText" | "linkTypes" | "onSave"
+  "linkText" | "linkHref" | "showLinkText" | "linkTypes" | "onSave" | "onRemove"
 >
 
 const LinkEditorModalContent = ({
@@ -79,6 +81,7 @@ const LinkEditorModalContent = ({
   linkHref,
   showLinkText = true,
   onSave,
+  onRemove,
   linkTypes,
 }: LinkEditorModalContentProps) => {
   const { strippedLinkText, onUploadedFile, buildFinalLinkTextForSave } =
@@ -96,10 +99,16 @@ const LinkEditorModalContent = ({
   } = useZodForm({
     mode: "onChange",
     schema: z.object({
-      linkText: z.string().min(1),
-      // TODO: Refactor to be required
-      // Context: quick hack to ensure error message don't shown for empty linkHref for FileAttachment
-      linkHref: z.string().min(1).optional(),
+      linkText: z.string().min(1, "Link text cannot be empty."),
+      linkHref: z
+        .string()
+        .min(1, "Link destination cannot be empty.")
+        // A cleared External/Email field still lands here as a bare scheme
+        // ("https://"/"mailto:"), not "", so `.min(1)` alone won't catch it.
+        .refine(
+          (href) => !["https://", "mailto:"].includes(href),
+          "Link destination cannot be empty.",
+        ),
     }),
     defaultValues: {
       linkText: strippedLinkText,
@@ -110,12 +119,8 @@ const LinkEditorModalContent = ({
 
   const isEditingLink = !!linkText && !!linkHref
 
-  const onSubmit = handleSubmit(
-    // TODO: Refactor to not have to check for !!linkHref
-    // Context: quick hack to ensure error message don't shown for empty linkHref for FileAttachment
-    ({ linkText, linkHref }) =>
-      !!linkHref &&
-      onSave(buildFinalLinkTextForSave(linkText, linkHref), linkHref),
+  const onSubmit = handleSubmit(({ linkText, linkHref }) =>
+    onSave(buildFinalLinkTextForSave(linkText, linkHref), linkHref),
   )
 
   return (
@@ -169,16 +174,28 @@ const LinkEditorModalContent = ({
         </ModalBody>
 
         <ModalFooter>
-          <Button
-            variant="solid"
-            onClick={onSubmit}
-            // NOTE: Using `isEmpty` here because we trigger `setError`
-            // using `isValid` doesn't trigger the error
-            isDisabled={!isEmpty(errors)}
-            type="submit"
-          >
-            {isEditingLink ? "Save link" : "Add link"}
-          </Button>
+          <HStack w="100%">
+            {isEditingLink && onRemove && (
+              <Button
+                variant="outline"
+                colorScheme="critical"
+                onClick={onRemove}
+              >
+                Remove link
+              </Button>
+            )}
+            <Spacer />
+            <Button
+              variant="solid"
+              onClick={onSubmit}
+              // NOTE: Using `isEmpty` here because we trigger `setError`
+              // using `isValid` doesn't trigger the error
+              isDisabled={!isEmpty(errors)}
+              type="submit"
+            >
+              {isEditingLink ? "Save link" : "Add link"}
+            </Button>
+          </HStack>
         </ModalFooter>
       </form>
     </ModalContent>
@@ -190,6 +207,7 @@ export interface LinkEditorModalProps {
   linkHref?: string
   showLinkText?: boolean
   onSave: (linkText: string, linkHref: string) => void
+  onRemove?: () => void
   isOpen: boolean
   onClose: () => void
   linkTypes: Record<
@@ -207,6 +225,7 @@ export const LinkEditorModal = ({
   showLinkText,
   linkHref,
   onSave,
+  onRemove,
   linkTypes,
 }: LinkEditorModalProps) => (
   <Modal isOpen={isOpen} onClose={onClose}>
@@ -222,6 +241,13 @@ export const LinkEditorModal = ({
           onSave(linkText, linkHref)
           onClose()
         }}
+        onRemove={
+          onRemove &&
+          (() => {
+            onRemove()
+            onClose()
+          })
+        }
       />
     )}
   </Modal>

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -51,6 +51,10 @@ export const linkEditorSchema = z.object({
   linkText: z.string().min(1, "Link text cannot be empty."),
   linkHref: z
     .string()
+    // Strips stray leading/trailing whitespace (e.g. from a paste) before
+    // any other check runs -- LinkHrefEditor's `curHref.startsWith(...)`
+    // display logic otherwise breaks on a leading space.
+    .trim()
     .min(1, "Link destination cannot be empty.")
     // A cleared External/Email field still lands here as a bare scheme
     // ("https://"/"mailto:"), not "", so `.min(1)` alone won't catch it.

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -20,6 +20,7 @@ import {
   ModalCloseButton,
 } from "@opengovsg/design-system-react"
 import { getResourceIdFromReferenceLink } from "@opengovsg/isomer-components"
+import DOMPurify from "isomorphic-dompurify"
 import { isEmpty } from "lodash-es"
 import { z } from "zod"
 import { LinkHrefEditor } from "~/features/editing-experience/components/LinkEditor"
@@ -46,24 +47,6 @@ import { AttachmentData } from "../AttachmentData"
 import { ResourceSelector } from "../ResourceSelector"
 import { FileAttachment } from "./FileAttachment"
 
-// Explicit, tested backstop alongside Tiptap's own `isAllowedUri` link-mark
-// guard — keeps the allowlist visible here rather than relying solely on
-// upstream library defaults.
-const DISALLOWED_HREF_SCHEMES = ["javascript:", "data:", "vbscript:"]
-
-// Browsers strip C0 control chars (tabs, newlines, CRs) and various unicode
-// whitespace from URLs before parsing the scheme, so "java\tscript:" is
-// interpreted as "javascript:". Same char class Tiptap's own isAllowedUri
-// uses (borrowed from DOMPurify) — must strip it too or this check is a
-// no-op against that bypass.
-const URL_WHITESPACE_REGEX =
-  /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
-
-const hasDisallowedHrefScheme = (href: string) => {
-  const normalized = href.replace(URL_WHITESPACE_REGEX, "").toLowerCase()
-  return DISALLOWED_HREF_SCHEMES.some((scheme) => normalized.startsWith(scheme))
-}
-
 export const linkEditorSchema = z.object({
   linkText: z.string().min(1, "Link text cannot be empty."),
   linkHref: z
@@ -75,8 +58,10 @@ export const linkEditorSchema = z.object({
       (href) => !["https://", "mailto:"].includes(href),
       "Link destination cannot be empty.",
     )
+    // Delegates scheme/attribute validation to DOMPurify rather than
+    // hand-rolling our own allowlist/denylist -- see PR #3171 review.
     .refine(
-      (href) => !hasDisallowedHrefScheme(href),
+      (href) => DOMPurify.isValidAttribute("a", "href", href),
       "Link destination is not allowed.",
     ),
 })

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -28,6 +28,7 @@ import { TableSizePicker } from "~/features/editing-experience/components/TableS
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
 import { TableSettingsModal } from "../TableSettingsModal"
 import { MenuBar } from "./MenuBar"
+import { TiptapLinkBubbleMenu } from "./TiptapLinkBubbleMenu"
 import { TiptapLinkEditorModal } from "./TiptapLinkEditorModal"
 
 export const TextMenuBar = ({ editor }: { editor: Editor }) => {
@@ -299,6 +300,12 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         editor={editor}
         isOpen={isLinkModalOpen}
         onClose={onLinkModalClose}
+      />
+
+      <TiptapLinkBubbleMenu
+        editor={editor}
+        onEdit={onLinkModalOpen}
+        isLinkModalOpen={isLinkModalOpen}
       />
 
       <MenuBar items={items} />

--- a/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkBubbleMenu.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkBubbleMenu.tsx
@@ -1,10 +1,12 @@
 import type { Editor } from "@tiptap/react"
 import { Box, HStack } from "@chakra-ui/react"
 import { BubbleMenu } from "@tiptap/react/menus"
-import { useCallback, useMemo } from "react"
+import { useCallback } from "react"
 import { BiPencil, BiUnlink } from "react-icons/bi"
 
 import { MenuItem } from "../MenuItem"
+
+const options = { placement: "bottom" as const }
 
 interface TiptapLinkBubbleMenuProps {
   editor: Editor
@@ -17,7 +19,6 @@ export const TiptapLinkBubbleMenu = ({
   onEdit,
   isLinkModalOpen,
 }: TiptapLinkBubbleMenuProps) => {
-  const options = useMemo(() => ({ placement: "bottom" as const }), [])
   const shouldShow = useCallback(
     ({ editor }: { editor: Editor }) =>
       !isLinkModalOpen && editor.isActive("link"),

--- a/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkBubbleMenu.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkBubbleMenu.tsx
@@ -28,13 +28,13 @@ export const TiptapLinkBubbleMenu = ({
     <BubbleMenu editor={editor} options={options} shouldShow={shouldShow}>
       <Box
         bg="white"
-        borderRadius="8px"
+        borderRadius="lg"
         border="1px solid"
         borderColor="base.divider.medium"
         boxShadow="md"
-        p="0.25rem"
+        p="1"
       >
-        <HStack spacing="0.25rem">
+        <HStack spacing="1">
           <MenuItem icon={BiPencil} title="Edit link" action={onEdit} />
           <MenuItem
             icon={BiUnlink}

--- a/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkBubbleMenu.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkBubbleMenu.tsx
@@ -1,0 +1,50 @@
+import type { Editor } from "@tiptap/react"
+import { Box, HStack } from "@chakra-ui/react"
+import { BubbleMenu } from "@tiptap/react/menus"
+import { useCallback, useMemo } from "react"
+import { BiPencil, BiUnlink } from "react-icons/bi"
+
+import { MenuItem } from "../MenuItem"
+
+interface TiptapLinkBubbleMenuProps {
+  editor: Editor
+  onEdit: () => void
+  isLinkModalOpen: boolean
+}
+
+export const TiptapLinkBubbleMenu = ({
+  editor,
+  onEdit,
+  isLinkModalOpen,
+}: TiptapLinkBubbleMenuProps) => {
+  const options = useMemo(() => ({ placement: "bottom" as const }), [])
+  const shouldShow = useCallback(
+    ({ editor }: { editor: Editor }) =>
+      !isLinkModalOpen && editor.isActive("link"),
+    [isLinkModalOpen],
+  )
+
+  return (
+    <BubbleMenu editor={editor} options={options} shouldShow={shouldShow}>
+      <Box
+        bg="white"
+        borderRadius="8px"
+        border="1px solid"
+        borderColor="base.divider.medium"
+        boxShadow="md"
+        p="0.25rem"
+      >
+        <HStack spacing="0.25rem">
+          <MenuItem icon={BiPencil} title="Edit link" action={onEdit} />
+          <MenuItem
+            icon={BiUnlink}
+            title="Remove link"
+            action={() =>
+              editor.chain().focus().extendMarkRange("link").unsetLink().run()
+            }
+          />
+        </HStack>
+      </Box>
+    </BubbleMenu>
+  )
+}

--- a/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TiptapLinkEditorModal.tsx
@@ -50,6 +50,9 @@ export const TiptapLinkEditorModal = ({
           .insertContent(`<a href="${linkHref}">${linkText}</a>`)
           .run()
       }}
+      onRemove={() => {
+        editor.chain().focus().extendMarkRange("link").unsetLink().run()
+      }}
       isOpen={isOpen}
       onClose={onClose}
     />

--- a/apps/studio/src/features/editing-experience/components/LinkEditor/LinkHrefEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/LinkHrefEditor.tsx
@@ -64,6 +64,7 @@ export const LinkHrefEditor = ({
               onChange={(e) => {
                 if (!e.target.value) {
                   setHref(e.target.value)
+                  return
                 }
                 setHref(generateHttpsLink(e.target.value))
               }}
@@ -84,6 +85,7 @@ export const LinkHrefEditor = ({
               onChange={(e) => {
                 if (!e.target.value) {
                   setHref(e.target.value)
+                  return
                 }
                 setHref(`mailto:${e.target.value}`)
               }}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
@@ -2,7 +2,7 @@ import type { BoxProps } from "@chakra-ui/react"
 import type { EditorContentProps, Editor as TiptapEditor } from "@tiptap/react"
 import type { PropsWithChildren } from "react"
 import type { EditorMenuBar } from "~/components/PageEditor/MenuBar/MenuBar"
-import { Box, useToken, VStack } from "@chakra-ui/react"
+import { Box, VStack } from "@chakra-ui/react"
 import { EditorContent } from "@tiptap/react"
 import { useMemo } from "react"
 
@@ -45,11 +45,6 @@ const EditorContainer = ({
 const EditorContentWrapper = ({
   editor,
 }: Pick<EditorContentProps, "editor">) => {
-  const [linkColor, linkHoverColor] = useToken("colors", [
-    "interaction.links.default",
-    "interaction.links.hover",
-  ])
-
   return (
     <Box
       as={EditorContent}
@@ -62,14 +57,6 @@ const EditorContentWrapper = ({
       backgroundColor="white"
       onClick={() => editor?.chain().focus().run()}
       cursor="text"
-      sx={{
-        "& a": {
-          color: linkColor,
-          _hover: {
-            color: linkHoverColor,
-          },
-        },
-      }}
     />
   )
 }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
@@ -2,7 +2,7 @@ import type { BoxProps } from "@chakra-ui/react"
 import type { EditorContentProps, Editor as TiptapEditor } from "@tiptap/react"
 import type { PropsWithChildren } from "react"
 import type { EditorMenuBar } from "~/components/PageEditor/MenuBar/MenuBar"
-import { Box, VStack } from "@chakra-ui/react"
+import { Box, useToken, VStack } from "@chakra-ui/react"
 import { EditorContent } from "@tiptap/react"
 import { useMemo } from "react"
 
@@ -45,6 +45,11 @@ const EditorContainer = ({
 const EditorContentWrapper = ({
   editor,
 }: Pick<EditorContentProps, "editor">) => {
+  const [linkColor, linkHoverColor] = useToken("colors", [
+    "interaction.links.default",
+    "interaction.links.hover",
+  ])
+
   return (
     <Box
       as={EditorContent}
@@ -57,6 +62,14 @@ const EditorContentWrapper = ({
       backgroundColor="white"
       onClick={() => editor?.chain().focus().run()}
       cursor="text"
+      sx={{
+        "& a": {
+          color: linkColor,
+          _hover: {
+            color: linkHoverColor,
+          },
+        },
+      }}
     />
   )
 }

--- a/apps/studio/src/styles/tiptap.scss
+++ b/apps/studio/src/styles/tiptap.scss
@@ -171,8 +171,12 @@ $max-depth: 13;
   }
 
   a {
-    color: #68cef8;
+    color: var(--chakra-colors-interaction-links-default);
     text-decoration: underline;
+
+    &:hover {
+      color: var(--chakra-colors-interaction-links-hover);
+    }
   }
 
   ul,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 6 | +142 | -24 |
| 🧪 Test | 1 | +139 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
- Adds a contextual bubble menu on RTE links with Edit / Remove actions (using the official `@tiptap/react/menus` `BubbleMenu`), and a "Remove link" button inside the edit modal itself — both undoable via the editor's existing Ctrl-Z history, no confirmation dialog.
- Fixes validation so a link can no longer be saved with an empty destination:
  - `linkHref` is now required in the modal's zod schema (was `.optional()` as a workaround for the FileAttachment flow).
  - Fixes `LinkHrefEditor.tsx`'s External/Email `onChange` handlers, which previously always overwrote a cleared field with a bare `"https://"`/`"mailto:"` instead of `""`, silently bypassing validation.
  - Adds a schema-level `.refine()` backstop rejecting bare `"https://"`/`"mailto:"` values.
- Improves the empty "Link text" Zod error message to "Link text cannot be empty." instead of the raw Zod message.
- Applies the `interaction.links.default`/`.hover` colour tokens to rendered links in the RTE (previously unstyled).

Linear: ISOM-2363

Filed as a separate follow-up (not in scope here): [ISOM-2521](https://linear.app/ogp/issue/ISOM-2521/link-editor-modal-switching-link-type-doesnt-clearsync-href-silently) — switching link type in the modal doesn't clear/sync `href`, so it's possible to silently save a stale destination under the wrong displayed type.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `oxlint` / `oxfmt --check` clean on touched files
- [x] `pnpm test:unit` — 1704 passed, 0 new failures
- [ ] Manual: click into an existing link → bubble menu appears with Edit/Remove
- [ ] Manual: Remove → link mark disappears, Ctrl-Z restores it
- [ ] Manual: Edit → opens the same modal as the toolbar button, prefilled correctly
- [ ] Manual: clearing the External/Email field disables Save with a clear inline error
- [ ] Manual: link colour in rendered content matches `interaction/links/default`
- [ ] Manual: FileAttachment upload-a-file-as-link flow still works with the tightened validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds link editing and removal controls to the rich-text editor while tightening destination validation and applying the standard interaction-link colors.
- Adds a contextual link bubble menu with Edit and Remove actions.
- Supports removing links from the edit modal.
- Rejects empty, malformed, and unsafe link destinations.
- Corrects External and Email field clearing behavior.
- Styles rendered links with the default and hover interaction tokens.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/components/PageEditor/LinkEditorModal.tsx | Adds shared destination validation and modal-level link removal without leaving an eligible blocking follow-up issue. |
| apps/studio/src/components/PageEditor/MenuBar/TiptapLinkBubbleMenu.tsx | Adds contextual Edit and Remove actions and now uses Chakra theme-scale values for spacing and radius. |
| apps/studio/src/components/PageEditor/MenuBar/TiptapLinkEditorModal.tsx | Connects modal removal to Tiptap's link-mark removal command. |
| apps/studio/src/features/editing-experience/components/LinkEditor/LinkHrefEditor.tsx | Prevents cleared External and Email fields from being replaced with bare schemes. |
| apps/studio/src/styles/tiptap.scss | Applies interaction-link default and hover color tokens to rich-text links. |
| apps/studio/src/components/PageEditor/LinkEditorModal.test.ts | Covers accepted destinations and empty, malformed, and unsafe href validation cases. |

</details>

<sub>Reviews (8): Last reviewed commit: ["fix(rte): add type-aware z.url() guard f..."](https://github.com/opengovsg/isomer/commit/eb52359ffccf7475750748dbf1928797729a175c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54263492)</sub>

<!-- /greptile_comment -->