### PR TITLE
fix(studio): prevent duplicate-title toast+close on collection/folder create

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -119,6 +119,7 @@ const CreateCollectionModalContent = ({
         description: err.message,
         ...BRIEF_TOAST_SETTINGS,
       })
+      onClose()
     },
   })
 

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -76,6 +76,7 @@ const CreateCollectionModalContent = ({
     watch,
     formState,
     setValue,
+    setError,
     getFieldState,
   } = useZodForm({
     defaultValues: {
@@ -91,7 +92,6 @@ const CreateCollectionModalContent = ({
   const utils = trpc.useUtils()
   const toast = useToast()
   const { mutate, isPending } = trpc.collection.create.useMutation({
-    onSettled: onClose,
     onSuccess: async () => {
       posthog.capture("collection_created", {
         site_id: siteId,
@@ -105,8 +105,13 @@ const CreateCollectionModalContent = ({
         status: "success",
         ...BRIEF_TOAST_SETTINGS,
       })
+      onClose()
     },
     onError: (err) => {
+      if (err.data?.code === "CONFLICT") {
+        setError("permalink", { message: err.message }, { shouldFocus: true })
+        return
+      }
       toast({
         title: "Failed to create collection",
         status: "error",

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -114,6 +114,7 @@ const CreateFolderModalContent = ({
         description: err.message,
         ...BRIEF_TOAST_SETTINGS,
       })
+      onClose()
     },
   })
 

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -73,6 +73,7 @@ const CreateFolderModalContent = ({
     watch,
     formState,
     setValue,
+    setError,
     getFieldState,
   } = useZodForm({
     defaultValues: {
@@ -85,7 +86,6 @@ const CreateFolderModalContent = ({
   const utils = trpc.useUtils()
   const toast = useToast()
   const { mutate, isPending } = trpc.folder.create.useMutation({
-    onSettled: onClose,
     onSuccess: async () => {
       posthog.capture("folder_created", {
         site_id: siteId,
@@ -100,8 +100,13 @@ const CreateFolderModalContent = ({
         status: "success",
         ...BRIEF_TOAST_SETTINGS,
       })
+      onClose()
     },
     onError: (err) => {
+      if (err.data?.code === "CONFLICT") {
+        setError("permalink", { message: err.message }, { shouldFocus: true })
+        return
+      }
       toast({
         title: "Failed to create folder",
         status: "error",


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +14 | -2 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
- Fixes ISOM-2504: creating a collection/folder with a name that collides with an existing sibling used to close the modal and show a generic error toast, losing the user's input.
- The `create` mutations already throw a `CONFLICT` `TRPCError` when the DB's unique constraint on `(siteId, parentId, permalink)` is violated. We now catch that specific error in `onError`, keep the modal open, and surface it inline on the permalink field via `setError`, matching the existing pattern in `CreatePageWizardContext.tsx`.
- `onClose()` moved out of `onSettled` into `onSuccess` only, so the modal no longer auto-closes on any error — it stays open so the user can fix the conflict without retyping the form.

## Test plan
- [x] `pnpm typecheck` passes for the touched files
- [x] `pnpm oxlint` clean on the touched files
- [x] `pnpm test:unit -- src/features/editing-experience` — 1704 passed / 41 skipped
- [ ] Manual check in Studio: create a collection/folder whose title collides with an existing sibling and confirm the modal stays open with an inline "already exists" message on the URL field instead of closing with a toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes folder and collection creation modals to keep user input visible after duplicate-permalink conflicts and display the server error inline.
- Moves successful modal closure into `onSuccess`.
- Maps `CONFLICT` responses to the permalink field.
- Retains the existing toast-and-close behavior for other errors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx | Handles collection permalink conflicts inline and closes the modal explicitly after success or non-conflict errors. |
| apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx | Applies the corresponding conflict handling and modal lifecycle changes to folder creation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(studio): close create modal on non-c..."](https://github.com/opengovsg/isomer/commit/a01a20e2a58bc2ec5592ec5a2c08faa6911029bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54266556)</sub>

**Context used:**

- Knowledge Base — [Resource Tree and Page Editing](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/resource-page-editing.md)

<!-- /greptile_comment -->