### PR TITLE
fix(studio): show disabled controls with tooltips instead of hiding them for editors/publishers

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -90,32 +90,48 @@ export const ResourceTableMenu = ({
             type === ResourceType.Folder ||
             type === ResourceType.Collection) && (
             // TODO: we need to change the resourceid next time when we implement root level permissions
-            <Can do="move" on={{ parentId }}>
-              <MenuItem
-                as="button"
-                onClick={handleMoveResourceClick}
-                icon={<BiFolderOpen fontSize="1rem" />}
-                aria-label={`Move resource to another location for ${title}`}
-              >
-                Move to...
-              </MenuItem>
+            <Can do="move" on={{ parentId }} passThrough>
+              {({ isAllowed }) => (
+                <MenuItem
+                  as="button"
+                  onClick={handleMoveResourceClick}
+                  icon={<BiFolderOpen fontSize="1rem" />}
+                  aria-label={`Move resource to another location for ${title}`}
+                  isDisabled={!isAllowed}
+                  tooltip={
+                    isAllowed
+                      ? undefined
+                      : "You need to be an Admin to move or delete items under Home."
+                  }
+                >
+                  Move to...
+                </MenuItem>
+              )}
             </Can>
           )}
           {resourceType !== ResourceType.RootPage && (
-            <Can do="delete" on={{ parentId }}>
-              <MenuItem
-                onClick={() => {
-                  setResourceModalState({
-                    title,
-                    resourceId,
-                    resourceType,
-                  })
-                }}
-                colorScheme="critical"
-                icon={<BiTrash fontSize="1rem" />}
-              >
-                Delete
-              </MenuItem>
+            <Can do="delete" on={{ parentId }} passThrough>
+              {({ isAllowed }) => (
+                <MenuItem
+                  onClick={() => {
+                    setResourceModalState({
+                      title,
+                      resourceId,
+                      resourceType,
+                    })
+                  }}
+                  colorScheme="critical"
+                  icon={<BiTrash fontSize="1rem" />}
+                  isDisabled={!isAllowed}
+                  tooltip={
+                    isAllowed
+                      ? undefined
+                      : "You need to be an Admin to move or delete items under Home."
+                  }
+                >
+                  Delete
+                </MenuItem>
+              )}
             </Can>
           )}
         </MenuList>

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -88,94 +88,95 @@ const SuspendablePublishButton = ({
     <Can do="publish" on="Resource" passThrough>
       {({ isAllowed }) => (
         <TouchableTooltip
-          hidden={isChangesPendingPublish}
-          label="All changes have been published"
+          hidden={isChangesPendingPublish && isAllowed}
+          label={
+            !isAllowed
+              ? "You need to be a Publisher or Admin to publish."
+              : "All changes have been published"
+          }
         >
-          {isAllowed && (
-            <>
-              {/* Render the modal conditionally to ensure the schema resets when the modal is opened/closed */}
-              {scheduledPublishingDisclosure.isOpen && (
-                <ScheduledPublishingModal
-                  siteId={siteId}
-                  pageId={pageId}
-                  {...scheduledPublishingDisclosure}
-                />
-              )}
-              {publishNowDisclosure.isOpen && (
-                <PublishingModal
-                  pageId={pageId}
-                  siteId={siteId}
-                  onPublishNow={(pageId, siteId) => mutate({ pageId, siteId })}
-                  isPublishingNow={isPending}
-                  {...publishNowDisclosure}
-                />
-              )}
-              {currPage.scheduledAt ? (
-                <CancelSchedulePublishIndicator
-                  siteId={siteId}
-                  pageId={pageId}
-                  scheduledAt={currPage.scheduledAt}
-                />
-              ) : (
-                <HStack spacing={0} position="relative">
-                  <Button
-                    variant="solid"
-                    size="sm"
-                    isDisabled={!isChangesPendingPublish}
-                    isLoading={isPending}
-                    borderRightRadius={0}
-                    onClick={() => {
-                      posthog.capture("publish_modal_opened", {
-                        site_id: siteId,
-                      })
-                      publishNowDisclosure.onOpen()
-                    }}
-                    {...rest}
-                  >
-                    Publish
-                  </Button>
-                  <>
-                    <Divider
-                      orientation="vertical"
-                      borderColor="base.canvas.default"
-                      height="auto"
+          <>
+            {/* Render the modal conditionally to ensure the schema resets when the modal is opened/closed */}
+            {scheduledPublishingDisclosure.isOpen && (
+              <ScheduledPublishingModal
+                siteId={siteId}
+                pageId={pageId}
+                {...scheduledPublishingDisclosure}
+              />
+            )}
+            {publishNowDisclosure.isOpen && (
+              <PublishingModal
+                pageId={pageId}
+                siteId={siteId}
+                onPublishNow={(pageId, siteId) => mutate({ pageId, siteId })}
+                isPublishingNow={isPending}
+                {...publishNowDisclosure}
+              />
+            )}
+            {currPage.scheduledAt ? (
+              <CancelSchedulePublishIndicator
+                siteId={siteId}
+                pageId={pageId}
+                scheduledAt={currPage.scheduledAt}
+              />
+            ) : (
+              <HStack spacing={0} position="relative">
+                <Button
+                  variant="solid"
+                  size="sm"
+                  isDisabled={!isChangesPendingPublish || !isAllowed}
+                  isLoading={isPending}
+                  borderRightRadius={0}
+                  onClick={() => {
+                    posthog.capture("publish_modal_opened", {
+                      site_id: siteId,
+                    })
+                    publishNowDisclosure.onOpen()
+                  }}
+                  {...rest}
+                >
+                  Publish
+                </Button>
+                <>
+                  <Divider
+                    orientation="vertical"
+                    borderColor="base.canvas.default"
+                    height="auto"
+                  />
+                  <Menu preventOverflow={true} isLazy>
+                    <MenuButton
+                      as={IconButton}
+                      aria-label="More options"
+                      icon={<Icon as={BiChevronDown} boxSize="1rem" />}
+                      size="sm"
+                      variant="solid"
+                      isDisabled={
+                        !isChangesPendingPublish || isPending || !isAllowed
+                      }
+                      borderLeftRadius={0}
                     />
-                    <Menu preventOverflow={true} isLazy>
-                      <MenuButton
-                        as={IconButton}
-                        aria-label="More options"
-                        icon={<Icon as={BiChevronDown} boxSize="1rem" />}
-                        size="sm"
-                        variant="solid"
-                        isDisabled={!isChangesPendingPublish || isPending}
-                        borderLeftRadius={0}
-                      />
-                      <MenuList>
-                        <MenuItem
-                          onClick={() => {
-                            posthog.capture("scheduled_publish_modal_opened", {
-                              site_id: siteId,
-                            })
-                            scheduledPublishingDisclosure.onOpen()
-                          }}
-                        >
-                          <HStack spacing="0.5rem" alignItems="center">
-                            <Icon as={BiTimeFive} boxSize="1rem" />
-                            <Text
-                              textStyle="body-2"
-                              color="base.content.strong"
-                            >
-                              Schedule for later
-                            </Text>
-                          </HStack>
-                        </MenuItem>
-                      </MenuList>
-                    </Menu>
-                  </>
-                </HStack>
-              )}
-            </>
-          )}
+                    <MenuList>
+                      <MenuItem
+                        onClick={() => {
+                          posthog.capture("scheduled_publish_modal_opened", {
+                            site_id: siteId,
+                          })
+                          scheduledPublishingDisclosure.onOpen()
+                        }}
+                      >
+                        <HStack spacing="0.5rem" alignItems="center">
+                          <Icon as={BiTimeFive} boxSize="1rem" />
+                          <Text textStyle="body-2" color="base.content.strong">
+                            Schedule for later
+                          </Text>
+                        </HStack>
+                      </MenuItem>
+                    </MenuList>
+                  </Menu>
+                </>
+              </HStack>
+            )}
+          </>
         </TouchableTooltip>
       )}
     </Can>

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -113,7 +113,7 @@ const SuspendablePublishButton = ({
                 {...publishNowDisclosure}
               />
             )}
-            {currPage.scheduledAt ? (
+            {currPage.scheduledAt && isAllowed ? (
               <CancelSchedulePublishIndicator
                 siteId={siteId}
                 pageId={pageId}

--- a/apps/studio/src/features/editing-experience/components/__tests__/PublishButton.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/__tests__/PublishButton.browser.test.tsx
@@ -100,8 +100,10 @@ describe("PublishButton permission gating", () => {
   // `{ isAllowed }` object instead of a positional boolean. Destructuring it as a
   // positional boolean made `allowed` an always-truthy object, leaking the button
   // to editors regardless of their permissions.
-  it("does NOT render the Publish button for editors", () => {
+  it("renders the Publish button disabled for editors", () => {
     renderForRole(RoleType.Editor)
-    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull()
+    const button = screen.queryByRole("button", { name: "Publish" })
+    expect(button).not.toBeNull()
+    expect(button).toBeDisabled()
   })
 })

--- a/apps/studio/src/features/users/components/AddNewUserButton.tsx
+++ b/apps/studio/src/features/users/components/AddNewUserButton.tsx
@@ -47,7 +47,7 @@ export const AddNewUserButton = ({
 
   if (!canManageUsers) {
     return (
-      <Tooltip label="Only admins can add users." placement="bottom">
+      <Tooltip label="You need to be an Admin to add users." placement="bottom">
         {button}
       </Tooltip>
     )

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -1,5 +1,5 @@
 import { Portal, useDisclosure } from "@chakra-ui/react"
-import { Button, Menu } from "@opengovsg/design-system-react"
+import { Button, Menu, TouchableTooltip } from "@opengovsg/design-system-react"
 import posthog from "posthog-js"
 import { BiData, BiFileBlank, BiFolder, BiHomeAlt } from "react-icons/bi"
 import { z } from "zod"
@@ -35,43 +35,51 @@ const HomepageMenuButton = ({
   onFolderCreateModalOpen,
 }: HomepageMenuButtonProps) => {
   return (
-    <Can do="create" on={{ parentId: null }}>
-      <Menu isLazy size="sm">
-        {({ isOpen }) => (
-          <>
-            <Menu.Button
-              isOpen={isOpen}
-              as={Button}
-              size="md"
-              justifySelf="flex-end"
-            >
-              Create new...
-            </Menu.Button>
-            <Portal>
-              <Menu.List>
-                <Menu.Item
-                  onClick={onFolderCreateModalOpen}
-                  icon={<BiFolder fontSize="1rem" />}
+    <Can do="create" on={{ parentId: null }} passThrough>
+      {({ isAllowed }) => {
+        return (
+          <Menu isLazy size="sm">
+            {({ isOpen }) => (
+              <TouchableTooltip
+                label="You need to be an Admin to create items under Home."
+                hidden={isAllowed}
+              >
+                <Menu.Button
+                  isOpen={isOpen}
+                  as={Button}
+                  size="md"
+                  justifySelf="flex-end"
+                  isDisabled={!isAllowed}
                 >
-                  Folder
-                </Menu.Item>
-                <Menu.Item
-                  onClick={onPageCreateModalOpen}
-                  icon={<BiFileBlank fontSize="1rem" />}
-                >
-                  Page
-                </Menu.Item>
-                <Menu.Item
-                  onClick={onCollectionCreateModalOpen}
-                  icon={<BiData fontSize="1rem" />}
-                >
-                  Collection
-                </Menu.Item>
-              </Menu.List>
-            </Portal>
-          </>
-        )}
-      </Menu>
+                  Create new...
+                </Menu.Button>
+                <Portal>
+                  <Menu.List>
+                    <Menu.Item
+                      onClick={onFolderCreateModalOpen}
+                      icon={<BiFolder fontSize="1rem" />}
+                    >
+                      Folder
+                    </Menu.Item>
+                    <Menu.Item
+                      onClick={onPageCreateModalOpen}
+                      icon={<BiFileBlank fontSize="1rem" />}
+                    >
+                      Page
+                    </Menu.Item>
+                    <Menu.Item
+                      onClick={onCollectionCreateModalOpen}
+                      icon={<BiData fontSize="1rem" />}
+                    >
+                      Collection
+                    </Menu.Item>
+                  </Menu.List>
+                </Portal>
+              </TouchableTooltip>
+            )}
+          </Menu>
+        )
+      }}
     </Can>
   )
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +172 | -147 |
| 🧪 Test | 1 | +4 | -2 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-2450

Editors and Publishers (i.e. everyone below Admin) had several controls **completely unmounted** from the DOM instead of shown-but-disabled, with no explanation:

- The "Create new…" button on the site root (Home) disappeared entirely.
- The row-level kebab menu on root-level resources showed an empty-looking menu, since "Move to…" and "Delete" were unmounted.
- The "Publish" split button in the page editor disappeared entirely for Editors.

This reads as a bug/dead-end rather than a permissions boundary — users can't tell whether the feature is broken or they simply lack access.

## Solution

<!-- How did you solve the problem? -->

All three surfaces were using CASL's `<Can do="..." on={...}>` in its default (unmount-on-disallow) mode. Switched each to `<Can ... passThrough>` and used the render-prop `isAllowed` to keep the control mounted, disabled, and paired with a tooltip explaining the required role — following the pattern the design (Figma "Bug bash 🐛") and tooltip copy in the ticket specify.

No permission logic changed — `permissions.util.ts` already correctly withheld `create`/`move`/`delete` at root and `publish` for Editors; this PR is purely presentational (hidden → disabled + tooltip).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Standardized the Collaborators "Add new user" tooltip copy from "Only admins can add users." to "You need to be an Admin to add users." to match the wording convention used across the other three surfaces in this PR (`AddNewUserButton.tsx`).

**Bug Fixes**:

- `pages/sites/[siteId]/index.tsx` (`HomepageMenuButton`): "Create new…" button on Home now renders disabled with tooltip *"You need to be an Admin to create items under Home."* for Editor/Publisher instead of disappearing.
- `features/dashboard/components/ResourceTable/ResourceTableMenu.tsx`: root-level "Move to…" and "Delete" menu items now render disabled with tooltip *"You need to be an Admin to move or delete items under Home."* for Editor/Publisher instead of disappearing. Behaviour inside folders/collections is unchanged (already unrestricted there, since the CASL rule keys off `parentId`).
- `features/editing-experience/components/PublishButton.tsx`: the Publish split button now stays mounted and disabled with tooltip *"You need to be a Publisher or Admin to publish."* for Editors, instead of disappearing. Also fixed the tooltip's `hidden` condition, which used `||` instead of `&&` and so suppressed the permission tooltip whenever there were pending changes — the exact case where an Editor most needed to see it.

**Out of scope** (per ticket): Site Settings page/save permissions and the Collection Preview filter management card are deferred to a separate permissions review (Ming Ting).

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

Manually verify as an Editor and as a Publisher:

- Site root: "Create new…" button is visible but disabled, with tooltip on hover.
- Site root, kebab menu on a root-level page/folder/collection: "Move to…" and "Delete" are visible but disabled, with tooltip on hover. Same menu inside a folder/collection is unaffected (enabled, no tooltip).
- Page editor: "Publish" split button is visible but disabled, with tooltip on hover — both when there are pending changes and when there aren't.
- As Admin (and Publisher, for the Publish button): all of the above remain fully enabled with no tooltip.
- Collaborators page: "Add new user" tooltip now reads "You need to be an Admin to add users."

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR keeps permission-restricted Studio controls visible but disabled, with role-specific tooltips explaining how access is granted.
- Shows disabled root-level create, move, and delete controls to non-Admins.
- Shows Editors a disabled Publish split button and hides the scheduled-cancellation action they cannot perform.
- Adds browser coverage for the Editor Publish-button state and standardizes collaborator tooltip copy.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported scheduled-cancellation path is no longer rendered for users without publish permission, and its replacement controls are disabled.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx | Uses pass-through permission checks to render root-level move and delete actions disabled with explanatory tooltips. |
| apps/studio/src/features/editing-experience/components/PublishButton.tsx | Keeps Publish visible but disabled for Editors and correctly restricts scheduled cancellation to users with publish permission. |
| apps/studio/src/features/editing-experience/components/__tests__/PublishButton.browser.test.tsx | Updates browser coverage to require that Editors see a disabled Publish button. |
| apps/studio/src/features/users/components/AddNewUserButton.tsx | Standardizes the Admin-required tooltip without changing behavior. |
| apps/studio/src/pages/sites/[siteId]/index.tsx | Keeps the root create menu visible but disabled for users lacking create permission. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: fix test"](https://github.com/opengovsg/isomer/commit/7b07f3010b57c134b9de24b4b7dbc915c7daa278) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54286777)</sub>

<!-- /greptile_comment -->