### PR TITLE
fix(move-resource): hide URL-change notice for collection links

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -157,10 +157,12 @@ const MoveResourceContent = withSuspense(
       isRedirectableType &&
       isDestinationResolved &&
       oldFullPermalink !== newFullPermalink
-    // The URL-change notice shows for any resource once a picked destination
-    // actually changes its URL; the redirect checkbox is the published subset.
+    // CollectionLinks have no URL of their own (their permalink is a hidden
+    // random UUID), so skip the notice even though their permalink changes.
     const showUrlChangeNotice =
-      isDestinationResolved && oldFullPermalink !== newFullPermalink
+      type !== ResourceType.CollectionLink &&
+      isDestinationResolved &&
+      oldFullPermalink !== newFullPermalink
     const { data: existingRedirect } = trpc.redirect.getBySource.useQuery(
       { siteId: Number(siteId), source: newFullPermalink },
       { enabled: showRedirectOption },


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +5 | -3 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Closes ISOM-2380

When moving a collection link, Studio's move dialog showed a "The page URL will change to ..." notice. But a `CollectionLink` has no real URL of its own — its `permalink` is a hidden, randomly generated UUID used only for internal resource-tree bookkeeping, not a public destination (the actual destination is stored in the link's `ref` field). Showing this notice exposed confusing, meaningless internal plumbing to users.

## Solution

`showUrlChangeNotice` in `MoveResourceModal.tsx` previously fired for any resource type whenever its computed full permalink changed, with no type gate — unlike the sibling `showRedirectOption` flag, which was already correctly restricted to `Page`/`CollectionPage`/`Folder`/`Collection`. This appears to be a regression from when the redirect-checkbox logic was split out of the general "URL changed" condition.

Added a `type !== ResourceType.CollectionLink` guard to `showUrlChangeNotice`, matching the same exclusion already applied to `CollectionLink` in `PageSettingsModal.tsx`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- The move dialog no longer shows a "URL will change" notice when moving a collection link, since collection links don't have a real URL of their own.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] In Studio, open a Collection that has at least one collection link ("Link or file" item) and one regular collection page.
- [ ] Click "Move" on the collection link, pick a different destination collection, and confirm the "The page URL will change to ..." notice does **not** appear.
- [ ] Click "Move" on the regular collection page, pick a different destination, and confirm the notice **still appears** as before (no regression).
- [ ] Move a Folder to a location where its URL changes and confirm the "URL will change... every page under it will move too" notice still appears as before.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents the move dialog from displaying a meaningless URL-change notice for collection links while retaining the existing behavior for resources with public URLs.
- Excludes `CollectionLink` from `showUrlChangeNotice`.
- Leaves redirect-option and move behavior unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new condition matches collection-link permalink semantics and existing sibling UI behavior, while preserving URL notices and redirect controls for pages, folders, and collections.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx | Correctly gates the URL-change notice for collection links without affecting redirect creation or notices for other movable resource types. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(move-resource): hide URL-change noti..."](https://github.com/opengovsg/isomer/commit/e63bc1a819c6a1c4968eadc8a449a1a68a2a17f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54268035)</sub>

**Context used:**

- Knowledge Base — [Resource Tree and Page Editing](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/resource-page-editing.md)
- Knowledge Base — [Redirects, SearchSG, and Asset Uploads](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/redirects-search-assets.md)

<!-- /greptile_comment -->