### PR TITLE
fix(studio): open edit form when adding a new nav/footer/block array item

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
@@ -71,7 +71,10 @@ function JsonFormsArrayControl(props: ArrayLayoutProps) {
               {label}
             </Text>
             <AddItemButton
-              onClick={addItem(path, createDefaultValue(schema, rootSchema))}
+              onClick={() => {
+                addItem(path, createDefaultValue(schema, rootSchema))()
+                setSelectedIndex(data)
+              }}
               isDisabled={isAddItemDisabled}
             >
               Add item

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkArrayControl.tsx
@@ -405,7 +405,10 @@ function JsonFormsArrayLinkControl({
                 variant="clear"
                 size="xs"
                 leftIcon={<Icon as={BiPlusCircle} />}
-                onClick={addItem(path, createDefaultValue(schema, rootSchema))}
+                onClick={() => {
+                  addItem(path, createDefaultValue(schema, rootSchema))()
+                  setSelectedIndex(data)
+                }}
                 isDisabled={
                   arraySchema.maxItems ? data >= arraySchema.maxItems : false
                 }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/JsonFormsNavbarControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/JsonFormsNavbarControl.tsx
@@ -193,7 +193,10 @@ function JsonFormsNavbarControl({
               <Button
                 variant="outline"
                 leftIcon={<Icon as={BiPlusCircle} fontSize="1.25rem" />}
-                onClick={addItem(path, createDefaultValue(schema, rootSchema))}
+                onClick={() => {
+                  addItem(path, createDefaultValue(schema, rootSchema))()
+                  setSelectedPath(composePaths(path, String(data)))
+                }}
               >
                 Add a link
               </Button>
@@ -227,10 +230,10 @@ function JsonFormsNavbarControl({
                     variant="clear"
                     size="xs"
                     leftIcon={<Icon as={BiPlusCircle} />}
-                    onClick={addItem(
-                      path,
-                      createDefaultValue(schema, rootSchema),
-                    )}
+                    onClick={() => {
+                      addItem(path, createDefaultValue(schema, rootSchema))()
+                      setSelectedPath(composePaths(path, String(data)))
+                    }}
                     isDisabled={
                       arraySchema.maxItems
                         ? data >= arraySchema.maxItems

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsSocialMediaControl/JsonFormsSocialMediaControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsSocialMediaControl/JsonFormsSocialMediaControl.tsx
@@ -374,7 +374,10 @@ const JsonFormsSocialMediaControl = ({
                 variant="clear"
                 size="xs"
                 leftIcon={<Icon as={BiPlusCircle} />}
-                onClick={addItem(path, createDefaultValue(schema, rootSchema))}
+                onClick={() => {
+                  addItem(path, createDefaultValue(schema, rootSchema))()
+                  setSelectedIndex(data)
+                }}
                 isDisabled={
                   arraySchema.maxItems ? data >= arraySchema.maxItems : false
                 }


### PR DESCRIPTION
## Problem

When adding a new child item to any editable array field in Studio, the app appends a blank item via `createDefaultValue` (leaving required fields empty) but never opens that item's edit form. The new row immediately renders in an error state ("Fix errors before publishing" / "Fix issues before saving"), and the user has to manually click into it to fill in the required fields — an unnecessary extra step on every single add.

This affects:
- Navbar items (Site Settings → Navbar) — nav items + sub-items
- Footer link columns (Site Settings → Footer)
- Footer social media links (Site Settings → Footer)
- Cards block (`infocards`)
- Columns of text block (`infocols`)
- Statistics block (`keystatistics`)
- Logo cloud block (`logocloud`)
- Image gallery block (`imagegallery`)
- Contact information block (`contactinformation`)
- Dynamic Data Banner (`dynamicdatabanner`)

Closes ISOM-2513

## Solution

Root cause was the same across four separate JsonForms array-control implementations that back all of the above: each "Add" button's `onClick` only dispatched `addItem(path, createDefaultValue(schema, rootSchema))` — it never touched the local selection state (`selectedIndex` / `selectedPath`) that these controls already use to decide which item's edit panel is open.

Each control now also selects the newly added item right after adding it, reusing the exact same selection state a manual "edit" click already sets — no new state, no new UI, no schema changes:

- `JsonFormsArrayControl.tsx` — `setSelectedIndex(data)`. Covers Cards, Columns-of-text, Statistics, Logo cloud, Image gallery, Contact information, Dynamic Data Banner (all schema-driven generic arrays).
- `JsonFormsNavbarControl.tsx` — `setSelectedPath(composePaths(path, String(data)))`, on both the empty-state and persistent "Add a link" buttons.
- `JsonFormsLinkArrayControl.tsx` — `setSelectedIndex(data)`. Footer link columns.
- `JsonFormsSocialMediaControl.tsx` — `setSelectedIndex(data)`. Footer social links.

`data` is the array's length just before the add, i.e. exactly the new item's index, so there's no need to read the array back after the dispatch.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Adding a nav item, footer link, footer social link, or any block array item (cards, columns, statistics, logo cloud, image gallery, contact info, dynamic data banner) now opens that item's edit form immediately, instead of leaving a blank, error-flagged row for the user to click into.

**Bug Fixes**:

- None (this is a UX papercut fix, not a correctness bug — the appended items were always valid data structurally, just empty)

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

`pnpm typecheck` and `pnpm lint` (oxlint, type-aware) pass on all 4 changed files — the pre-existing `pnpm typecheck` failures on `origin/main` (stale `@opengovsg/isomer-components` exports) are unrelated and reproduce identically with this branch's changes stashed out.

No component test or Storybook story was added: none of the ~30 JsonForms renderer controls in this directory (including the 4 touched here) currently have any component-level test harness, since they require full JsonForms schema/ajv/dispatch context to render. Building that harness is out of scope for this fix. Manual verification in a running Studio instance is recommended before merge:

1. Site Settings → Navbar → Add a link → form should open immediately (repeat for a sub-item add, if applicable)
2. Site Settings → Footer → add a link column item, then a social media link → each should open its edit form immediately
3. On a page, add a Cards / Columns-of-text / Statistics / Logo cloud / Image gallery / Contact information block → click "Add item" → the new item's form should open immediately

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Studio’s four JsonForms array-control implementations so adding a navbar, footer, social-media, or schema-driven block item immediately opens that new item’s editor.
- Wraps each existing add callback to dispatch the append and select the pre-add array length as the new index.
- Uses path-based selection for navbar entries and index-based selection for the other array controls.
- Preserves existing maximum-item guards and data schemas.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

Each handler retains the existing append operation and then selects the pre-add array length, which is the index of the newly appended item; the navbar implementation applies the same value through its existing path-based selection mechanism.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx | Selects the newly appended generic array item using the array’s pre-add length. |
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkArrayControl.tsx | Opens the newly added footer link item while preserving the existing maximum-item guard. |
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/JsonFormsNavbarControl.tsx | Selects the newly appended navbar item by its composed JsonForms path in both empty and populated states. |
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsSocialMediaControl/JsonFormsSocialMediaControl.tsx | Opens the newly appended social-media item using its zero-based index. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(studio): open edit form when adding ..."](https://github.com/opengovsg/isomer/commit/1ec119d555b58e488b3a6ab1d602cfad2e7f5a55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54273697)</sub>

**Context used:**

- Knowledge Base — [Resource Tree and Page Editing](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/resource-page-editing.md)

<!-- /greptile_comment -->