### PR TITLE
perf(studio): derive collection thumbnail fallback in SQL for localised sitemap

### DIFF
--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -4,6 +4,7 @@ import {
   setupBlob,
   setupCollection,
   setupCollectionMeta,
+  setupCollectionPage,
   setupFolder,
   setupFolderMeta,
   setupFullSite,
@@ -1621,6 +1622,158 @@ describe("resource.service", () => {
         // The ordering logic only applies to Page resources with parentId
         expect(result).toBeDefined()
         expect(result.id).toBe(rootPage.id)
+      })
+    })
+
+    describe("firstImage", () => {
+      type SitemapNode = Awaited<ReturnType<typeof getLocalisedSitemap>>
+      type PageBody = Awaited<
+        ReturnType<typeof setupBlob>
+      >["content"]["content"]
+
+      const findNode = (
+        node: SitemapNode,
+        id: string,
+      ): SitemapNode | undefined => {
+        if (node.id === id) return node
+        for (const child of node.children ?? []) {
+          const found = findNode(child, id)
+          if (found) return found
+        }
+        return undefined
+      }
+
+      // Publishes a collection item whose body is `content`, then returns it.
+      // The collection's index page is previewed so that the items show up as
+      // immediate siblings without going through the tag-mapping path.
+      const setupCollectionWithItemBody = async (content: PageBody) => {
+        const user = await setupUser({ isDeleted: false })
+        const { site } = await setupSite()
+        await setupPageResource({
+          resourceType: ResourceType.RootPage,
+          siteId: site.id,
+        })
+        const { collection } = await setupCollection({
+          siteId: site.id,
+          permalink: "test-collection",
+          state: ResourceState.Published,
+        })
+        const { page: indexPage } = await setupPageResource({
+          resourceType: ResourceType.IndexPage,
+          siteId: site.id,
+          parentId: collection.id,
+          state: ResourceState.Published,
+          userId: user.id,
+        })
+        const { page: item, blob } = await setupCollectionPage({
+          siteId: site.id,
+          parentId: collection.id,
+          permalink: "an-article",
+          title: "An article",
+          state: ResourceState.Published,
+          userId: user.id,
+        })
+
+        await db
+          .updateTable("Blob")
+          .where("id", "=", blob.id)
+          .set({ content: { ...blob.content, content } })
+          .execute()
+
+        const sitemap = await getLocalisedSitemap(site.id, Number(indexPage.id))
+        return findNode(sitemap, item.id)
+      }
+
+      it("should use the image that comes first in document order", async () => {
+        // Arrange + Act: images are interleaved with prose so that picking any
+        // image other than the earliest one yields a different src
+        const node = await setupCollectionWithItemBody([
+          { type: "prose", content: [] },
+          { type: "image", src: "/first.jpg", alt: "First image" },
+          { type: "prose", content: [] },
+          { type: "image", src: "/second.jpg", alt: "Second image" },
+          { type: "image", src: "/third.jpg", alt: "Third image" },
+        ])
+
+        // Assert
+        expect(node?.firstImage).toEqual({
+          src: "/first.jpg",
+          alt: "First image",
+        })
+      })
+
+      it("should not set firstImage when the body has no image block", async () => {
+        // Arrange + Act
+        const node = await setupCollectionWithItemBody([
+          { type: "prose", content: [] },
+        ])
+
+        // Assert
+        expect(node).toBeDefined()
+        expect(node?.firstImage).toBeUndefined()
+      })
+
+      it("should fall back to an empty alt when the image block has none", async () => {
+        // Arrange + Act
+        // `alt` is required by the schema but nothing enforces it on the stored
+        // JSON, so the cast reproduces a blob that omits it
+        const node = await setupCollectionWithItemBody([
+          { type: "image", src: "/no-alt.jpg" } as unknown as PageBody[number],
+        ])
+
+        // Assert
+        expect(node?.firstImage).toEqual({ src: "/no-alt.jpg", alt: "" })
+      })
+
+      it("should not set firstImage for non-article layouts", async () => {
+        // Arrange: a regular content page whose body happens to contain an image
+        const user = await setupUser({ isDeleted: false })
+        const { site } = await setupSite()
+        await setupPageResource({
+          resourceType: ResourceType.RootPage,
+          siteId: site.id,
+        })
+        const { folder } = await setupFolder({
+          siteId: site.id,
+          permalink: "a-folder",
+          state: ResourceState.Published,
+        })
+        const { page: sibling } = await setupPageResource({
+          resourceType: ResourceType.Page,
+          siteId: site.id,
+          parentId: folder.id,
+          permalink: "sibling",
+          title: "Sibling",
+          state: ResourceState.Published,
+          userId: user.id,
+        })
+        const { page: contentPage, blob } = await setupPageResource({
+          resourceType: ResourceType.Page,
+          siteId: site.id,
+          parentId: folder.id,
+          permalink: "with-image",
+          title: "With image",
+          state: ResourceState.Published,
+          userId: user.id,
+        })
+        await db
+          .updateTable("Blob")
+          .where("id", "=", blob.id)
+          .set({
+            content: {
+              ...blob.content,
+              content: [{ type: "image", src: "/ignored.jpg", alt: "Ignored" }],
+            },
+          })
+          .execute()
+
+        // Act
+        const sitemap = await getLocalisedSitemap(site.id, Number(sibling.id))
+
+        // Assert
+        const node = findNode(sitemap, contentPage.id)
+        expect(node).toBeDefined()
+        expect(node?.firstImage).toBeUndefined()
       })
     })
   })

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -17,6 +17,7 @@ import {
   normalizeRedirectSource,
 } from "~/schemas/redirect"
 import {
+  type FirstImage,
   getSitemapTree,
   injectTagMappings,
   isCollectionItem,
@@ -441,13 +442,26 @@ export const getLocalisedSitemap = async (
       ELSE ''
     END
 `.as("date")
-  const contentSql = sql<string>`
+  // Only the first top-level image block is ever consumed (as the collection
+  // card thumbnail fallback), so project it here instead of returning the
+  // entire page body, which is unbounded in the size of a collection.
+  const firstImageSql = sql<FirstImage | null>`
     CASE
       WHEN (published.content ->> 'layout') IN ('article','link')
-      THEN published.content ->> 'content'
-      ELSE ''
+       AND jsonb_typeof(published.content -> 'content') = 'array'
+      THEN (
+        /* ORDER BY ord makes document order explicit; a bare LIMIT 1 would
+           rely on the function scan's emission order */
+        SELECT jsonb_build_object('src', block ->> 'src', 'alt', block ->> 'alt')
+        FROM jsonb_array_elements(published.content -> 'content')
+          WITH ORDINALITY AS t(block, ord)
+        WHERE block ->> 'type' = 'image'
+        ORDER BY ord
+        LIMIT 1
+      )
+      ELSE NULL
     END
-`.as("content")
+`.as("firstImage")
   const taggedSql = sql<string | null>`
     CASE
       WHEN (published.content ->> 'layout') IN ('article','link')
@@ -476,7 +490,7 @@ export const getLocalisedSitemap = async (
           thumbnailSql,
           categorySql,
           dateSql,
-          contentSql,
+          firstImageSql,
           taggedSql,
           ...defaultResourceSelect,
         ])
@@ -495,7 +509,9 @@ export const getLocalisedSitemap = async (
               eb.cast<string>(eb.val(""), "text").as("thumbnail"),
               eb.cast<string>(eb.val(""), "text").as("category"),
               eb.cast<string>(eb.val(""), "text").as("date"),
-              eb.cast<string>(eb.val(""), "text").as("content"),
+              eb
+                .cast<FirstImage | null>(eb.val(null), "jsonb")
+                .as("firstImage"),
               eb.cast<string | null>(eb.val(null), "text").as("tagged"),
               ...defaultResourceSelect,
             ]),
