### PR TITLE
Feature/isom 2243 studio links support linking to the homepage in the link

### DIFF
--- a/.claude/skills/feature-implement/SKILL.md
+++ b/.claude/skills/feature-implement/SKILL.md
@@ -36,7 +36,8 @@ Particular files to re-read every time:
 - `apps/studio/src/server/CLAUDE.md` if touching the server
 - `apps/studio/src/features/CLAUDE.md` if touching a feature
 - `packages/components/CLAUDE.md` if touching the published-site renderer
-- `apps/studio/prisma/CLAUDE.md` if touching the schema
+- `packages/db/prisma/CLAUDE.md` if touching the schema or migrations
+- `apps/studio/prisma/CLAUDE.md` if touching Studio seed data, JSON-column types, or one-off data scripts
 
 ### 3. Stack the work
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Isomer code review instructions
+
+Use these instructions when reviewing changes in this repository. More specific
+rules are applied from `.github/instructions/*.instructions.md` based on the
+changed file.
+
+## Findings
+
+- Report an issue only when a changed line creates a concrete correctness,
+  security, data-integrity, or compatibility problem, or breaks an explicit
+  repository invariant with a named maintenance or rollout consequence. Name
+  the triggering input or caller and the observable consequence.
+- Do not report formatting, import ordering, lint, or type errors already
+  enforced by CI unless the change disables or bypasses that enforcement. Do
+  not present a stylistic preference as a defect.
+- Respect the terminology and invariants in the nearest `CONTEXT.md` and in
+  current, non-superseded decisions under `docs/adr/`. When reporting a
+  conflict, identify the exact invariant and explain how the changed behavior
+  violates it.
+- At a boundary between Studio, the database, shared packages, build tooling,
+  and published sites, identify the exact producer, consumer, or persisted
+  historical shape that the change breaks. Do not speculate about an unnamed
+  caller.
+- Recommend a test only when you can name the changed behavior that is
+  uncovered and the assertion that would fail before the fix.
+
+## Stacked pull requests
+
+- Review every pull request against its actual base as an independently
+  mergeable and revertible change. A non-default base may represent a stacked
+  pull request. Do not assume that another pull request will repair a
+  regression in the current diff.

--- a/.github/instructions/configuration.instructions.md
+++ b/.github/instructions/configuration.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: ".env.example,apps/studio/.env.example,apps/studio/src/env.mjs,**/package.json,pnpm-workspace.yaml,pnpm-lock.yaml,**/turbo.json,.github/workflows/**/*,.github/actions/**/*,tooling/build/**/*"
+---
+
+# Configuration review instructions
+
+- For a new Studio environment variable, verify the Zod server or client
+  schema, the explicit `processEnv` mapping in `apps/studio/src/env.mjs`, the
+  relevant example environment file, and every build or runtime deployment
+  surface that must provide it. Report the exact missing consumer rather than
+  requesting propagation everywhere.
+- Never expose a secret through a `NEXT_PUBLIC_` variable, client bundle,
+  public build argument, workflow output, or log. Client variables must be
+  intentionally public and declared in the client schema.
+- Use `catalog:` for shared external dependencies declared in
+  `pnpm-workspace.yaml` and `workspace:*` for internal workspace packages.
+  Preserve documented compatibility pins unless all named consumers are
+  migrated in the same rollout.
+- Require `pnpm-lock.yaml` to match dependency manifest changes. Do not report
+  findings in a mechanically updated lockfile unless they reveal a concrete
+  manifest, integrity, platform, or lifecycle-script problem.
+- When changing package scripts, Turbo tasks, or GitHub workflows, identify the
+  affected workspace or CI/deployment caller and ensure its command, inputs,
+  outputs, and required environment remain connected.

--- a/.github/instructions/database.instructions.md
+++ b/.github/instructions/database.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: "packages/db/prisma/schema.prisma,packages/db/prisma.config.ts,packages/db/prisma/migrations/**/*,packages/db/prisma/custom/**/*,packages/db/prisma/generate.cts,packages/db/src/generated/**/*,apps/studio/prisma/types.ts"
+---
+
+# Database review instructions
+
+- Migrations run before new application code. Require the previous deployed
+  application version and queued jobs to continue working after each migration
+  in the pull request.
+- Stage incompatible changes. Add required columns as nullable, backfill, and
+  tighten later. Rename or type-change columns by adding the replacement,
+  migrating or dual-writing, switching readers, and removing the old column in
+  a later rollout.
+- Flag `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, `TRUNCATE`, destructive data
+  rewrites, or Prisma-generated drop-and-add renames unless the pull request
+  contains an explicit rollout plan and human approval.
+- On large tables, require indexes to be created with
+  `CREATE INDEX CONCURRENTLY` through the custom-migration workflow so writes
+  are not locked.
+- After `schema.prisma` changes, require the committed Kysely outputs under
+  `packages/db/src/generated/` to be regenerated. Do not recommend hand edits
+  to generated files.
+- Keep JSON fields' `@kyselyType` annotations aligned with
+  `apps/studio/prisma/types.ts`; report the exact generated or runtime type that
+  becomes inconsistent.

--- a/.github/instructions/published-sites.instructions.md
+++ b/.github/instructions/published-sites.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "packages/components/src/**/*,tooling/template/**/*"
+---
+
+# Published-site compatibility review instructions
+
+- Treat stored site JSON and already-published content as historical inputs
+  that must continue to render. Schema and interface additions must be
+  optional. Do not remove a field or change its type until producers and stored
+  data have completed a migration-first rollout.
+- Preserve the boundary: Studio produces typed, schema-valid content and
+  `packages/components` renders it. Published components must not import
+  Studio code, call Studio APIs, depend on Studio-private symbols, or branch on
+  Studio-internal feature flags.
+- Keep the base published render paths server-renderable. Network-driven or
+  browser-only behavior must be isolated in an explicit client hook or nested
+  client component and must not execute during server rendering. Do not add
+  top-level access to `window`, `document`, `localStorage`, or similar APIs in
+  server-rendered modules.
+- When changing a public schema, interface, type, constant, or component,
+  verify that it is exported through the package's public entry point and that
+  current Studio and template consumers remain compatible.
+- Flag a compatibility problem only when you can identify the old content
+  shape or concrete consumer that fails.

--- a/.github/instructions/studio-server.instructions.md
+++ b/.github/instructions/studio-server.instructions.md
@@ -1,0 +1,27 @@
+---
+applyTo: "apps/studio/src/server/**/*.ts,apps/studio/src/pages/api/**/*.ts"
+---
+
+# Studio server review instructions
+
+- Require the appropriate authorization check in the router or API handler
+  before calling a service, writing to the database, publishing, or causing an
+  external side effect. A valid session proves authentication, not permission
+  for the requested site or resource.
+- Use `protectedProcedure` by default. `publicProcedure` and
+  `webhookProcedure` are valid only for deliberately unauthenticated or
+  API-key-authenticated callers. Do not accept ad hoc authentication middleware
+  in individual routers.
+- For every state-changing resource mutation, require the audit event and the
+  write to use the same database transaction. Audit deltas must contain the
+  actual persisted before and after values, rather than request input assumed
+  to match the database.
+- Require `.meta({ rateLimitOptions: ... })` for user-triggered procedures that
+  call external services such as email, S3, or Singpass.
+- Do not return raw database errors, caught `error.message` values, request
+  data, stack traces, credentials, or other sensitive internal details to
+  clients. Log server details with the request logger and return an appropriate
+  generic `TRPCError` or HTTP response.
+- Validate external input with the relevant Zod schema before it reaches
+  business logic. Keep tRPC routers focused on input, authorization, and
+  service orchestration rather than placing business logic in the callback.

--- a/.github/instructions/ui-accessibility.instructions.md
+++ b/.github/instructions/ui-accessibility.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "apps/studio/src/**/*.tsx,packages/components/src/**/*.tsx"
+---
+
+# UI accessibility review instructions
+
+- Every changed interactive control must be keyboard reachable and operable
+  and must expose an accessible name. Prefer native elements and the existing
+  Chakra UI or React Aria primitives over recreating their behavior.
+- Flag click handlers on non-interactive elements when there is no equivalent
+  keyboard interaction, focusability, and semantic role.
+- Icon-only controls need a meaningful accessible name. Decorative icons must
+  be hidden from assistive technology when adjacent text already supplies the
+  name.
+- Images conveying content need meaningful alternative text; decorative images
+  use an empty `alt` value. Do not duplicate surrounding text in alt text
+  without adding information.
+- Do not rely on color alone to communicate state, errors, selection, or
+  required actions. Preserve visible keyboard focus and sufficient non-text
+  contrast for controls and state indicators.
+- Report an accessibility finding only when the changed interaction creates a
+  concrete keyboard, screen-reader, focus, naming, or perception failure; do
+  not request redundant ARIA where native semantics are already sufficient.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm dev:e2e          # Start dev server + run E2E tests
 # From apps/studio
 pnpm test:unit        # Run Vitest unit tests
 pnpm test:watch       # Watch mode for unit tests
-pnpm exec playwright test tests/e2e/specific-test.spec.ts  # Run single E2E test
+pnpm exec playwright test tests/e2e/smoke.test.ts          # Run single E2E test
 pnpm test:unit -- src/path/to/test.test.ts                 # Run single unit test
 ```
 
