### PR TITLE
feat(studio): support selecting the homepage as a link/move destination

### DIFF
--- a/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
@@ -5,7 +5,7 @@ import { dataAttr } from "@chakra-ui/utils"
 import { Button } from "@opengovsg/design-system-react"
 import { getIcon } from "~/utils/resources"
 
-interface ResourceItemProps {
+export interface ResourceItemProps {
   item: ResourceItemContent
   isDisabled?: boolean
   isHighlighted?: boolean

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Skeleton, Text, VStack } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { Suspense, useMemo } from "react"
 import { useSearchQuery } from "~/hooks/useSearchQuery"
+import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import {
@@ -71,6 +72,8 @@ const SuspensableResourceSelector = ({
   const isSearchQueryEmpty: boolean = searchQuery.trim().length === 0
   const hasAdditionalLeftPadding: boolean = isSearchQueryEmpty
 
+  const [rootPage] = trpc.page.getRootPage.useSuspenseQuery({ siteId })
+
   const {
     fullPermalink,
     moveDestPermalink,
@@ -105,6 +108,7 @@ const SuspensableResourceSelector = ({
 
   const {
     isResourceIdHighlighted,
+    isHomeHighlighted,
     isResourceItemDisabled,
     hasParentInStack,
     handleClickBackButton,
@@ -139,13 +143,14 @@ const SuspensableResourceSelector = ({
                 title: "Home",
                 permalink: "/",
                 type: ResourceType.RootPage,
-                id: null,
+                id: rootPage.id,
                 parentId: null,
               },
             ])
           }
           searchQuery={searchQuery}
           isLoading={isLoading}
+          isHomeHighlighted={isHomeHighlighted}
         />
       </Suspense>
     )
@@ -157,6 +162,8 @@ const SuspensableResourceSelector = ({
     handleClickResourceItem,
     searchQuery,
     isLoading,
+    isHomeHighlighted,
+    rootPage.id,
   ])
 
   const renderedContent = useMemo(() => {

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -133,6 +133,17 @@ const SuspensableResourceSelector = ({
           hasParentInStack={hasParentInStack}
           handleClickBackButton={handleClickBackButton}
           resourceItemsWithAncestryStack={resourceItemsWithAncestryStack}
+          handleOnClick={() =>
+            handleClickResourceItem([
+              {
+                title: "Home",
+                permalink: "/",
+                type: ResourceType.RootPage,
+                id: null,
+                parentId: null,
+              },
+            ])
+          }
           searchQuery={searchQuery}
           isLoading={isLoading}
         />
@@ -143,6 +154,7 @@ const SuspensableResourceSelector = ({
     hasParentInStack,
     handleClickBackButton,
     resourceItemsWithAncestryStack,
+    handleClickResourceItem,
     searchQuery,
     isLoading,
   ])

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -4,7 +4,6 @@ import { Box, Flex, Skeleton, Text, VStack } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { Suspense, useMemo } from "react"
 import { useSearchQuery } from "~/hooks/useSearchQuery"
-import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import {
@@ -72,9 +71,8 @@ const SuspensableResourceSelector = ({
   const isSearchQueryEmpty: boolean = searchQuery.trim().length === 0
   const hasAdditionalLeftPadding: boolean = isSearchQueryEmpty
 
-  const [rootPage] = trpc.page.getRootPage.useSuspenseQuery({ siteId })
-
   const {
+    rootPage,
     fullPermalink,
     moveDestPermalink,
     moveDest,
@@ -141,7 +139,7 @@ const SuspensableResourceSelector = ({
             handleClickResourceItem([
               {
                 title: "Home",
-                permalink: "/",
+                permalink: "",
                 type: ResourceType.RootPage,
                 id: rootPage.id,
                 parentId: null,

--- a/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
@@ -1,11 +1,19 @@
 import type { ResourceItemContent } from "~/schemas/resource"
 import { Flex, HStack, Spacer, Text } from "@chakra-ui/react"
-import { Link } from "@opengovsg/design-system-react"
+import { Button, Link } from "@opengovsg/design-system-react"
 import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
-const HomeHeader = () => {
+import type { ResourceItemProps } from "./ResourceItem"
+
+const HomeHeader = ({
+  handleOnClick,
+}: Pick<ResourceItemProps, "handleOnClick">) => {
   return (
-    <Flex
+    <Button
+      as={Flex}
+      variant="clear"
+      onClick={handleOnClick}
+      cursor="pointer"
       w="full"
       px="0.75rem"
       py="0.375rem"
@@ -27,7 +35,7 @@ const HomeHeader = () => {
       >
         Home
       </Text>
-    </Flex>
+    </Button>
   )
 }
 
@@ -88,6 +96,7 @@ interface SuspendableHeaderProps {
   resourceItemsWithAncestryStack: ResourceItemContent[][] | undefined
   searchQuery: string
   isLoading: boolean
+  handleOnClick: ResourceItemProps["handleOnClick"]
 }
 export const SuspendableHeader = ({
   isSearchQueryEmpty,
@@ -95,6 +104,7 @@ export const SuspendableHeader = ({
   handleClickBackButton,
   resourceItemsWithAncestryStack,
   searchQuery,
+  handleOnClick,
   isLoading,
 }: SuspendableHeaderProps) => {
   if (isLoading) return <LoadingHeader />
@@ -103,7 +113,7 @@ export const SuspendableHeader = ({
     return <BackButtonHeader handleOnClick={handleClickBackButton} />
 
   if (isSearchQueryEmpty || !resourceItemsWithAncestryStack)
-    return <HomeHeader />
+    return <HomeHeader handleOnClick={handleOnClick} />
 
   return (
     <SearchResultsHeader

--- a/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx
@@ -1,5 +1,6 @@
 import type { ResourceItemContent } from "~/schemas/resource"
 import { Flex, HStack, Spacer, Text } from "@chakra-ui/react"
+import { dataAttr } from "@chakra-ui/utils"
 import { Button, Link } from "@opengovsg/design-system-react"
 import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
@@ -7,7 +8,8 @@ import type { ResourceItemProps } from "./ResourceItem"
 
 const HomeHeader = ({
   handleOnClick,
-}: Pick<ResourceItemProps, "handleOnClick">) => {
+  isHighlighted = false,
+}: Pick<ResourceItemProps, "handleOnClick"> & { isHighlighted?: boolean }) => {
   return (
     <Button
       as={Flex}
@@ -19,6 +21,15 @@ const HomeHeader = ({
       py="0.375rem"
       color="base.content.default"
       alignItems="center"
+      data-selected={dataAttr(isHighlighted)}
+      _selected={{
+        color: "interaction.main.default",
+        bg: "interaction.muted.main.active",
+        _hover: {
+          color: "interaction.main.default",
+          bg: "interaction.muted.main.active",
+        },
+      }}
     >
       <HStack spacing="0.25rem">
         <BiHomeAlt />
@@ -97,6 +108,7 @@ interface SuspendableHeaderProps {
   searchQuery: string
   isLoading: boolean
   handleOnClick: ResourceItemProps["handleOnClick"]
+  isHomeHighlighted: boolean
 }
 export const SuspendableHeader = ({
   isSearchQueryEmpty,
@@ -106,6 +118,7 @@ export const SuspendableHeader = ({
   searchQuery,
   handleOnClick,
   isLoading,
+  isHomeHighlighted,
 }: SuspendableHeaderProps) => {
   if (isLoading) return <LoadingHeader />
 
@@ -113,7 +126,12 @@ export const SuspendableHeader = ({
     return <BackButtonHeader handleOnClick={handleClickBackButton} />
 
   if (isSearchQueryEmpty || !resourceItemsWithAncestryStack)
-    return <HomeHeader handleOnClick={handleOnClick} />
+    return (
+      <HomeHeader
+        handleOnClick={handleOnClick}
+        isHighlighted={isHomeHighlighted}
+      />
+    )
 
   return (
     <SearchResultsHeader

--- a/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
@@ -135,8 +135,17 @@ export const useResourceSelector = ({
       }
 
       setResourceStack(resourceItemWithAncestryStack)
+      // The backend represents "root" as `parentId: null`, not the RootPage
+      // row's own id — sending the real id here for a move would make the
+      // moved resource a child of the RootPage row instead of a top-level
+      // resource. Link mode still needs the real id to build the reference
+      // link, so only translate to `null` for the move destination.
+      const destinationResourceId =
+        interactionType === "move" && lastChild.type === ResourceType.RootPage
+          ? null
+          : lastChild.id
       onChange(
-        lastChild.id,
+        destinationResourceId,
         resourceItemWithAncestryStack
           .map((resource) => resource.permalink)
           .join("/"),
@@ -144,6 +153,7 @@ export const useResourceSelector = ({
       setIsResourceHighlighted(true)
     },
     [
+      interactionType,
       onChange,
       setIsResourceHighlighted,
       setResourceStack,

--- a/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
@@ -41,6 +41,11 @@ export const useResourceSelector = ({
     [isResourceHighlighted, moveDest?.id],
   )
 
+  const isHomeHighlighted = useMemo(
+    () => isResourceHighlighted && moveDest?.type === ResourceType.RootPage,
+    [isResourceHighlighted, moveDest?.type],
+  )
+
   const { data: nestedChildrenOfExistingResourceResult } =
     trpc.resource.getNestedFolderChildrenOf.useQuery({
       resourceId: String(existingResource?.id),
@@ -148,6 +153,7 @@ export const useResourceSelector = ({
 
   return {
     isResourceIdHighlighted,
+    isHomeHighlighted,
     isResourceItemDisabled,
     hasParentInStack,
     handleClickBackButton,

--- a/apps/studio/src/components/ResourceSelector/useResourceStack.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceStack.tsx
@@ -1,6 +1,7 @@
 import type { ResourceItemContent } from "~/schemas/resource"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { trpc } from "~/utils/trpc"
+import { ResourceType } from "~prisma/generated/generatedEnums"
 
 interface UseResourceStackProps {
   siteId: number
@@ -13,6 +14,8 @@ export const useResourceStack = ({
   selectedResourceId,
   existingResource,
 }: UseResourceStackProps) => {
+  const [rootPage] = trpc.page.getRootPage.useSuspenseQuery({ siteId })
+
   const { data: pendingMovedItemAncestryStack } =
     trpc.resource.getAncestryStack.useQuery({
       siteId: String(siteId),
@@ -20,11 +23,26 @@ export const useResourceStack = ({
       includeSelf: !!selectedResourceId,
     })
 
+  // NOTE: getAncestryStack's underlying query excludes RootPage from its base
+  // case, so it always resolves to an empty stack when selectedResourceId is
+  // the homepage's own id. Special-case it here so reopening a homepage
+  // selection still highlights "Home" instead of showing nothing selected.
+  const isSelectedResourceHome = selectedResourceId === rootPage.id
+  const homeAncestryItem: ResourceItemContent = {
+    title: "Home",
+    permalink: "",
+    type: ResourceType.RootPage,
+    id: rootPage.id,
+    parentId: null,
+  }
+
   // NOTE: This is the stack of user's navigation through the resource tree
   // NOTE: We should always start the stack from `/` (root)
   // so that the user will see a full overview of their site structure
   const [resourceStack, setResourceStack] = useState<ResourceItemContent[]>(
-    pendingMovedItemAncestryStack ?? [],
+    isSelectedResourceHome
+      ? [homeAncestryItem]
+      : (pendingMovedItemAncestryStack ?? []),
   )
 
   useEffect(() => {
@@ -71,6 +89,7 @@ export const useResourceStack = ({
 
   // currently do not support fetching next page for search
   return {
+    rootPage,
     fullPermalink,
     moveDestPermalink,
     moveDest,

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1461,7 +1461,7 @@ describe("resource.router", async () => {
       )
     })
 
-    it("should return 403 if source and destination resources belong to different sites", async () => {
+    it("should return 400 if source and destination resources belong to different sites", async () => {
       // Arrange
       const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
       const { page: originPage, site: originSite } = await setupPageResource({

--- a/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
+++ b/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { userEvent, within } from "storybook/test"
+import { expect, userEvent, within } from "storybook/test"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { resourceHandlers } from "tests/msw/handlers/resource"
@@ -229,5 +229,34 @@ export const CollectionItemInvalidDestination: Story = {
     await within(canvasElement.ownerDocument.body).findByText(
       "Collection items can only be moved to another collection",
     )
+  },
+}
+
+// Clicking the "Home" row sets the site root as the move destination — the
+// row itself should pick up the same selected styling a regular folder row
+// gets once it's the chosen destination.
+export const HomeSelected: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...SHARED_HANDLERS,
+        resourceHandlers.getBatchAncestryWithSelf.foldersOnly(),
+      ],
+    },
+  },
+  play: async (context) => {
+    const { canvasElement } = context
+    await Default.play?.(context)
+
+    // Scoped to the dialog: the underlying dashboard page also renders a
+    // "Home" link in its sidebar, so an unscoped query matches more than
+    // one element.
+    const dialog = await within(canvasElement.ownerDocument.body).findByRole(
+      "dialog",
+    )
+    const homeRow = await within(dialog).findByText("Home")
+    await userEvent.click(homeRow)
+
+    await expect(homeRow.closest("[data-selected]")).not.toBeNull()
   },
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 5 | +88 | -8 |
| 🧪 Test | 2 | +31 | -2 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Closes ISOM-2243

Studio's resource picker (used for both "link to a page" and "move resource") had no way to target the site's homepage — the "Home" row shown at the top of the picker was purely decorative. It wasn't clickable, so there was no way to pick the site root as a link or move destination, and it never reflected whether it was the currently selected destination.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- The "Home" row in the resource picker (`ResourceSelector`) is now clickable, letting users pick the site root as a link/move destination.
- The Home row now shows the same "selected" highlight styling that a regular folder row gets once it's the chosen destination (`data-selected` + `_selected` styles, mirroring `ResourceItem`).

**Improvements**:

- `isHomeHighlighted` is derived in `useResourceSelector` from `moveDest?.type === RootPage`, avoiding the need to special-case a nullable resource ID just to detect the root selection.

**Bug Fixes**:

- None

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

- New Storybook interaction story: `Pages/Site Management/Move Resource Modal` → `Home Selected` — clicks the Home row and asserts it picks up the selected styling.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows the shared resource picker to select and highlight the site homepage for link and move workflows.
- Makes the Home row interactive and applies selected-state styling.
- Represents homepage moves as a null parent while preserving the root-page ID for links.
- Encapsulates root-page fetching and homepage stack initialization in the resource-stack hook.
- Adds Storybook coverage for selecting Home and adjusts an existing resource-router test description.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/components/ResourceSelector/ResourceSelector.tsx | Wires the root page into the Home-row selection flow through the resource-stack hook. |
| apps/studio/src/components/ResourceSelector/ResourceSelectorHeader.tsx | Makes the Home header keyboard-accessible and visually reflects its selected state. |
| apps/studio/src/components/ResourceSelector/useResourceSelector.tsx | Tracks homepage highlighting and translates the root page to a null parent only for move operations. |
| apps/studio/src/components/ResourceSelector/useResourceStack.tsx | Encapsulates root-page retrieval and restores homepage selections in the resource ancestry stack. |
| apps/studio/src/stories/Page/MoveResourceModal.stories.tsx | Adds an interaction story asserting that selecting Home applies the selected state. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(studio): resolve root-move destinati..."](https://github.com/opengovsg/isomer/commit/2aed9bdf749c84c83a672130c3c609695d2d8619) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54271676)</sub>

<!-- /greptile_comment -->