@@ -523,7 +539,7 @@ export const getLocalisedSitemap = async (
           thumbnailSql,
           categorySql,
           dateSql,
-          contentSql,
+          firstImageSql,
           taggedSql,
           ...defaultResourceSelect,
         ]),
@@ -546,7 +562,7 @@ export const getLocalisedSitemap = async (
           thumbnailSql,
           categorySql,
           dateSql,
-          contentSql,
+          firstImageSql,
           eb.cast<string | null>(eb.val(null), "text").as("tagged"),
           ...defaultResourceSelect,
         ])
@@ -572,7 +588,7 @@ export const getLocalisedSitemap = async (
               thumbnailSql,
               categorySql,
               dateSql,
-              contentSql,
+              firstImageSql,
               eb.cast<string | null>(eb.val(null), "text").as("tagged"),
               ...defaultResourceSelect,
             ]),
@@ -585,7 +601,7 @@ export const getLocalisedSitemap = async (
       "thumbnail",
       "category",
       "date",
-      "content",
+      "firstImage",
       "tagged",
       ...defaultResourceSelect,
     ])
@@ -597,7 +613,7 @@ export const getLocalisedSitemap = async (
           "thumbnail",
           "category",
           "date",
-          "content",
+          "firstImage",
           "tagged",
           ...defaultResourceSelect,
         ]),