@@ -57,7 +57,7 @@ pnpm clean            # Clean build artifacts
 ## Architecture
 
 ### Monorepo Structure
-- `apps/studio` - Main Next.js 15 application (CMS/site builder)
+- `apps/studio` - Main Next.js 16 application (CMS/site builder)
 - `packages/components` - Reusable component library (@opengovsg/isomer-components)
 - `packages/pgboss` - Job queue wrapper (@isomer/pgboss)
 - `tooling/*` - Shared configs (TypeScript, Oxlint, Storybook)
@@ -73,7 +73,7 @@ pnpm clean            # Clean build artifacts
 - `theme/` - Chakra UI theme configuration
 
 ### Key Technologies
-- **Framework**: Next.js 15, React 18
+- **Framework**: Next.js 16, React 18
 - **API**: tRPC for type-safe client-server communication
 - **Database**: PostgreSQL with Prisma ORM
 - **Styling**: Tailwind CSS + Chakra UI
@@ -84,9 +84,10 @@ pnpm clean            # Clean build artifacts
 - **Formatting**: Oxfmt
 
 ### Database
-- Schema: `apps/studio/prisma/schema.prisma`
-- Migrations: `apps/studio/prisma/migrations/`
-- Custom migrations: `apps/studio/prisma/custom/`
+- Schema: `packages/db/prisma/schema.prisma`
+- Migrations: `packages/db/prisma/migrations/`
+- Custom migrations: `packages/db/prisma/custom/`
+- Generated Kysely types: `packages/db/src/generated/`
 
 ## Testing Notes
 

--- a/apps/studio/.storybook/main.ts
+++ b/apps/studio/.storybook/main.ts
@@ -35,8 +35,8 @@ const config: StorybookConfig = {
     reactDocgen: "react-docgen-typescript",
   },
 
-  // Force Storybook to use the same React version as the app, as it defaults
-  // to using React 19 when using Next.js 15. We require React 18 due to
+  // Force Storybook to use the same React version as the app, rather than its
+  // React 19 default. We require React 18 due to
   // react-input-mask used by OGP's design system, which uses findDOMNode which
   // has been removed in React 19.
   // Ref: https://github.com/storybookjs/storybook/issues/30646

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -163,7 +163,7 @@ pnpm test:unit -- src/path/to/file.test.ts   # single file
 ```bash
 pnpm setup:test                                           # start Docker services first
 pnpm test:e2e
-pnpm exec playwright test tests/e2e/specific.spec.ts      # single test
+pnpm exec playwright test tests/e2e/smoke.test.ts         # single test
 ```
 
 - Requires `pnpm setup:test` (containerized PostgreSQL + MockPass)

--- a/apps/studio/prisma/CLAUDE.md
+++ b/apps/studio/prisma/CLAUDE.md
@@ -1,101 +1,52 @@
-# Prisma + migrations (`apps/studio/prisma`)
+# Studio database support (`apps/studio/prisma`)
 
-The Prisma schema is the source of truth for the database. Migrations apply atomically against production via the `migrate:<env>` flow in the root `README.md`. Mistakes here are expensive — a bad migration can lock tables, drop data, or block deploys.
+This directory contains Studio-owned database support files. The Prisma schema,
+migrations, custom migrations, and generated database types live in
+`packages/db/`; see `packages/db/prisma/CLAUDE.md` before changing them.
 
 ## Layout
 
-```
+```text
 prisma/
