### PR TITLE
Fix homepage meta description fallback to site name

### DIFF
--- a/packages/components/src/engine/__tests__/metadata.test.ts
+++ b/packages/components/src/engine/__tests__/metadata.test.ts
@@ -18,6 +18,7 @@ const basePage = {
 describe("getMetadata", () => {
   describe("Homepage", () => {
     it("uses the hero subtitle as the meta description when present", () => {
+      // Arrange
       const props = {
         layout: ISOMER_PAGE_LAYOUTS.Homepage,
         site: baseSite,
@@ -25,10 +26,15 @@ describe("getMetadata", () => {
         content: [{ type: "hero", subtitle: "Welcome to our site" }],
       } as unknown as IsomerPageSchemaType
 
-      expect(getMetadata(props).description).toBe("Welcome to our site")
+      // Act
+      const actual = getMetadata(props).description
+
+      // Assert
+      expect(actual).toBe("Welcome to our site")
     })
 
     it("falls back to the site name when the hero subtitle is empty", () => {
+      // Arrange
       const props = {
         layout: ISOMER_PAGE_LAYOUTS.Homepage,
         site: baseSite,
@@ -36,10 +42,15 @@ describe("getMetadata", () => {
         content: [{ type: "hero", subtitle: "" }],
       } as unknown as IsomerPageSchemaType
 
-      expect(getMetadata(props).description).toBe(baseSite.siteName)
+      // Act
+      const actual = getMetadata(props).description
+
+      // Assert
+      expect(actual).toBe(baseSite.siteName)
     })
 
     it("falls back to the site name when there is no hero block", () => {
+      // Arrange
       const props = {
         layout: ISOMER_PAGE_LAYOUTS.Homepage,
         site: baseSite,
@@ -47,10 +58,15 @@ describe("getMetadata", () => {
         content: [],
       } as unknown as IsomerPageSchemaType
 
-      expect(getMetadata(props).description).toBe(baseSite.siteName)
+      // Act
+      const actual = getMetadata(props).description
+
+      // Assert
+      expect(actual).toBe(baseSite.siteName)
     })
 
     it("uses the overridden meta description when set", () => {
+      // Arrange
       const props = {
         layout: ISOMER_PAGE_LAYOUTS.Homepage,
         site: baseSite,
@@ -59,12 +75,17 @@ describe("getMetadata", () => {
         content: [{ type: "hero", subtitle: "Welcome to our site" }],
       } as unknown as IsomerPageSchemaType
 
-      expect(getMetadata(props).description).toBe("Custom description")
+      // Act
+      const actual = getMetadata(props).description
+
+      // Assert
+      expect(actual).toBe("Custom description")
     })
   })
 
   describe("Content", () => {
     it("uses the page summary as the meta description", () => {
+      // Arrange
       const props = {
         layout: ISOMER_PAGE_LAYOUTS.Content,
         site: baseSite,
@@ -72,10 +93,15 @@ describe("getMetadata", () => {
         content: [],
       } as unknown as IsomerPageSchemaType
 
-      expect(getMetadata(props).description).toBe("Page summary")
+      // Act
+      const actual = getMetadata(props).description
+
+      // Assert
+      expect(actual).toBe("Page summary")
     })
 
     it("uses the overridden meta description when set", () => {
+      // Arrange
       const props = {
         layout: ISOMER_PAGE_LAYOUTS.Content,
         site: baseSite,
@@ -84,7 +110,11 @@ describe("getMetadata", () => {
         content: [],
       } as unknown as IsomerPageSchemaType
 
-      expect(getMetadata(props).description).toBe("Custom description")
+      // Act
+      const actual = getMetadata(props).description
+
+      // Assert
+      expect(actual).toBe("Custom description")
     })
   })
 })

--- a/packages/components/src/engine/__tests__/metadata.test.ts
+++ b/packages/components/src/engine/__tests__/metadata.test.ts
@@ -1,0 +1,90 @@
+import type { IsomerPageSchemaType } from "~/types/schema"
+import { describe, expect, it } from "vitest"
+import { ISOMER_PAGE_LAYOUTS } from "~/types/constants"
+
+import { getMetadata } from "../metadata"
+
+const baseSite = {
+  siteName: "Ministry of Foreign Affairs",
+  url: "https://www.mfa.gov.sg",
+  logoUrl: "/logo.svg",
+} as IsomerPageSchemaType["site"]
+
+const basePage = {
+  permalink: "/",
+  title: "Home",
+} as IsomerPageSchemaType["page"]
+
+describe("getMetadata", () => {
+  describe("Homepage", () => {
+    it("uses the hero subtitle as the meta description when present", () => {
+      const props = {
+        layout: ISOMER_PAGE_LAYOUTS.Homepage,
+        site: baseSite,
+        page: basePage,
+        content: [{ type: "hero", subtitle: "Welcome to our site" }],
+      } as unknown as IsomerPageSchemaType
+
+      expect(getMetadata(props).description).toBe("Welcome to our site")
+    })
+
+    it("falls back to the site name when the hero subtitle is empty", () => {
+      const props = {
+        layout: ISOMER_PAGE_LAYOUTS.Homepage,
+        site: baseSite,
+        page: basePage,
+        content: [{ type: "hero", subtitle: "" }],
+      } as unknown as IsomerPageSchemaType
+
+      expect(getMetadata(props).description).toBe(baseSite.siteName)
+    })
+
+    it("falls back to the site name when there is no hero block", () => {
+      const props = {
+        layout: ISOMER_PAGE_LAYOUTS.Homepage,
+        site: baseSite,
+        page: basePage,
+        content: [],
+      } as unknown as IsomerPageSchemaType
+
+      expect(getMetadata(props).description).toBe(baseSite.siteName)
+    })
+
+    it("uses the overridden meta description when set", () => {
+      const props = {
+        layout: ISOMER_PAGE_LAYOUTS.Homepage,
+        site: baseSite,
+        page: basePage,
+        meta: { description: "Custom description" },
+        content: [{ type: "hero", subtitle: "Welcome to our site" }],
+      } as unknown as IsomerPageSchemaType
+
+      expect(getMetadata(props).description).toBe("Custom description")
+    })
+  })
+
+  describe("Content", () => {
+    it("uses the page summary as the meta description", () => {
+      const props = {
+        layout: ISOMER_PAGE_LAYOUTS.Content,
+        site: baseSite,
+        page: { ...basePage, contentPageHeader: { summary: "Page summary" } },
+        content: [],
+      } as unknown as IsomerPageSchemaType
+
+      expect(getMetadata(props).description).toBe("Page summary")
+    })
+
+    it("uses the overridden meta description when set", () => {
+      const props = {
+        layout: ISOMER_PAGE_LAYOUTS.Content,
+        site: baseSite,
+        page: { ...basePage, contentPageHeader: { summary: "Page summary" } },
+        meta: { description: "Custom description" },
+        content: [],
+      } as unknown as IsomerPageSchemaType
+
+      expect(getMetadata(props).description).toBe("Custom description")
+    })
+  })
+})

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -25,7 +25,10 @@ const getMetaDescription = (props: IsomerPageSchemaType) => {
     case ISOMER_PAGE_LAYOUTS.Collection:
       return props.page.subtitle
     case ISOMER_PAGE_LAYOUTS.Homepage:
-      return props.content.find((item) => item.type === "hero")?.subtitle
+      return (
+        props.content.find((item) => item.type === "hero")?.subtitle ||
+        props.site.siteName
+      )
     case ISOMER_PAGE_LAYOUTS.File:
     case ISOMER_PAGE_LAYOUTS.Link:
     case ISOMER_PAGE_LAYOUTS.Search:


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +4 | -1 |
| 🧪 Test | 1 | +120 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The homepage meta description was not falling back to the site name when the hero subtitle was empty or missing, resulting in an undefined meta description.

closes https://linear.app/ogp/issue/ISOM-2209/make-site-name-the-meta-description-for-homepage

## Solution

Updated the `getMetaDescription` function in `metadata.ts` to fall back to `props.site.siteName` when the hero subtitle is empty or not present on homepage layouts.

**Bug Fixes**:

- Homepage meta description now correctly falls back to site name when hero subtitle is empty or missing
- Added comprehensive test coverage for homepage and content page meta description logic

## Breaking Changes

- [ ] No - this PR is backwards compatible

## Tests

Added unit tests in `packages/components/src/engine/__tests__/metadata.test.ts` covering:
- Homepage with hero subtitle present
- Homepage with empty hero subtitle (fallback to site name)
- Homepage with no hero block (fallback to site name)
- Homepage with custom meta description override
- Content page with summary
- Content page with custom meta description override

All tests pass and validate the fallback behavior works correctly.

https://claude.ai/code/session_01N5xtZ3TYej5UG1oVUUV8k4