@@ -610,7 +626,7 @@ export const getLocalisedSitemap = async (
           "thumbnail",
           "category",
           "date",
-          "content",
+          "firstImage",
           "tagged",
           ...defaultResourceSelect,
         ]),

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -2,7 +2,6 @@ import type {
   ArticlePagePageProps,
   CollectionPagePageProps,
   FileRefPageProps,
-  IsomerComponent,
   IsomerSitemap,
   LinkRefPageProps,
 } from "@opengovsg/isomer-components"
@@ -17,6 +16,13 @@ import {
 } from "~/server/modules/resource/resource.service"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
+// Projected in SQL from the first top-level image block of the page body, so
+// the body itself never has to leave the database
+export interface FirstImage {
+  src: string | null
+  alt: string | null
+}
+
 type ResourceDto = Omit<
   Resource,
   "id" | "parentId" | "publishedVersionId" | "draftBlobId"
@@ -28,7 +34,7 @@ type ResourceDto = Omit<
   category?: string
   tagged?: string | null
   date?: string
-  content?: string
+  firstImage?: FirstImage | null
 }
 
 const parseTagged = (raw: string | null | undefined): string[] | undefined => {
@@ -84,15 +90,10 @@ const getSitemapTreeFromArray = (
   // TODO: Sort the children by the page ordering if the FolderMeta resource exists
   return children.map((resource) => {
     const permalink = `${path}${resource.permalink}`
-    const parsedContent =
-      typeof resource.content === "string" && resource.content !== ""
-        ? (JSON.parse(resource.content) as IsomerComponent[])
-        : undefined
-    const firstImageComponent = Array.isArray(parsedContent)
-      ? parsedContent.find(
-          (item): item is Extract<IsomerComponent, { type: "image" }> =>
-            item.type === "image",
-        )
+    // Null when the body has no image block at all; `src` is null only when a
+    // block exists but omits it
+    const firstImage = resource.firstImage?.src
+      ? { src: resource.firstImage.src, alt: resource.firstImage.alt ?? "" }
       : undefined
 
     if (resource.type === ResourceType.Page) {
@@ -108,12 +109,7 @@ const getSitemapTreeFromArray = (
           src: resource.thumbnail ?? "",
           alt: "",
         },
-        firstImage: firstImageComponent
-          ? {
-              src: firstImageComponent.src,
-              alt: firstImageComponent.alt,
-            }
-          : undefined,
+        firstImage,
       }
     } else if (resource.type === ResourceType.CollectionPage) {
       return {
@@ -131,12 +127,7 @@ const getSitemapTreeFromArray = (
           src: resource.thumbnail ?? "",
           alt: "",
         },
-        firstImage: firstImageComponent
-          ? {
-              src: firstImageComponent.src,
-              alt: firstImageComponent.alt,
-            }
-          : undefined,
+        firstImage,
       }
     } else if (resource.type === ResourceType.CollectionLink) {
       return {
@@ -154,12 +145,7 @@ const getSitemapTreeFromArray = (
           src: resource.thumbnail ?? "",
           alt: "",
         },
-        firstImage: firstImageComponent
-          ? {
-              src: firstImageComponent.src,
-              alt: firstImageComponent.alt,
-            }
-          : undefined,
+        firstImage,
         ref: "/",
       }
     }
@@ -189,12 +175,7 @@ const getSitemapTreeFromArray = (
       image: !!indexPage?.thumbnail
         ? { src: indexPage.thumbnail, alt: "" }
         : undefined,
-      firstImage: firstImageComponent
-        ? {
-            src: firstImageComponent.src,
-            alt: firstImageComponent.alt,
-          }
-        : undefined,
+      firstImage,
       children: getSitemapTreeFromArray(
         resources,
         resource.id,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +44 | -47 |
| 🧪 Test | 1 | +153 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Closes ISOM-2322

High CPU load on the app server was traced to slow requests generating more than 4MB of data, virtually all of them from `getLocalisedSitemap` in preview. The query selected each sibling's **entire page body** (`published.content ->> 'content'`), and the immediate-siblings arm has no `LIMIT`, so previewing any page inside a large collection read every sibling's full body. That body was then `JSON.parse`d in Node purely to extract the first image block, which is used only as the collection card thumbnail fallback. The body itself never reaches the client — `IsomerSitemap` has no `content` field — so ~97% of the transferred bytes were pure waste.

## Solution

Project the first image block directly in SQL instead of shipping the whole body to Node. `WITH ORDINALITY` + `ORDER BY ord` keeps document order an explicit guarantee rather than relying on the function scan's emission order, and a `jsonb_typeof(...) = 'array'` guard prevents `jsonb_array_elements` from erroring on blobs whose `content` is not an array.

Measured against local Postgres at 2000 collection articles (~6KB bodies):

| | bytes to Node | PG execution |
| --- | --- | --- |
| Before | 7133 kB | 9.98 ms |
| After | 88 kB | 5.56 ms |

Postgres gets faster too, since the body no longer has to be materialised as text — this is not a database-for-app-server trade. On the Node side, the per-sibling `JSON.parse` and its heap churn are removed entirely, and the outer `UNION` de-duplication no longer hashes a multi-KB text column per row (12.8 ms → 0.84 ms in isolation).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

The tRPC response shape is unchanged. `content` was never part of the returned sitemap; only the internal projection used to derive `firstImage` changed.

**Features**:

- None

**Improvements**:

- `getLocalisedSitemap` no longer reads page bodies for a page's siblings; it selects only the first image block's `src`/`alt`.
- Removed the per-sibling `JSON.parse` from `getSitemapTreeFromArray`.
- Added regression coverage for `firstImage`, which previously had none.

**Bug Fixes**:

- None. Selection of *which* image becomes the thumbnail is now explicitly ordered by document position; previously it depended on `jsonb_array_elements` emission order, which is not a guarantee.

## Before & After Screenshots

No visual change — this is a data-fetching change behind an identical response shape.

## Tests

`pnpm test:unit` in `apps/studio`: 1750 passed, 41 skipped (baseline before this change was 1746 passed). Four new integration tests against real Postgres cover document ordering, no image block, an image block missing `alt`, and non-article layouts. Each was mutation-tested — breaking the SQL predicate or flipping the sort direction makes them fail — so they are not passing vacuously. Typecheck and lint are clean.

**Manual Verification Steps**:

- [ ] Open a site with a large collection (e.g. `ura-corp`) in Studio and edit any collection article. Confirm the preview loads and renders as before.
- [ ] In the collection's settings, set "Show thumbnail" fallback to **first image**. Confirm collection items that have no thumbnail of their own display the first image from their page body, and that it is the *first* image for articles containing several.
- [ ] Confirm collection items that do have their own thumbnail still show that thumbnail rather than the first body image.
- [ ] Set the thumbnail fallback to **logo** and confirm items without a thumbnail fall back to the site logo.
- [ ] Open a regular (non-collection) content page containing an image and confirm its preview is unaffected.
- [ ] In DevTools, compare the `site.getLocalisedSitemap` response time for a page in a large collection against production and confirm it is materially faster.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves collection-thumbnail fallback extraction into PostgreSQL so localized sitemap generation no longer transfers and parses complete sibling page bodies.
- Projects only the first top-level image block’s `src` and `alt` fields.
- Preserves document order with ordinality and safely handles non-array content.
- Updates sitemap tree construction to consume the projected image.
- Adds database-backed regression coverage for ordering, absent images, missing alt text, and non-article layouts.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security failures identified.

The SQL projection preserves the former first-top-level-image behavior, safely handles malformed content shapes, and maintains compatible JSONB types across every query branch while eliminating unnecessary page-body transfer and parsing.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/resource/resource.service.ts | Replaces full page-body projection with guarded, ordered SQL extraction of first-image metadata across compatible query branches. |
| apps/studio/src/utils/sitemap.ts | Removes per-resource JSON parsing and maps the projected image into the existing sitemap response shape. |
| apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts | Adds integration coverage for first-image ordering, absence, missing alt text, and layout filtering. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Preview as Studio preview
    participant Service as getLocalisedSitemap
    participant DB as PostgreSQL
    participant Tree as Sitemap tree builder
    Preview->>Service: Request localized sitemap
    Service->>DB: Query resources and first image metadata
    DB->>DB: Scan top-level blocks in document order
    DB-->>Service: Resource rows with firstImage JSONB
    Service->>Tree: Build IsomerSitemap
    Tree-->>Preview: Sitemap with thumbnail fallback metadata
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(studio): derive collection thumbnai..."](https://github.com/opengovsg/isomer/commit/b1e49c6672a55d66f1ba649c8bcc1a0c3f8b9a4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54284186)</sub>

<!-- /greptile_comment -->