-├── schema.prisma           # The schema. Generator targets: prisma-client-js, prisma-json-types-generator, prisma-kysely.
-├── migrations/             # Prisma-managed migrations (timestamp-prefixed folders).
-│   └── <ts>_<name>/migration.sql
-├── custom/                 # Hand-authored SQL applied via the custom migration mechanism.
-│   ├── install.ts          # Roller that splices custom SQL into the next migration.
-│   └── migration.sql       # Accumulated custom statements awaiting the next dev migration.
-├── generated/              # Kysely + Prisma JSON types (generated). Do not edit.
-├── scripts/                # Ad-hoc data scripts (run manually, not by migrate).
-├── seed.ts                 # Seed data for local dev.
-└── types.ts                # JSON column TS types — referenced from schema via `prisma-json-types-generator`.
+├── types.ts       # Precise PrismaJson types used by Studio
+├── seed.ts        # Local-development seed data
+└── scripts/       # Manually run data and administration scripts
 ```
 
-## Generators — what runs at `pnpm generate`
+## JSON-column types
 
-| Generator                     | Output                                       | Why                                           |
-| ----------------------------- | -------------------------------------------- | --------------------------------------------- |
-| `prisma-client-js`            | `node_modules/.prisma/client`                | Default Prisma client used by legacy queries. |
-| `prisma-json-types-generator` | Types for `Json` columns                     | Reads from `prisma/types.ts`.                 |
-| `prisma-kysely`               | `prisma/generated/generatedTypes.ts` + enums | Kysely DB types — preferred for new queries.  |
-
-After any schema change, run `pnpm generate` and commit the regenerated `prisma/generated/` files.
-
-## Workflow — adding a new migration
-
-1. Edit `schema.prisma`.
-2. From `apps/studio/`: `pnpm migrate:dev`. Name the migration descriptively (`add_<table>_<reason>`).
-3. Inspect the generated `migration.sql` — Prisma sometimes generates destructive operations (drops, renames) when a non-destructive one would do.
-4. Run `pnpm generate` to refresh the Kysely + JSON types.
-5. Commit:
-   - `prisma/schema.prisma`
-   - `prisma/migrations/<ts>_<name>/migration.sql`
-   - `prisma/generated/*`
-6. Update `apps/studio/prisma/types.ts` if you added/changed a JSON column.
-
-## Custom migrations
-
-The `custom/` folder lets you ship hand-written SQL (triggers, partial indexes, RLS) that Prisma's introspection cannot express. Statements in `custom/migration.sql` get merged into the next Prisma migration by `custom/install.ts`.
-
-Use this for:
-
-- Triggers and stored procedures.
-- Partial / expression indexes that Prisma can't express.
-- Data backfills attached to a schema change.
-
-Do **not** use this to bypass Prisma's tracked migration history. Every change must still land in a tracked migration folder.
-
-## Rules
-
-### Backward-compatible by default
-
-- Migrations run before the new app code is deployed. The old code must still work against the new schema during the window.
-- New required columns: add as nullable, backfill, then tighten in a follow-up migration.
-- Column renames: add new, dual-write, drop old — three migrations, not one.
-- Type changes: add a new column with the new type, migrate data, swap in code, drop old.
-
-### One migration per PR
-
-- A PR that touches the schema should land its migration alone, or as the only schema-change PR in a Graphite stack.
-- Migrations that change schema in a non-backward-compatible way **must not** be stacked with app code changes that depend on them — they ship in their own PR and merge first.
-
-### No destructive ops without explicit approval
-
-- `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, `TRUNCATE` require an explicit approving reviewer in the PR description.
-- The agent must refuse to ship a destructive migration without a human picking the approach.
-
-### Indexes
-
-- New indexes on large tables should use `CREATE INDEX CONCURRENTLY` via a custom migration. Prisma's default `CREATE INDEX` will lock writes.
-- An index that supports a new query path lands in the same PR as the query.
-
-### JSON columns
-
-- The TS type for each JSON column lives in `prisma/types.ts` and is picked up by `prisma-json-types-generator`. Update both together.
+- `types.ts` is the precise `PrismaJson` namespace declaration used by Studio.
+  Keep it aligned with JSON fields and `/// @kyselyType(...)` annotations in
+  `packages/db/prisma/schema.prisma`.
+- `packages/db/src/prisma-json-types.d.ts` intentionally contains loose stubs
+  so `@isomer/db` can type-check without depending on Studio or
+  `@opengovsg/isomer-components`. Do not replace those stubs with Studio types.
+- After changing a JSON-column shape or the database schema, run
+  `pnpm --filter @isomer/db generate` from the repository root and commit the
+  regenerated files under `packages/db/src/generated/`.
 
 ## Seeding
 
-- `prisma/seed.ts` is for local dev only — it must be idempotent (re-running should produce the same state).
-- Tests use their own setup, not the seed file.
+- `seed.ts` is for local development only. It must be idempotent: rerunning it
+  should produce the same state.
+- Tests use their own setup and fixtures, not the development seed.
+- Run it from `apps/studio` with `pnpm db:seed` after local services and
+  migrations are ready.
 
-## Scripts (`prisma/scripts/`)
+## One-off scripts
 
-- One-off data scripts (rename a column, normalise a value across rows) live here.
-- Each script must be idempotent and dry-runnable.
-- Scripts are **not** run by `migrate:<env>` — they're executed manually and recorded in the PR description.
+- Put manual data and administration scripts under `scripts/`.
+- Make scripts idempotent and dry-runnable where the operation allows it.
+- Scripts are not run by the migration workflow. Record the command, target
+  environment, and outcome in the pull request or operational runbook.
+- Pair with another engineer before running a script against production.
+- Use the environment and tunnel instructions in `scripts/README.md`.
 
 ## Anti-patterns the agent should refuse
 
-- Combining a schema change with un-related app code in one migration PR.
-- A `DROP COLUMN` / `DROP TABLE` in the same migration that adds its replacement.
-- New required columns without a backfill + two-phase rollout.
-- Editing files under `prisma/generated/` by hand.
-- Skipping `pnpm generate` after a schema change.
-- A non-idempotent script in `prisma/scripts/`.
+- Editing the database schema or migrations in this directory instead of
+  `packages/db/prisma/`.
+- Changing a JSON-column schema without updating `types.ts` and regenerating
+  `packages/db/src/generated/`.
+- Adding a non-idempotent seed or destructive one-off script without an
+  explicit operational plan and human review.

--- a/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
@@ -5,7 +5,7 @@ import { dataAttr } from "@chakra-ui/utils"
 import { Button } from "@opengovsg/design-system-react"
 import { getIcon } from "~/utils/resources"
 
-interface ResourceItemProps {
+export interface ResourceItemProps {
   item: ResourceItemContent
   isDisabled?: boolean
   isHighlighted?: boolean

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Skeleton, Text, VStack } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { Suspense, useMemo } from "react"
 import { useSearchQuery } from "~/hooks/useSearchQuery"
+import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import {
@@ -71,6 +72,8 @@ const SuspensableResourceSelector = ({
   const isSearchQueryEmpty: boolean = searchQuery.trim().length === 0
   const hasAdditionalLeftPadding: boolean = isSearchQueryEmpty
 
+  const [rootPage] = trpc.page.getRootPage.useSuspenseQuery({ siteId })
+
   const {
     fullPermalink,
     moveDestPermalink,
@@ -105,6 +108,7 @@ const SuspensableResourceSelector = ({
 
   const {
     isResourceIdHighlighted,
+    isHomeHighlighted,
     isResourceItemDisabled,
     hasParentInStack,
     handleClickBackButton,
@@ -139,13 +143,14 @@ const SuspensableResourceSelector = ({
                 title: "Home",
                 permalink: "/",
                 type: ResourceType.RootPage,
-                id: null,
+                id: rootPage.id,
                 parentId: null,
               },
             ])
           }
           searchQuery={searchQuery}
           isLoading={isLoading}
+          isHomeHighlighted={isHomeHighlighted}
         />
       </Suspense>
     )
@@ -157,6 +162,8 @@ const SuspensableResourceSelector = ({
     handleClickResourceItem,
     searchQuery,
     isLoading,
+    isHomeHighlighted,
+    rootPage.id,
   ])
 
   const renderedContent = useMemo(() => {

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -133,6 +133,17 @@ const SuspensableResourceSelector = ({
           hasParentInStack={hasParentInStack}
           handleClickBackButton={handleClickBackButton}
           resourceItemsWithAncestryStack={resourceItemsWithAncestryStack}
+          handleOnClick={() =>
+            handleClickResourceItem([
+              {
+                title: "Home",
+                permalink: "/",
+                type: ResourceType.RootPage,
+                id: null,
+                parentId: null,
+              },
+            ])
+          }
           searchQuery={searchQuery}
           isLoading={isLoading}
         />
@@ -143,6 +154,7 @@ const SuspensableResourceSelector = ({
     hasParentInStack,
     handleClickBackButton,
     resourceItemsWithAncestryStack,
+    handleClickResourceItem,
     searchQuery,
     isLoading,
   ])

--- a/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
@@ -1,11 +1,19 @@
 import type { ResourceItemContent } from "~/schemas/resource"
 import { Flex, HStack, Spacer, Text } from "@chakra-ui/react"
-import { Link } from "@opengovsg/design-system-react"
+import { Button, Link } from "@opengovsg/design-system-react"
 import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
-const HomeHeader = () => {
+import type { ResourceItemProps } from "./ResourceItem"
+
+const HomeHeader = ({
+  handleOnClick,
+}: Pick<ResourceItemProps, "handleOnClick">) => {
   return (
-    <Flex
+    <Button
+      as={Flex}
+      variant="clear"
+      onClick={handleOnClick}
+      cursor="pointer"
       w="full"
       px="0.75rem"
       py="0.375rem"
@@ -27,7 +35,7 @@ const HomeHeader = () => {
       >
         Home
       </Text>
-    </Flex>
+    </Button>
   )
 }
 
@@ -88,6 +96,7 @@ interface SuspendableHeaderProps {
   resourceItemsWithAncestryStack: ResourceItemContent[][] | undefined
   searchQuery: string
   isLoading: boolean
+  handleOnClick: ResourceItemProps["handleOnClick"]
 }
 export const SuspendableHeader = ({
   isSearchQueryEmpty,
@@ -95,6 +104,7 @@ export const SuspendableHeader = ({
   handleClickBackButton,
   resourceItemsWithAncestryStack,
   searchQuery,
+  handleOnClick,
   isLoading,
 }: SuspendableHeaderProps) => {
   if (isLoading) return <LoadingHeader />
@@ -103,7 +113,7 @@ export const SuspendableHeader = ({
     return <BackButtonHeader handleOnClick={handleClickBackButton} />
 
   if (isSearchQueryEmpty || !resourceItemsWithAncestryStack)
-    return <HomeHeader />
+    return <HomeHeader handleOnClick={handleOnClick} />
 
   return (
     <SearchResultsHeader

--- a/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
@@ -1,5 +1,6 @@
 import type { ResourceItemContent } from "~/schemas/resource"
 import { Flex, HStack, Spacer, Text } from "@chakra-ui/react"
+import { dataAttr } from "@chakra-ui/utils"
 import { Button, Link } from "@opengovsg/design-system-react"
 import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
@@ -7,7 +8,8 @@ import type { ResourceItemProps } from "./ResourceItem"
 
 const HomeHeader = ({
   handleOnClick,
-}: Pick<ResourceItemProps, "handleOnClick">) => {
+  isHighlighted = false,
+}: Pick<ResourceItemProps, "handleOnClick"> & { isHighlighted?: boolean }) => {
   return (
     <Button
       as={Flex}
@@ -19,6 +21,15 @@ const HomeHeader = ({
       py="0.375rem"
       color="base.content.default"
       alignItems="center"
+      data-selected={dataAttr(isHighlighted)}
+      _selected={{
+        color: "interaction.main.default",
+        bg: "interaction.muted.main.active",
+        _hover: {
+          color: "interaction.main.default",
+          bg: "interaction.muted.main.active",
+        },
+      }}
     >
       <HStack spacing="0.25rem">
         <BiHomeAlt />
@@ -97,6 +108,7 @@ interface SuspendableHeaderProps {
   searchQuery: string
   isLoading: boolean
   handleOnClick: ResourceItemProps["handleOnClick"]
+  isHomeHighlighted: boolean
 }
 export const SuspendableHeader = ({
   isSearchQueryEmpty,
@@ -106,6 +118,7 @@ export const SuspendableHeader = ({
   searchQuery,
   handleOnClick,
   isLoading,
+  isHomeHighlighted,
 }: SuspendableHeaderProps) => {
   if (isLoading) return <LoadingHeader />
 
@@ -113,7 +126,12 @@ export const SuspendableHeader = ({
     return <BackButtonHeader handleOnClick={handleClickBackButton} />
 
   if (isSearchQueryEmpty || !resourceItemsWithAncestryStack)
-    return <HomeHeader handleOnClick={handleOnClick} />
+    return (
+      <HomeHeader
+        handleOnClick={handleOnClick}
+        isHighlighted={isHomeHighlighted}
+      />
+    )
 
   return (
     <SearchResultsHeader

--- a/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
@@ -41,6 +41,11 @@ export const useResourceSelector = ({
     [isResourceHighlighted, moveDest?.id],
   )
 
+  const isHomeHighlighted = useMemo(
+    () => isResourceHighlighted && moveDest?.type === ResourceType.RootPage,
+    [isResourceHighlighted, moveDest?.type],
+  )
+
   const { data: nestedChildrenOfExistingResourceResult } =
     trpc.resource.getNestedFolderChildrenOf.useQuery({
       resourceId: String(existingResource?.id),
@@ -148,6 +153,7 @@ export const useResourceSelector = ({
 
   return {
     isResourceIdHighlighted,
+    isHomeHighlighted,
     isResourceItemDisabled,
     hasParentInStack,
     handleClickBackButton,

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import { moveResourceAtom } from "../../atoms"
+import { useValidateResourceMove } from "../../hooks/useValidateResourceMove"
 
 export const MoveResourceModal = () => {
   // NOTE: This is what we are trying to move
@@ -116,6 +117,13 @@ const MoveResourceContent = withSuspense(
     })
 
     const movedItem = useAtomValue(moveResourceAtom)
+    const { isLoading: isValidMoveLoading, isValidMove } =
+      useValidateResourceMove({
+        sourceId: movedItem?.id,
+        destinationId: curResourceId ?? null,
+      })
+    // movedResourceId: movedItem.id,
+    // destinationResourceId: curResourceId ?? null,
 
     const [shouldCreateRedirect, setShouldCreateRedirect] = useState(true)
     const [{ fullPermalink: movedFullPermalink }] =
@@ -240,9 +248,12 @@ const MoveResourceContent = withSuspense(
               ability.cannot("move", {
                 parentId: curResourceId ?? null,
               }) ||
-              ability.cannot("move", { parentId: movedItem?.parentId ?? null })
+              ability.cannot("move", {
+                parentId: movedItem?.parentId ?? null,
+              }) ||
+              !isValidMove
             }
-            isLoading={isPending}
+            isLoading={isPending || isValidMoveLoading}
             onClick={() =>
               movedItem?.id &&
               mutate({

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -117,11 +117,14 @@ const MoveResourceContent = withSuspense(
     })
 
     const movedItem = useAtomValue(moveResourceAtom)
-    const { isLoading: isValidMoveLoading, isValidMove } =
-      useValidateResourceMove({
-        sourceId: movedItem?.id,
-        destinationId: curResourceId ?? null,
-      })
+    const {
+      isLoading: isValidMoveLoading,
+      isValidMove,
+      errorMessage,
+    } = useValidateResourceMove({
+      sourceId: movedItem?.id,
+      destinationId: curResourceId ?? null,
+    })
     // movedResourceId: movedItem.id,
     // destinationResourceId: curResourceId ?? null,
 
@@ -183,6 +186,11 @@ const MoveResourceContent = withSuspense(
               existingResource={movedItem ?? undefined}
               onChange={(resourceId) => setCurResourceId(resourceId)}
             />
+            {curResourceId !== undefined && errorMessage && (
+              <Infobox variant="error" size="sm" w="full">
+                {errorMessage}
+              </Infobox>
+            )}
             {showUrlChangeNotice && (
               <VStack alignItems="flex-start" spacing="0.75rem" w="full">
                 <Box
@@ -251,7 +259,7 @@ const MoveResourceContent = withSuspense(
               ability.cannot("move", {
                 parentId: movedItem?.parentId ?? null,
               }) ||
-              !isValidMove
+              isValidMove !== true
             }
             isLoading={isPending || isValidMoveLoading}
             onClick={() =>

--- a/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
@@ -1,0 +1,58 @@
+import { skipToken } from "@tanstack/react-query"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { sitePageSchema } from "~/pages/sites/[siteId]"
+import { isResourceMoveValid } from "~/utils/resources"
+import { trpc } from "~/utils/trpc"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+export const useValidateResourceMove = ({
+  sourceId,
+  destinationId,
+}: {
+  sourceId?: string
+  // NOTE: null if moving to root
+  destinationId: string | null
+}) => {
+  const { siteId } = useQueryParse(sitePageSchema)
+  const { data: source, isLoading: isSourceLoading } =
+    trpc.resource.getMetadataById.useQuery(
+      sourceId ? { siteId, resourceId: sourceId } : skipToken,
+    )
+  const { data: destination, isLoading: isDestinationLoading } =
+    trpc.resource.getMetadataById.useQuery(
+      destinationId !== null
+        ? { siteId, resourceId: destinationId }
+        : skipToken,
+    )
+
+  const { data: rootPage, isLoading: isRootPageLoading } =
+    trpc.page.getRootPage.useQuery(
+      destinationId === null ? { siteId } : skipToken,
+    )
+
+  // NOTE: getRootPage only selects a minimal projection (id/title/draftBlobId)
+  // since it's shared with unrelated previews. Its `id` is the only field
+  // isResourceMoveValid actually reads off the destination when moving to
+  // root — the rest are structurally required but functionally unused, so
+  // they're safe to fill in as the known constants for the root resource.
+  const destinationResource =
+    destinationId === null
+      ? rootPage && {
+          id: rootPage.id,
+          type: ResourceType.RootPage,
+          siteId,
+          permalink: "/",
+          parentId: null,
+        }
+      : destination
+
+  const isValidMove =
+    !!source &&
+    !!destinationResource &&
+    isResourceMoveValid(source, destinationResource)
+
+  return {
+    isLoading: isSourceLoading || isDestinationLoading || isRootPageLoading,
+    isValidMove,
+  }
+}

--- a/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts
@@ -51,8 +51,16 @@ export const useValidateResourceMove = ({
     !!destinationResource &&
     isResourceMoveValid(source, destinationResource)
 
+  const errorMessage =
+    isValidMove instanceof Error
+      ? isValidMove.message
+      : !isValidMove
+        ? "Invalid resource move"
+        : undefined
+
   return {
     isLoading: isSourceLoading || isDestinationLoading || isRootPageLoading,
     isValidMove,
+    errorMessage,
   }
 }

--- a/apps/studio/src/server/CLAUDE.md
+++ b/apps/studio/src/server/CLAUDE.md
@@ -65,7 +65,7 @@ Never write your own auth middleware in a router. If you need a new auth shape, 
 - Kysely (`db`) is the default. Prefer it for new queries.
 - Prisma (`ctx.prisma`) is used for legacy queries and where Kysely lacks parity.
 - Mix in one router only when necessary, and prefer one transaction owner per mutation.
-- Migrations and schema live under `apps/studio/prisma/` — see `apps/studio/prisma/CLAUDE.md`.
+- Migrations and schema live under `packages/db/prisma/` — see `packages/db/prisma/CLAUDE.md`. Studio-owned seed data, JSON-column types, and one-off scripts remain under `apps/studio/prisma/`.
 
 ## Testing
 

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -27,6 +27,7 @@ import {
   searchWithResourceIdsSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
+import { isResourceMoveValid } from "~/utils/resources"
 import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 
 import type { PermissionsProps } from "../permissions/permissions.type"
@@ -377,15 +378,6 @@ export const resourceRouter = router({
               throw new TRPCError({ code: "BAD_REQUEST" })
             }
 
-            // Prevent users from moving the search page (permalink /search, no parent)
-            // This is a special page that is used to display the SearchSG results
-            if (toMove.permalink === "search" && toMove.parentId === null) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message: "The search page cannot be moved",
-              })
-            }
-
             let query = tx.selectFrom("Resource")
             query = !!destinationResourceId
               ? query.where("id", "=", destinationResourceId)
@@ -393,17 +385,10 @@ export const resourceRouter = router({
                   .where("type", "=", ResourceType.RootPage)
                   .where("siteId", "=", siteId)
             const parent = await query
-              .select(["id", "type", "siteId"])
+              .select(["id", "type", "siteId", "permalink", "parentId"])
               .executeTakeFirst()
 
-            if (
-              !parent ||
-              // NOTE: we only allow moves to folders/root.
-              // for moves to root, we only allow this for admin
-              (parent.type !== ResourceType.RootPage &&
-                parent.type !== ResourceType.Folder &&
-                parent.type !== ResourceType.Collection)
-            ) {
+            if (!parent) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
                 message:
@@ -411,46 +396,11 @@ export const resourceRouter = router({
               })
             }
 
-            if (toMove.parentId === parent.id) {
+            const moveValidity = isResourceMoveValid(toMove, parent)
+            if (moveValidity instanceof Error) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
-                message: "You cannot move a resource to the same folder",
-              })
-            }
-
-            // NOTE: If the users are trying to move into a collection,
-            // check that the resource first belongs to a collection
-            if (
-              parent.type !== ResourceType.Collection &&
-              (toMove.type === ResourceType.CollectionPage ||
-                toMove.type === ResourceType.CollectionLink)
-            ) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message:
-                  "Collection items can only be moved to another collection",
-              })
-            }
-
-            if (
-              parent.type === ResourceType.Collection &&
-              toMove.type !== ResourceType.CollectionPage &&
-              toMove.type !== ResourceType.CollectionLink
-            ) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message: "Folder items can only be moved to another folder",
-              })
-            }
-
-            if (movedResourceId === destinationResourceId) {
-              throw new TRPCError({ code: "BAD_REQUEST" })
-            }
-
-            if (toMove.siteId !== parent.siteId) {
-              throw new TRPCError({
-                code: "FORBIDDEN",
-                message: "You cannot move a resource to a different site",
+                message: moveValidity.message,
               })
             }
 

--- a/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
+++ b/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
@@ -7,7 +7,9 @@ import SitePage from "~/pages/sites/[siteId]"
 
 import { ADMIN_HANDLERS } from "../handlers"
 
-const SHARED_HANDLERS = [
+// Split out so the move-validation stories can swap in their own
+// `getMetadataById` mock instead of the generic `content()` one.
+const SHARED_HANDLERS_WITHOUT_METADATA = [
   ...ADMIN_HANDLERS,
   pageHandlers.listWithoutRoot.default(),
   pageHandlers.getRootPage.default(),
@@ -18,6 +20,10 @@ const SHARED_HANDLERS = [
   resourceHandlers.getChildrenOf.default(),
   resourceHandlers.getWithFullPermalink.default(),
   resourceHandlers.getAncestryStack.default(),
+]
+
+const SHARED_HANDLERS = [
+  ...SHARED_HANDLERS_WITHOUT_METADATA,
   resourceHandlers.getMetadataById.content(),
 ]
 
@@ -177,5 +183,51 @@ export const RedirectShadowWarning: Story = {
   },
   play: async (context) => {
     await SingleClick.play?.(context)
+  },
+}
+
+// Collection items (CollectionPage/CollectionLink) may only be moved to
+// another collection — isResourceMoveValid rejects a plain folder as the
+// destination, and the modal should surface that error instead of allowing
+// the move.
+export const CollectionItemInvalidDestination: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...SHARED_HANDLERS_WITHOUT_METADATA,
+        resourceHandlers.getBatchAncestryWithSelf.foldersOnly(),
+        // "Test page 1" (id 4) is mocked as a CollectionPage here so it can
+        // be moved via the ordinary root dashboard listing without a real
+        // collection fixture; "Folder 1" (id 1) is the invalid destination.
+        resourceHandlers.getMetadataById.byId({
+          "4": {
+            id: "4",
+            type: "CollectionPage",
+            title: "Test page 1",
+            permalink: "test-page-1",
+            parentId: null,
+            siteId: 1,
+            publishedVersionId: null,
+          },
+          "1": {
+            id: "1",
+            type: "Folder",
+            title: "Folder 1",
+            permalink: "folder-1",
+            parentId: null,
+            siteId: 1,
+            publishedVersionId: null,
+          },
+        }),
+      ],
+    },
+  },
+  play: async (context) => {
+    const { canvasElement } = context
+    await SingleClick.play?.(context)
+
+    await within(canvasElement.ownerDocument.body).findByText(
+      "Collection items can only be moved to another collection",
+    )
   },
 }

--- a/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
+++ b/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { userEvent, within } from "storybook/test"
+import { expect, userEvent, within } from "storybook/test"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { resourceHandlers } from "tests/msw/handlers/resource"
@@ -229,5 +229,34 @@ export const CollectionItemInvalidDestination: Story = {
     await within(canvasElement.ownerDocument.body).findByText(
       "Collection items can only be moved to another collection",
     )
+  },
+}
+
+// Clicking the "Home" row sets the site root as the move destination — the
+// row itself should pick up the same selected styling a regular folder row
+// gets once it's the chosen destination.
+export const HomeSelected: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...SHARED_HANDLERS,
+        resourceHandlers.getBatchAncestryWithSelf.foldersOnly(),
+      ],
+    },
+  },
+  play: async (context) => {
+    const { canvasElement } = context
+    await Default.play?.(context)
+
+    // Scoped to the dialog: the underlying dashboard page also renders a
+    // "Home" link in its sidebar, so an unscoped query matches more than
+    // one element.
+    const dialog = await within(canvasElement.ownerDocument.body).findByRole(
+      "dialog",
+    )
+    const homeRow = await within(dialog).findByText("Home")
+    await userEvent.click(homeRow)
+
+    await expect(homeRow.closest("[data-selected]")).not.toBeNull()
   },
 }

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -80,3 +80,65 @@ export const getStudioResourceUrl = (resource: Resource): string => {
       return exhaustiveCheck
   }
 }
+
+type BareResource = Pick<
+  Resource,
+  "type" | "id" | "siteId" | "permalink" | "parentId"
+>
+
+// NOTE: Assumes that both source and destination already exist
+export const isResourceMoveValid = (
+  source: BareResource,
+  destination: BareResource,
+) => {
+  // Prevent users from moving the search page (permalink /search, no parent)
+  // This is a special page that is used to display the SearchSG results
+  if (source.permalink === "search" && source.parentId === null) {
+    return new Error("The search page cannot be moved")
+  }
+
+  if (
+    !destination ||
+    // NOTE: we only allow moves to folders/root.
+    // for moves to root, we only allow this for admin
+    (destination.type !== ResourceType.RootPage &&
+      destination.type !== ResourceType.Folder &&
+      destination.type !== ResourceType.Collection)
+  ) {
+    return new Error(
+      "Please ensure that you are trying to move your resource into a valid destination",
+    )
+  }
+
+  if (source.parentId === destination.id) {
+    return new Error("You cannot move a resource to the same folder")
+  }
+
+  // NOTE: If the users are trying to move into a collection,
+  // check that the resource first belongs to a collection
+  if (
+    destination.type !== ResourceType.Collection &&
+    (source.type === ResourceType.CollectionPage ||
+      source.type === ResourceType.CollectionLink)
+  ) {
+    return new Error("Collection items can only be moved to another collection")
+  }
+
+  if (
+    destination.type === ResourceType.Collection &&
+    source.type !== ResourceType.CollectionPage &&
+    source.type !== ResourceType.CollectionLink
+  ) {
+    return new Error("Folder items can only be moved to another folder")
+  }
+
+  if (source.id === destination.id) {
+    return new Error("You cannot move a resource to the same folder")
+  }
+
+  if (source.siteId !== destination.siteId) {
+    return new Error("You cannot move a resource to a different site")
+  }
+
+  return true
+}

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -1,3 +1,5 @@
+import type { RouterOutput } from "~/utils/trpc"
+
 import { trpcMsw } from "../mockTrpc"
 import { DEFAULT_COLLECTION_ITEMS } from "./collection"
 import { DEFAULT_PAGE_ITEMS } from "./page"
@@ -258,6 +260,22 @@ export const resourceHandlers = {
           siteId: 1,
           publishedVersionId: null,
         }
+      }),
+    // Resolves the mocked metadata by the requested `resourceId`, so a story
+    // can give the moved resource and the picked destination distinct types
+    // (e.g. a Page moved onto a Collection) to exercise move validation.
+    byId: (
+      resourcesById: Record<
+        string,
+        RouterOutput["resource"]["getMetadataById"]
+      >,
+    ) =>
+      trpcMsw.resource.getMetadataById.query(({ input: { resourceId } }) => {
+        const resource = resourcesById[resourceId]
+        if (!resource) {
+          throw new Error(`No mocked resource for id ${resourceId}`)
+        }
+        return resource
       }),
   },
   search: {

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -83,11 +83,11 @@ For an agent to read a frame reliably:
 
 ## PR review
 
-There is no automated review bot. Risk tiering and review grading are done via the `pr-review` skill, which reads `docs/risk-taxonomy.md` (file-glob rules, reversibility modifiers, hot paths) and diffs the current branch against `main`. It posts a single informational comment — it never approves, requests changes, or merges.
+Automated review has two separate roles. GitHub Copilot code review can leave code findings on pull requests, guided by the repository-wide `.github/copilot-instructions.md` and scoped rules under `.github/instructions/`. The `pr-review` skill handles repository-specific risk tiering and review grading: it reads `docs/risk-taxonomy.md` (file-glob rules, reversibility modifiers, hot paths), diffs the current branch against `main`, and posts a single informational comment. It never approves, requests changes, or merges.
 
 For a full human-authority review (the typical "review this PR" ask), use the `review-pr` skill instead; `pr-review` is for automation-style grading only.
 
-All PRs require human approval before merge, regardless of risk tier.
+All PRs require human approval before merge, regardless of automated findings or risk tier.
 
 ## GitHub PR conventions
 

--- a/docs/risk-taxonomy.md
+++ b/docs/risk-taxonomy.md
@@ -18,8 +18,10 @@ Match top-down — the first matching glob wins for that file. The PR's tier is 
 
 ### `risk:high`
 
-- `apps/studio/prisma/migrations/**`
-- `apps/studio/prisma/schema.prisma`
+- `packages/db/prisma/migrations/**`
+- `packages/db/prisma/schema.prisma`
+- `packages/db/prisma/custom/**`
+- `packages/db/prisma.config.ts`
 - `apps/studio/src/server/modules/auth/**`
 - `apps/studio/src/server/modules/permissions/**`
 - `apps/studio/src/server/modules/audit/**`
@@ -70,6 +72,7 @@ Server-side logic, data contracts, and shared libraries — things where a bug c
 - `packages/components/src/templates/**`
 - `packages/components/src/schemas/**`
 - `packages/components/src/engine/**`
+- `packages/db/src/**`, `packages/db/prisma/generate.cts`
 - `packages/pgboss/**`, `packages/redis/**`, `packages/logging/**`, `packages/validators/**` — exception: removing/renaming a pgboss job handler or changing its payload type triggers the reversibility modifier and bumps to risk:high
 
 ### `risk:low`
@@ -95,8 +98,8 @@ There is no bot that submits an actual GitHub APPROVE review — the `pr-review`
 
 1. The PR touches no file outside the `risk:low` globs.
 2. CI is green (lint, typecheck, build, tests).
-3. Code review (human, since there is no automated code-review skill) surfaces no blocking issues.
-4. Security review (human, since there is no automated security-review skill) surfaces no blocking issues.
+3. Any automated code-review findings, including GitHub Copilot findings when a review runs, are resolved or explicitly dismissed as non-blocking.
+4. Human code and security review surfaces no blocking issues.
 5. The PR does not change `package.json` scripts, `engines`, `pnpm.overrides`, or workspace dependencies.
 6. No reversibility modifier applies (external side-effects, row mutations, pgboss handler removal/rename/payload change, S3 object deletions).
 

--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -109,7 +109,7 @@ src/
 ## Tests
 
 - Visual + behavioural tests via Storybook.
-- Unit tests (`.spec.ts`) for utilities and engine code.
+- Unit tests (`.test.ts` / `.test.tsx`) for utilities and engine code.
 - Snapshot tests are discouraged except for the JSON Schema itself.
 
 ## Anti-patterns the agent should refuse

--- a/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
+++ b/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
@@ -4,7 +4,8 @@
 
 export const PreloadHelper = ({ href }: { href: string }) => {
   // TODO: replace with ReactDom.preconnect and ReactDom.dnsPrefetch
-  // However, note that they are only available in React 19 which is not yet supported by Next.js
+  // They are only available in React 19, while this repository remains on
+  // React 18 because some design-system dependencies still use findDOMNode.
   // Ref: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#resource-hints
   return (
     <>

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -2,4 +2,4 @@
 
 Shared database layer for the Isomer monorepo. Owns the Prisma schema, generated Kysely types, and the `createDb()` Kysely factory consumed by `apps/studio` and tooling scripts.
 
-This package is being assembled progressively. See `docs/superpowers/specs/2026-06-02-extract-db-package-design.md` for the migration plan.
+See `prisma/CLAUDE.md` for the schema, migration, and generated-type workflow.

--- a/packages/db/prisma/CLAUDE.md
+++ b/packages/db/prisma/CLAUDE.md
@@ -1,0 +1,109 @@
+# Prisma schema and migrations (`packages/db/prisma`)
+
+The Prisma schema is the source of truth for the database. Migrations run
+before new application code is deployed, so mistakes here can lock tables,
+drop data, or make the old application version fail during rollout.
+
+## Layout
+
+```text
+packages/db/
+├── prisma/
+│   ├── schema.prisma       # Database schema
+│   ├── migrations/         # Prisma-managed, timestamped migrations
+│   ├── custom/             # Hand-authored SQL and its installer
+│   ├── generate.cts        # Post-processes generated Kysely types
+│   └── generated/prisma/   # Generated Prisma client; gitignored
+└── src/
+    ├── generated/          # Generated Kysely types and enums; committed
+    └── prisma-json-types.d.ts
+```
+
+Studio's precise JSON-column types, development seed, and one-off data scripts
+remain under `apps/studio/prisma/`; see that directory's `CLAUDE.md` when they
+are part of the change.
+
+## Generated outputs
+
+Running `pnpm --filter @isomer/db generate` produces:
+
+| Generator / step      | Output                                                                        | Commit?        |
+| --------------------- | ----------------------------------------------------------------------------- | -------------- |
+| Prisma client         | `packages/db/prisma/generated/prisma/`                                        | No; gitignored |
+| `prisma-kysely`       | `packages/db/src/generated/generatedTypes.ts` and `generatedEnums.ts`         | Yes            |
+| `prisma/generate.cts` | `packages/db/src/generated/selectableTypes.ts` and unsupported-column patches | Yes            |
+
+Do not edit generated files by hand. After every schema change, regenerate and
+commit all changes under `packages/db/src/generated/`.
+
+## Adding a migration
+
+1. Edit `packages/db/prisma/schema.prisma`.
+2. From `apps/studio`, run `pnpm migrate:dev` and give the migration a
+   descriptive name. Equivalently, run the filtered `@isomer/db` migration
+   command from the repository root.
+3. Inspect the generated `migration.sql`; Prisma may express a rename as a
+   destructive drop and add.
+4. Run `pnpm --filter @isomer/db generate` from the repository root.
+5. Commit the schema, the new migration directory, and changes under
+   `packages/db/src/generated/`.
+6. If a JSON column changed, update `apps/studio/prisma/types.ts` in the same
+   change.
+
+## Custom migrations
+
+Use `packages/db/prisma/custom/migration.sql` for database objects Prisma cannot
+express, such as triggers, stored procedures, partial indexes, or data
+backfills tied to a schema change. Run
+`pnpm --filter @isomer/db migrate:custom` to copy new statements into a tracked
+timestamped migration.
+
+Do not use custom SQL to bypass Prisma's migration history. Every production
+change must still be present under `packages/db/prisma/migrations/`.
+
+## Rules
+
+### Backward-compatible by default
+
+- The old application version must continue to work after the migration runs.
+- Add required columns as nullable, backfill them, then tighten the constraint
+  in a follow-up migration.
+- Rename columns by adding the replacement, dual-writing or migrating data,
+  switching readers, and dropping the old column only after rollout.
+- Change a column type by adding a new column and migrating callers; do not
+  rewrite it in place when old code or queued jobs can still use it.
+
+### Isolate schema changes
+
+- Keep one schema-change concern per pull request.
+- A non-backward-compatible migration must land separately before application
+  code that depends on it; do not hide the dependency inside a Graphite stack.
+
+### Destructive operations require explicit approval
+
+- `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, and `TRUNCATE` require explicit
+  human approval recorded in the pull request.
+- Do not combine removal of an old field with addition of its replacement in a
+  single rollout migration.
+
+### Indexes
+
+- Create indexes on large tables with `CREATE INDEX CONCURRENTLY` through a
+  custom migration so writes are not locked.
+- Land an index that supports a new query path with that query change.
+
+### JSON columns
+
+- Keep each JSON field's `/// @kyselyType(...)` annotation in `schema.prisma`
+  aligned with `apps/studio/prisma/types.ts`.
+- Regenerate the committed Kysely types after changing either side of the
+  contract.
+
+## Anti-patterns the agent should refuse
+
+- A destructive migration without an explicit rollout plan and approval.
+- A new required column without a backfill and staged rollout.
+- Hand-editing files under `packages/db/src/generated/` or
+  `packages/db/prisma/generated/`.
+- Skipping generation after a schema change.
+- Putting Studio seed data or one-off administration scripts in `packages/db`.


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 16 | +373 | -67 |
| 🧪 Test | 2 | +101 | -2 |
| 📄 Doc | 10 | +167 | -102 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds homepage selection and shared move validation to the Studio resource selector and move flow, alongside repository guidance updates.
- Makes the Home row selectable and displays its selected state.
- Reuses resource-move validation in both the modal and server mutation.
- Adds Storybook coverage for invalid collection destinations and Home selection.
- Updates database, review, framework, and workflow documentation.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR does not appear safe to merge because selecting Home still bypasses root-move authorization and can persist a resource outside the top-level tree representation.

The current flow passes the RootPage row ID through the non-null-parent permission check and stores that ID as the moved resource's parent, so Editor and Publisher users can perform an administrator-only root move and leave the resource absent from root traversal.

**Files Needing Attention:** apps/studio/src/components/ResourceSelector/ResourceSelector.tsx, apps/studio/src/components/ResourceSelector/useResourceSelector.tsx, apps/studio/src/server/modules/resource/resource.router.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/components/ResourceSelector/ResourceSelector.tsx | Adds selectable Home behavior, but still represents the root destination using the RootPage row ID. |
| apps/studio/src/features/editing-experience/hooks/useValidateResourceMove.ts | Adds client-side metadata-based move validation and safely disables submission while destination metadata is loading. |
| apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx | Integrates move validation into modal feedback and submission gating, while forwarding the selected Home ID unchanged. |
| apps/studio/src/server/modules/resource/resource.router.ts | Centralizes move validation but continues treating the concrete RootPage ID as a normal non-null destination during authorization and persistence. |
| apps/studio/src/utils/resources.ts | Extracts resource-move invariants into a shared validator covering destination type, collection membership, identity, and site boundaries. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: add interaction story for home-sel..."](https://github.com/opengovsg/isomer/commit/8e1489c26ef03bc5f5ffda26efc7036f5cb19892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54268683)</sub>

**Context used:**

- Knowledge Base — [Resource Tree and Page Editing](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/resource-page-editing.md)
- Knowledge Base — [Permissions, RBAC, and the Whitelist](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/permissions-rbac.md)

<!-- /greptile_comment -->