### PR TITLE
ci: build and publish isomer-components to S3 cache on deploy

### DIFF
--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -75,14 +75,17 @@ jobs:
           pnpm config set store-dir .pnpm-store --location project
 
       - name: Install pnpm dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter isomer-base-template...
 
       # Shared S3 cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
-      # Rather than caching the pnpm store and a built dist separately, archive the whole
-      # repository (source + node_modules) as a single tarball so downstream per-site
-      # CodeBuild projects can pull it down instead of cloning/installing themselves.
+      # Archived as two separate tarballs so downstream per-site CodeBuild projects can pull
+      # them down instead of cloning/installing themselves:
+      #   1. isomer.tar.zst - the repository itself (source only, no node_modules/.pnpm-store).
+      #   2. isomer-pnpm-store.tar.zst - the project-local pnpm store, cached separately since
+      #      restoring it doesn't touch the repository and it's what publisher.sh's install
+      #      step actually needs to relink node_modules without hitting the registry.
       #
-      # publisher.sh (the consumer) downloads this from isomer/latest/isomer.tar.zst, extracts it with
+      # publisher.sh (the consumer) downloads isomer.tar.zst from isomer/latest/, extracts it with
       # `tar --use-compress-program=zstd -xf`, then `cd isomer/` - mirroring what
       # `git clone .../isomer.git` would have produced. So the archive must be
       # zstd-compressed and rooted at an `isomer/` directory, not the bare working tree.
@@ -102,6 +105,7 @@ jobs:
           }
 
           REPO_TGZ="isomer.tar.zst"
+          STORE_TGZ="isomer-pnpm-store.tar.zst"
           # publisher.sh's production path only ever reads isomer/latest/. This branch
           # exists so a manual/test workflow_dispatch of *this* workflow (passing an
           # explicit ref) writes to its own prefix instead of clobbering isomer/latest/
@@ -111,13 +115,13 @@ jobs:
           # workflow produced for that branch instead of re-cloning from scratch, and
           # only falls back to a fresh git clone if no such archive was published.
           if [ -n "$REQUESTED_REF" ]; then
-            REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$REQUESTED_REF/$REPO_TGZ"
+            CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$REQUESTED_REF"
           else
-            REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/latest/$REPO_TGZ"
+            CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/latest"
           fi
+          REPO_CACHE_PATH="$CACHE_PREFIX/$REPO_TGZ"
+          STORE_CACHE_PATH="$CACHE_PREFIX/$STORE_TGZ"
 
-          echo "Archiving repository..."
-          start_time=$(date +%s)
           # Record the resolved ref inside the archive so publisher.sh's production
           # path - which has no branch input and no .git to inspect - can key its
           # isomer-components dist cache by the actual release instead of a fixed
@@ -129,12 +133,26 @@ jobs:
           # directory itself and `ln -s` would fail with "File exists".
           ARCHIVE_STAGING=$(mktemp -d)
           ln -s "$(pwd)" "$ARCHIVE_STAGING/isomer"
-          tar --exclude=.git -h --use-compress-program="zstd -6" -cf "$ARCHIVE_STAGING/$REPO_TGZ" -C "$ARCHIVE_STAGING" isomer
+
+          echo "Archiving repository..."
+          start_time=$(date +%s)
+          tar --exclude=.git --exclude=node_modules --exclude=.pnpm-store -h --use-compress-program="zstd -6" -cf "$ARCHIVE_STAGING/$REPO_TGZ" -C "$ARCHIVE_STAGING" isomer
           calculate_duration $start_time
 
           echo "Uploading repository archive to S3..."
           start_time=$(date +%s)
           aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$REPO_TGZ" $REPO_CACHE_PATH
-          rm -rf "$ARCHIVE_STAGING"
           echo "Uploaded repository archive"
+          calculate_duration $start_time
+
+          echo "Archiving pnpm store..."
+          start_time=$(date +%s)
+          tar --use-compress-program="zstd -6" -cf "$ARCHIVE_STAGING/$STORE_TGZ" .pnpm-store
+          calculate_duration $start_time
+
+          echo "Uploading pnpm store archive to S3..."
+          start_time=$(date +%s)
+          aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$STORE_TGZ" $STORE_CACHE_PATH
+          rm -rf "$ARCHIVE_STAGING"
+          echo "Uploaded pnpm store archive"
           calculate_duration $start_time

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -10,25 +10,6 @@ name: Build and publish site
 # repository (source + node_modules) to S3, which downstream per-site
 # CodeBuild projects pull down instead of cloning/installing themselves.
 on:
-  workflow_dispatch:
-    inputs:
-      aws-region:
-        description: "AWS region to use"
-        required: true
-        default: "ap-southeast-1"
-        type: string
-      cicd-role:
-        description: "AWS IAM role to assume by GitHub action runner"
-        required: true
-        type: string
-      s3-cache-bucket-name:
-        description: "S3 bucket used to cache the pnpm store and isomer-components dist between builds (same bucket/prefix pattern as the CodeBuild projects)"
-        required: true
-        type: string
-      isomer-build-repo-branch:
-        description: "Git ref (tag or branch) of opengovsg/isomer to build. Leave empty to use the latest release tag."
-        required: false
-        type: string
   workflow_call:
     inputs:
       aws-region:

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -1,0 +1,181 @@
+name: Build and publish site
+
+# Migrated from tooling/build/scripts/publisher.sh, which used to run as the
+# entrypoint of a per-site AWS CodeBuild project. CodeBuild supplied SITE_NAME /
+# S3_BUCKET_NAME / CLOUDFRONT_DISTRIBUTION_ID / S3_CACHE_BUCKET_NAME etc. as
+# project-level env vars; those become workflow_dispatch inputs here. The
+# git-clone-from-scratch step becomes actions/checkout; the S3 pnpm-store/dist
+# tarball caching is otherwise kept as-is.
+on:
+  workflow_dispatch:
+    inputs:
+      aws-region:
+        description: "AWS region to use"
+        required: true
+        default: "ap-southeast-1"
+        type: string
+      aws-account-id:
+        description: "AWS account ID to use"
+        required: true
+        type: string
+      cicd-role:
+        description: "AWS IAM role to assume by GitHub action runner"
+        required: true
+        type: string
+      s3-cache-bucket-name:
+        description: "S3 bucket used to cache the pnpm store and isomer-components dist between builds (same bucket/prefix pattern as the CodeBuild projects)"
+        required: true
+        type: string
+      isomer-build-repo-branch:
+        description: "Git ref (tag or branch) of opengovsg/isomer to build. Leave empty to use the latest release tag."
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      aws-region:
+        description: "AWS region to use"
+        required: false
+        default: "ap-southeast-1"
+        type: string
+      aws-account-id:
+        description: "AWS account ID to use"
+        required: true
+        type: string
+      cicd-role:
+        description: "AWS IAM role to assume by GitHub action runner"
+        required: true
+        type: string
+      s3-cache-bucket-name:
+        description: "S3 bucket used to cache the pnpm store and isomer-components dist between builds (same bucket/prefix pattern as the CodeBuild projects)"
+        required: true
+        type: string
+      isomer-build-repo-branch:
+        description: "Git ref (tag or branch) of opengovsg/isomer to build. Leave empty to use the latest release tag."
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve build ref
+        id: resolve-ref
+        env:
+          REQUESTED_REF: ${{ inputs.isomer-build-repo-branch }}
+        run: |
+          # Assumption: all production builds use release tags. If a ref is passed in
+          # explicitly, treat it as a feature branch for cache-key purposes below.
+          if [ -n "$REQUESTED_REF" ]; then
+            echo "ref=$REQUESTED_REF" >> "$GITHUB_OUTPUT"
+            echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
+          else
+            LATEST_TAG=$(git ls-remote --tags --sort='v:refname' https://github.com/opengovsg/isomer.git | tail -n1 | awk '{print $2}' | sed -E 's|refs/tags/||; s/\^.*$//')
+            echo "ref=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+            echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout ${{ steps.resolve-ref.outputs.ref }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.resolve-ref.outputs.ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ inputs.cicd-role }}
+          role-session-name: github-action-build-components
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Set up pnpm
+        run: |
+          corepack enable
+          corepack install -g pnpm@11.5.1
+
+          # Use a project-local store only in this job so the S3 tarball is self-contained.
+          # Do not set storeDir in pnpm-workspace.yaml: local dev keeps the default global store.
+          pnpm config set store-dir .pnpm-store --location project
+
+      ### Create a cache key for the current build ###
+      - name: Resolve cache key
+        id: cache-key
+        env:
+          RESOLVED_REF: ${{ steps.resolve-ref.outputs.ref }}
+          IS_RELEASE_TAG: ${{ steps.resolve-ref.outputs.is_release_tag }}
+        run: |
+          if [ "$IS_RELEASE_TAG" = "true" ]; then
+            echo "key=$RESOLVED_REF" >> "$GITHUB_OUTPUT"
+          else
+            # Not a release tag, so it's a feature branch - use a combination of branch name
+            # and commit hash E.g. feat-buildsupercoolfeature-1a2b3c4d. This ensures that each
+            # unique feature branch and commit will have its own cache, reducing manual cache
+            # invalidation and human factor when testing on staging.
+            echo "key=$RESOLVED_REF-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
+      # pnpm keeps package bytes in a content-addressable store; `store-dir` is set above for this run only.
+      # We archive only `.pnpm-store`; `pnpm install` recreates node_modules from the store + lockfile.
+      - name: Install pnpm dependencies
+        env:
+          S3_CACHE_BUCKET_NAME: ${{ inputs.s3-cache-bucket-name }}
+          UNIQUE_CACHE_KEY: ${{ steps.cache-key.outputs.key }}
+        run: |
+          calculate_duration() {
+            local start_time=$1
+            local end_time
+            end_time=$(date +%s)
+            echo "Time taken: $((end_time - start_time)) seconds"
+          }
+
+          TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
+          TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
+          echo "Fetching cached pnpm store..."
+          aws s3 cp --only-show-errors $TEMPLATE_DEPS_CACHE_PATH $TEMPLATE_DEPS_TGZ || true
+          echo "Installing workspace dependencies..."
+          start_time=$(date +%s)
+          pnpm install --frozen-lockfile
+          calculate_duration $start_time
+
+          echo "Caching pnpm store to S3..."
+          start_time=$(date +%s)
+          tar --use-compress-program="zstd -6" -cf $TEMPLATE_DEPS_TGZ .pnpm-store
+          aws s3 cp --only-show-errors $TEMPLATE_DEPS_TGZ $TEMPLATE_DEPS_CACHE_PATH
+          rm $TEMPLATE_DEPS_TGZ
+          echo "Cached pnpm store"
+          calculate_duration $start_time
+
+      # packages/components/dist is gitignored; Next resolves @opengovsg/isomer-components via workspace.
+      # Cache dist separately from .pnpm-store: restoring plain files does not affect the content-addressable store or node_modules linking.
+      - name: Build isomer-components dist
+        env:
+          S3_CACHE_BUCKET_NAME: ${{ inputs.s3-cache-bucket-name }}
+          UNIQUE_CACHE_KEY: ${{ steps.cache-key.outputs.key }}
+        run: |
+          calculate_duration() {
+            local start_time=$1
+            local end_time
+            end_time=$(date +%s)
+            echo "Time taken: $((end_time - start_time)) seconds"
+          }
+
+          COMPONENTS_DIST_TGZ="isomer-components-dist.tar.zst"
+          COMPONENTS_DIST_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$COMPONENTS_DIST_TGZ"
+          echo "Fetching cached isomer-components dist..."
+          aws s3 cp --only-show-errors $COMPONENTS_DIST_CACHE_PATH $COMPONENTS_DIST_TGZ || true
+          echo "Building @opengovsg/isomer-components..."
+          start_time=$(date +%s)
+          pnpm --filter @opengovsg/isomer-components run build
+          calculate_duration $start_time
+
+          echo "Caching isomer-components dist to S3..."
+          start_time=$(date +%s)
+          tar --use-compress-program="zstd -6" -cf $COMPONENTS_DIST_TGZ -C packages/components dist
+          aws s3 cp --only-show-errors $COMPONENTS_DIST_TGZ $COMPONENTS_DIST_CACHE_PATH
+          rm $COMPONENTS_DIST_TGZ
+          echo "Cached isomer-components dist"
+          calculate_duration $start_time

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -121,9 +121,14 @@ jobs:
           }
 
           REPO_TGZ="isomer.tar.zst"
-          # publisher.sh's production path only ever reads isomer/latest/. Manual/test
-          # dispatches with an explicit ref get their own prefix so they can never
-          # clobber the artifact a concurrent real deploy is about to consume.
+          # publisher.sh's production path only ever reads isomer/latest/, and nothing
+          # currently reads isomer/refs/*. This branch exists only so a manual/test
+          # workflow_dispatch of *this* workflow (passing an explicit ref) writes to its
+          # own prefix instead of clobbering isomer/latest/ while a real deploy's
+          # publisher.sh run might be downloading it. It is unrelated to publisher.sh's
+          # own ISOMER_BUILD_REPO_BRANCH git-clone path (line ~25 of publisher.sh), which
+          # is a separate escape hatch for testing site-publish against a feature branch
+          # and always clones fresh rather than consuming any archive this workflow produces.
           if [ -n "$REQUESTED_REF" ]; then
             REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$REQUESTED_REF/$REPO_TGZ"
           else

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -17,10 +17,6 @@ on:
         required: true
         default: "ap-southeast-1"
         type: string
-      aws-account-id:
-        description: "AWS account ID to use"
-        required: true
-        type: string
       cicd-role:
         description: "AWS IAM role to assume by GitHub action runner"
         required: true
@@ -39,10 +35,6 @@ on:
         description: "AWS region to use"
         required: false
         default: "ap-southeast-1"
-        type: string
-      aws-account-id:
-        description: "AWS account ID to use"
-        required: true
         type: string
       cicd-role:
         description: "AWS IAM role to assume by GitHub action runner"
@@ -72,14 +64,12 @@ jobs:
           REQUESTED_REF: ${{ inputs.isomer-build-repo-branch }}
         run: |
           # Assumption: all production builds use release tags. If a ref is passed in
-          # explicitly, treat it as a feature branch for cache-key purposes below.
+          # explicitly, use it as-is instead of resolving the latest tag.
           if [ -n "$REQUESTED_REF" ]; then
             echo "ref=$REQUESTED_REF" >> "$GITHUB_OUTPUT"
-            echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
           else
             LATEST_TAG=$(git ls-remote --tags --sort='v:refname' https://github.com/opengovsg/isomer.git | tail -n1 | awk '{print $2}' | sed -E 's|refs/tags/||; s/\^.*$//')
             echo "ref=$LATEST_TAG" >> "$GITHUB_OUTPUT"
-            echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout ${{ steps.resolve-ref.outputs.ref }}
@@ -103,23 +93,6 @@ jobs:
           # Do not set storeDir in pnpm-workspace.yaml: local dev keeps the default global store.
           pnpm config set store-dir .pnpm-store --location project
 
-      ### Create a cache key for the current build ###
-      - name: Resolve cache key
-        id: cache-key
-        env:
-          RESOLVED_REF: ${{ steps.resolve-ref.outputs.ref }}
-          IS_RELEASE_TAG: ${{ steps.resolve-ref.outputs.is_release_tag }}
-        run: |
-          if [ "$IS_RELEASE_TAG" = "true" ]; then
-            echo "key=$RESOLVED_REF" >> "$GITHUB_OUTPUT"
-          else
-            # Not a release tag, so it's a feature branch - use a combination of branch name
-            # and commit hash E.g. feat-buildsupercoolfeature-1a2b3c4d. This ensures that each
-            # unique feature branch and commit will have its own cache, reducing manual cache
-            # invalidation and human factor when testing on staging.
-            echo "key=$RESOLVED_REF-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile
 
@@ -127,11 +100,18 @@ jobs:
       # Rather than caching the pnpm store and a built dist separately, archive the whole
       # repository (source + node_modules) as a single tarball so downstream per-site
       # CodeBuild projects can pull it down instead of cloning/installing themselves.
-      # .git is excluded since only the working tree is needed.
+      #
+      # publisher.sh (the consumer) downloads this from isomer/latest/isomer.tar.zst, extracts it with
+      # `tar --use-compress-program=zstd -xf`, then `cd isomer/` - mirroring what
+      # `git clone .../isomer.git` would have produced. So the archive must be
+      # zstd-compressed and rooted at an `isomer/` directory, not the bare working tree.
+      # A symlink lets tar rename the root on the fly without copying the whole tree;
+      # `-h` dereferences it so the symlink itself isn't archived.
       - name: Archive and publish repository
         env:
           S3_CACHE_BUCKET_NAME: ${{ inputs.s3-cache-bucket-name }}
-          UNIQUE_CACHE_KEY: ${{ steps.cache-key.outputs.key }}
+          REQUESTED_REF: ${{ inputs.isomer-build-repo-branch }}
+          RESOLVED_REF: ${{ steps.resolve-ref.outputs.ref }}
         run: |
           calculate_duration() {
             local start_time=$1
@@ -140,17 +120,35 @@ jobs:
             echo "Time taken: $((end_time - start_time)) seconds"
           }
 
-          REPO_TGZ="isomer-repo.tar.zst"
-          REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/latest/$REPO_TGZ"
+          REPO_TGZ="isomer.tar.zst"
+          # publisher.sh's production path only ever reads isomer/latest/. Manual/test
+          # dispatches with an explicit ref get their own prefix so they can never
+          # clobber the artifact a concurrent real deploy is about to consume.
+          if [ -n "$REQUESTED_REF" ]; then
+            REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$REQUESTED_REF/$REPO_TGZ"
+          else
+            REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/latest/$REPO_TGZ"
+          fi
 
           echo "Archiving repository..."
           start_time=$(date +%s)
-          tar --exclude=.git --use-compress-program="zstd -6" -cf $REPO_TGZ .
+          # Record the resolved ref inside the archive so publisher.sh's production
+          # path - which has no branch input and no .git to inspect - can key its
+          # isomer-components dist cache by the actual release instead of a fixed
+          # string, which would otherwise never invalidate across releases.
+          echo "$RESOLVED_REF" > .isomer-release-ref
+          # Stage the rename-symlink in a fresh temp dir rather than the checkout's
+          # parent: actions/checkout's default workspace path is
+          # /home/runner/work/isomer/isomer, so "../isomer" there is the checkout
+          # directory itself and `ln -s` would fail with "File exists".
+          ARCHIVE_STAGING=$(mktemp -d)
+          ln -s "$(pwd)" "$ARCHIVE_STAGING/isomer"
+          tar --exclude=.git -h --use-compress-program="zstd -6" -cf "$ARCHIVE_STAGING/$REPO_TGZ" -C "$ARCHIVE_STAGING" isomer
           calculate_duration $start_time
 
           echo "Uploading repository archive to S3..."
           start_time=$(date +%s)
-          aws s3 cp --only-show-errors $REPO_TGZ $REPO_CACHE_PATH
-          rm $REPO_TGZ
+          aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$REPO_TGZ" $REPO_CACHE_PATH
+          rm -rf "$ARCHIVE_STAGING"
           echo "Uploaded repository archive"
           calculate_duration $start_time

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -127,6 +127,11 @@ jobs:
           # isomer-components dist cache by the actual release instead of a fixed
           # string, which would otherwise never invalidate across releases.
           echo "$RESOLVED_REF" > .isomer-release-ref
+          # Also record the commit SHA: the archive excludes .git below, but
+          # publisher.sh's branch cache-key still needs a commit to disambiguate
+          # builds of the same branch, and it can't run `git rev-parse` once .git
+          # is gone.
+          git rev-parse --short HEAD > .isomer-build-sha
           # Stage the rename-symlink in a fresh temp dir rather than the checkout's
           # parent: actions/checkout's default workspace path is
           # /home/runner/work/isomer/isomer, so "../isomer" there is the checkout

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -4,8 +4,11 @@ name: Build and publish site
 # entrypoint of a per-site AWS CodeBuild project. CodeBuild supplied SITE_NAME /
 # S3_BUCKET_NAME / CLOUDFRONT_DISTRIBUTION_ID / S3_CACHE_BUCKET_NAME etc. as
 # project-level env vars; those become workflow_dispatch inputs here. The
-# git-clone-from-scratch step becomes actions/checkout; the S3 pnpm-store/dist
-# tarball caching is otherwise kept as-is.
+# git-clone-from-scratch step becomes actions/checkout. Rather than building
+# isomer-components and caching the pnpm store/dist as separate tarballs, this
+# workflow installs dependencies and publishes a single tarball of the whole
+# repository (source + node_modules) to S3, which downstream per-site
+# CodeBuild projects pull down instead of cloning/installing themselves.
 on:
   workflow_dispatch:
     inputs:
@@ -117,10 +120,15 @@ jobs:
             echo "key=$RESOLVED_REF-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
-      # Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
-      # pnpm keeps package bytes in a content-addressable store; `store-dir` is set above for this run only.
-      # We archive only `.pnpm-store`; `pnpm install` recreates node_modules from the store + lockfile.
       - name: Install pnpm dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Shared S3 cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
+      # Rather than caching the pnpm store and a built dist separately, archive the whole
+      # repository (source + node_modules) as a single tarball so downstream per-site
+      # CodeBuild projects can pull it down instead of cloning/installing themselves.
+      # .git is excluded since only the working tree is needed.
+      - name: Archive and publish repository
         env:
           S3_CACHE_BUCKET_NAME: ${{ inputs.s3-cache-bucket-name }}
           UNIQUE_CACHE_KEY: ${{ steps.cache-key.outputs.key }}
@@ -132,46 +140,17 @@ jobs:
             echo "Time taken: $((end_time - start_time)) seconds"
           }
 
-          TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
-          TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
-          echo "Installing workspace dependencies..."
+          REPO_TGZ="isomer-repo.tar.zst"
+          REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/latest/$REPO_TGZ"
+
+          echo "Archiving repository..."
           start_time=$(date +%s)
-          pnpm install --frozen-lockfile
+          tar --exclude=.git --use-compress-program="zstd -6" -cf $REPO_TGZ .
           calculate_duration $start_time
 
-          echo "Caching pnpm store to S3..."
+          echo "Uploading repository archive to S3..."
           start_time=$(date +%s)
-          tar --use-compress-program="zstd -6" -cf $TEMPLATE_DEPS_TGZ .pnpm-store
-          aws s3 cp --only-show-errors $TEMPLATE_DEPS_TGZ $TEMPLATE_DEPS_CACHE_PATH
-          rm $TEMPLATE_DEPS_TGZ
-          echo "Cached pnpm store"
-          calculate_duration $start_time
-
-      # packages/components/dist is gitignored; Next resolves @opengovsg/isomer-components via workspace.
-      # Cache dist separately from .pnpm-store: restoring plain files does not affect the content-addressable store or node_modules linking.
-      - name: Build isomer-components dist
-        env:
-          S3_CACHE_BUCKET_NAME: ${{ inputs.s3-cache-bucket-name }}
-          UNIQUE_CACHE_KEY: ${{ steps.cache-key.outputs.key }}
-        run: |
-          calculate_duration() {
-            local start_time=$1
-            local end_time
-            end_time=$(date +%s)
-            echo "Time taken: $((end_time - start_time)) seconds"
-          }
-
-          COMPONENTS_DIST_TGZ="isomer-components-dist.tar.zst"
-          COMPONENTS_DIST_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$COMPONENTS_DIST_TGZ"
-          echo "Building @opengovsg/isomer-components..."
-          start_time=$(date +%s)
-          pnpm --filter @opengovsg/isomer-components run build
-          calculate_duration $start_time
-
-          echo "Caching isomer-components dist to S3..."
-          start_time=$(date +%s)
-          tar --use-compress-program="zstd -6" -cf $COMPONENTS_DIST_TGZ -C packages/components dist
-          aws s3 cp --only-show-errors $COMPONENTS_DIST_TGZ $COMPONENTS_DIST_CACHE_PATH
-          rm $COMPONENTS_DIST_TGZ
-          echo "Cached isomer-components dist"
+          aws s3 cp --only-show-errors $REPO_TGZ $REPO_CACHE_PATH
+          rm $REPO_TGZ
+          echo "Uploaded repository archive"
           calculate_duration $start_time

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -121,14 +121,14 @@ jobs:
           }
 
           REPO_TGZ="isomer.tar.zst"
-          # publisher.sh's production path only ever reads isomer/latest/, and nothing
-          # currently reads isomer/refs/*. This branch exists only so a manual/test
-          # workflow_dispatch of *this* workflow (passing an explicit ref) writes to its
-          # own prefix instead of clobbering isomer/latest/ while a real deploy's
-          # publisher.sh run might be downloading it. It is unrelated to publisher.sh's
-          # own ISOMER_BUILD_REPO_BRANCH git-clone path (line ~25 of publisher.sh), which
-          # is a separate escape hatch for testing site-publish against a feature branch
-          # and always clones fresh rather than consuming any archive this workflow produces.
+          # publisher.sh's production path only ever reads isomer/latest/. This branch
+          # exists so a manual/test workflow_dispatch of *this* workflow (passing an
+          # explicit ref) writes to its own prefix instead of clobbering isomer/latest/
+          # while a real deploy's publisher.sh run might be downloading it.
+          # publisher.sh's own ISOMER_BUILD_REPO_BRANCH git-clone path (~line 24) reads
+          # from this same isomer/refs/<branch>/ prefix first, reusing the archive this
+          # workflow produced for that branch instead of re-cloning from scratch, and
+          # only falls back to a fresh git clone if no such archive was published.
           if [ -n "$REQUESTED_REF" ]; then
             REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$REQUESTED_REF/$REPO_TGZ"
           else

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -25,10 +25,6 @@ on:
         description: "S3 bucket used to cache the pnpm store and isomer-components dist between builds (same bucket/prefix pattern as the CodeBuild projects)"
         required: true
         type: string
-      isomer-build-repo-branch:
-        description: "Git ref (tag or branch) of opengovsg/isomer to build. Leave empty to use the latest release tag."
-        required: false
-        type: string
 
 permissions:
   id-token: write
@@ -42,18 +38,25 @@ jobs:
       - name: Resolve build ref
         id: resolve-ref
         env:
-          REQUESTED_REF: ${{ inputs.isomer-build-repo-branch }}
+          # workflow_call inherits the triggering event's context, so this is populated
+          # whenever a caller (e.g. deploy_production.yml, deploy_uat.yml) itself runs off
+          # a `release` event - the exact tag that triggered it, not just "whatever
+          # currently sorts highest on the remote" (which can diverge on backfilled
+          # releases or newer prerelease tags).
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          # Always populated regardless of trigger type - the commit that triggered this
+          # run (e.g. the pushed commit for deploy_staging.yml, which has no release tag).
+          SHA: ${{ github.sha }}
         run: |
-          # Assumption: all production builds use release tags. If a ref is passed in
-          # explicitly, use it as-is instead of resolving the latest tag.
-          if [ -n "$REQUESTED_REF" ]; then
-            echo "ref=$REQUESTED_REF" >> "$GITHUB_OUTPUT"
+          # Priority: the tag that triggered this run (if any), else the triggering commit.
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "ref=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           else
-            LATEST_TAG=$(git ls-remote --tags --sort='v:refname' https://github.com/opengovsg/isomer.git | tail -n1 | awk '{print $2}' | sed -E 's|refs/tags/||; s/\^.*$//')
-            echo "ref=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+            echo "ref=$SHA" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout ${{ steps.resolve-ref.outputs.ref }}
+        id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.resolve-ref.outputs.ref }}
@@ -94,8 +97,11 @@ jobs:
       - name: Archive and publish repository
         env:
           S3_CACHE_BUCKET_NAME: ${{ inputs.s3-cache-bucket-name }}
-          REQUESTED_REF: ${{ inputs.isomer-build-repo-branch }}
           RESOLVED_REF: ${{ steps.resolve-ref.outputs.ref }}
+          # Use the commit actions/checkout actually resolved and checked out for
+          # RESOLVED_REF, rather than re-deriving it with `git rev-parse HEAD` - GitHub's
+          # own record of what was checked out, not our own read of the working tree.
+          GIT_SHA: ${{ steps.checkout.outputs.commit }}
         run: |
           calculate_duration() {
             local start_time=$1
@@ -106,21 +112,11 @@ jobs:
 
           REPO_TGZ="isomer.tar.zst"
           STORE_TGZ="isomer-pnpm-store.tar.zst"
-          # publisher.sh's production path only ever reads isomer/latest/. This branch
-          # exists so a manual/test workflow_dispatch of *this* workflow (passing an
-          # explicit ref) writes to its own prefix instead of clobbering isomer/latest/
-          # while a real deploy's publisher.sh run might be downloading it.
-          # publisher.sh's own ISOMER_BUILD_REPO_BRANCH git-clone path (~line 24) reads
-          # from this same isomer/refs/<branch>/ prefix first, reusing the archive this
-          # workflow produced for that branch instead of re-cloning from scratch, and
-          # only falls back to a fresh git clone if no such archive was published.
-          if [ -n "$REQUESTED_REF" ]; then
-            CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$REQUESTED_REF"
-          else
-            CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/latest"
-          fi
-          REPO_CACHE_PATH="$CACHE_PREFIX/$REPO_TGZ"
-          STORE_CACHE_PATH="$CACHE_PREFIX/$STORE_TGZ"
+          # publisher.sh's production path always reads isomer/latest/.
+          REPO_CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/latest"
+          STORE_CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/$GIT_SHA"
+          REPO_CACHE_PATH="$REPO_CACHE_PREFIX/$REPO_TGZ"
+          STORE_CACHE_PATH="$STORE_CACHE_PREFIX/$STORE_TGZ"
 
           # Record the resolved ref inside the archive so publisher.sh's production
           # path - which has no branch input and no .git to inspect - can key its
@@ -128,16 +124,32 @@ jobs:
           # string, which would otherwise never invalidate across releases.
           echo "$RESOLVED_REF" > .isomer-release-ref
           # Also record the commit SHA: the archive excludes .git below, but
-          # publisher.sh's branch cache-key still needs a commit to disambiguate
-          # builds of the same branch, and it can't run `git rev-parse` once .git
-          # is gone.
-          git rev-parse --short HEAD > .isomer-build-sha
+          # publisher.sh needs it both to disambiguate branch cache-keys and to
+          # locate the SHA-scoped pnpm store archive above, and it can't run
+          # `git rev-parse` once .git is gone. Reuse $GIT_SHA so the recorded
+          # value matches the one used for STORE_CACHE_PREFIX.
+          echo "$GIT_SHA" > .isomer-build-sha
           # Stage the rename-symlink in a fresh temp dir rather than the checkout's
           # parent: actions/checkout's default workspace path is
           # /home/runner/work/isomer/isomer, so "../isomer" there is the checkout
           # directory itself and `ln -s` would fail with "File exists".
           ARCHIVE_STAGING=$(mktemp -d)
           ln -s "$(pwd)" "$ARCHIVE_STAGING/isomer"
+
+          # Upload the SHA-scoped store before the repository archive/pointer: publisher.sh's
+          # production path reads the SHA from the repository archive and immediately tries to
+          # download the store at that SHA, so publishing the repository first would let it
+          # observe a new SHA whose store isn't there yet.
+          echo "Archiving pnpm store..."
+          start_time=$(date +%s)
+          tar --use-compress-program="zstd -6" -cf "$ARCHIVE_STAGING/$STORE_TGZ" .pnpm-store
+          calculate_duration $start_time
+
+          echo "Uploading pnpm store archive to S3..."
+          start_time=$(date +%s)
+          aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$STORE_TGZ" $STORE_CACHE_PATH
+          echo "Uploaded pnpm store archive"
+          calculate_duration $start_time
 
           echo "Archiving repository..."
           start_time=$(date +%s)
@@ -147,17 +159,6 @@ jobs:
           echo "Uploading repository archive to S3..."
           start_time=$(date +%s)
           aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$REPO_TGZ" $REPO_CACHE_PATH
-          echo "Uploaded repository archive"
-          calculate_duration $start_time
-
-          echo "Archiving pnpm store..."
-          start_time=$(date +%s)
-          tar --use-compress-program="zstd -6" -cf "$ARCHIVE_STAGING/$STORE_TGZ" .pnpm-store
-          calculate_duration $start_time
-
-          echo "Uploading pnpm store archive to S3..."
-          start_time=$(date +%s)
-          aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$STORE_TGZ" $STORE_CACHE_PATH
           rm -rf "$ARCHIVE_STAGING"
-          echo "Uploaded pnpm store archive"
+          echo "Uploaded repository archive"
           calculate_duration $start_time

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -134,8 +134,6 @@ jobs:
 
           TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
           TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
-          echo "Fetching cached pnpm store..."
-          aws s3 cp --only-show-errors $TEMPLATE_DEPS_CACHE_PATH $TEMPLATE_DEPS_TGZ || true
           echo "Installing workspace dependencies..."
           start_time=$(date +%s)
           pnpm install --frozen-lockfile
@@ -165,8 +163,6 @@ jobs:
 
           COMPONENTS_DIST_TGZ="isomer-components-dist.tar.zst"
           COMPONENTS_DIST_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$COMPONENTS_DIST_TGZ"
-          echo "Fetching cached isomer-components dist..."
-          aws s3 cp --only-show-errors $COMPONENTS_DIST_CACHE_PATH $COMPONENTS_DIST_TGZ || true
           echo "Building @opengovsg/isomer-components..."
           start_time=$(date +%s)
           pnpm --filter @opengovsg/isomer-components run build

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -80,6 +80,12 @@ jobs:
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile --filter isomer-base-template...
 
+      # publisher.sh's per-site builds each need this dist (packages/components/dist is
+      # gitignored, so it isn't in the repository archive below); building it once here
+      # instead of once per site is the whole point of centralizing this in CI.
+      - name: Build isomer-components
+        run: pnpm --filter @opengovsg/isomer-components run build
+
       # Shared S3 cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
       # Archived as two separate tarballs so downstream per-site CodeBuild projects can pull
       # them down instead of cloning/installing themselves:
@@ -97,10 +103,9 @@ jobs:
       - name: Archive and publish repository
         env:
           S3_CACHE_BUCKET_NAME: ${{ inputs.s3-cache-bucket-name }}
-          RESOLVED_REF: ${{ steps.resolve-ref.outputs.ref }}
-          # Use the commit actions/checkout actually resolved and checked out for
-          # RESOLVED_REF, rather than re-deriving it with `git rev-parse HEAD` - GitHub's
-          # own record of what was checked out, not our own read of the working tree.
+          # Use the commit actions/checkout actually resolved and checked out, rather
+          # than re-deriving it with `git rev-parse HEAD` - GitHub's own record of what
+          # was checked out, not our own read of the working tree.
           GIT_SHA: ${{ steps.checkout.outputs.commit }}
         run: |
           calculate_duration() {
@@ -112,18 +117,18 @@ jobs:
 
           REPO_TGZ="isomer.tar.zst"
           STORE_TGZ="isomer-pnpm-store.tar.zst"
+          COMPONENTS_DIST_TGZ="isomer-components-dist.tar.zst"
           # publisher.sh's production path always reads isomer/latest/.
           REPO_CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/latest"
           STORE_CACHE_PREFIX="s3://$S3_CACHE_BUCKET_NAME/isomer/$GIT_SHA"
           REPO_CACHE_PATH="$REPO_CACHE_PREFIX/$REPO_TGZ"
           STORE_CACHE_PATH="$STORE_CACHE_PREFIX/$STORE_TGZ"
+          # Keyed by commit SHA, same prefix as the pnpm store: shared across every ref
+          # that happens to point at this commit, and what publisher.sh's branch path
+          # tries first before falling back to its own branch-scoped cache.
+          COMPONENTS_DIST_CACHE_PATH="$STORE_CACHE_PREFIX/$COMPONENTS_DIST_TGZ"
 
-          # Record the resolved ref inside the archive so publisher.sh's production
-          # path - which has no branch input and no .git to inspect - can key its
-          # isomer-components dist cache by the actual release instead of a fixed
-          # string, which would otherwise never invalidate across releases.
-          echo "$RESOLVED_REF" > .isomer-release-ref
-          # Also record the commit SHA: the archive excludes .git below, but
+          # Record the commit SHA: the archive excludes .git below, but
           # publisher.sh needs it both to disambiguate branch cache-keys and to
           # locate the SHA-scoped pnpm store archive above, and it can't run
           # `git rev-parse` once .git is gone. Reuse $GIT_SHA so the recorded
@@ -149,6 +154,17 @@ jobs:
           start_time=$(date +%s)
           aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$STORE_TGZ" $STORE_CACHE_PATH
           echo "Uploaded pnpm store archive"
+          calculate_duration $start_time
+
+          echo "Archiving isomer-components dist..."
+          start_time=$(date +%s)
+          tar --use-compress-program="zstd -6" -cf "$ARCHIVE_STAGING/$COMPONENTS_DIST_TGZ" -C packages/components dist
+          calculate_duration $start_time
+
+          echo "Uploading isomer-components dist archive to S3..."
+          start_time=$(date +%s)
+          aws s3 cp --only-show-errors "$ARCHIVE_STAGING/$COMPONENTS_DIST_TGZ" $COMPONENTS_DIST_CACHE_PATH
+          echo "Uploaded isomer-components dist archive"
           calculate_duration $start_time
 
           echo "Archiving repository..."

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -78,7 +78,7 @@ jobs:
           pnpm config set store-dir .pnpm-store --location project
 
       - name: Install pnpm dependencies
-        run: pnpm install --frozen-lockfile --filter isomer-base-template...
+        run: pnpm install --frozen-lockfile
 
       # publisher.sh's per-site builds each need this dist (packages/components/dist is
       # gitignored, so it isn't in the repository archive below); building it once here

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -48,3 +48,12 @@ jobs:
       posthog-host: "https://rpfs.isomer.gov.sg"
       posthog-assets-host: "https://us-assets.i.posthog.com"
       posthog-project-token: "phc_uZuYdUk5MvkoNAzxvh9TXdGXXjSL684XAHBjR5r74Ra8"
+
+  build_components:
+    name: Build and publish components 
+    uses: ./.github/workflows/build-components.yml
+    with:
+      aws-region: "ap-southeast-1"
+      aws-account-id: "730335583385"
+      cicd-role: "arn:aws:iam::730335583385:role/isomer-next-infra-prod-deploy-role"
+      s3-cache-bucket-name: "isomer-next-infra-prod-sites-cache-bucket-private-693316f"

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -54,6 +54,5 @@ jobs:
     uses: ./.github/workflows/build-components.yml
     with:
       aws-region: "ap-southeast-1"
-      aws-account-id: "730335583385"
       cicd-role: "arn:aws:iam::730335583385:role/isomer-next-infra-prod-deploy-role"
       s3-cache-bucket-name: "isomer-next-infra-prod-sites-cache-bucket-private-693316f"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -59,6 +59,5 @@ jobs:
     uses: ./.github/workflows/build-components.yml
     with:
       aws-region: "ap-southeast-1"
-      aws-account-id: "058264420411"
       cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-stg-deploy-role"
       s3-cache-bucket-name: "isomer-next-infra-stg-sites-cache-bucket-private-c7e5cf4"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -53,3 +53,12 @@ jobs:
       posthog-host: "https://rpfs.isomer.gov.sg"
       posthog-assets-host: "https://us-assets.i.posthog.com"
       posthog-project-token: "phc_uZuYdUk5MvkoNAzxvh9TXdGXXjSL684XAHBjR5r74Ra8"
+
+  build_components:
+    name: Build and publish components 
+    uses: ./.github/workflows/build-components.yml
+    with:
+      aws-region: "ap-southeast-1"
+      aws-account-id: "058264420411"
+      cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-stg-deploy-role"
+      s3-cache-bucket-name: "isomer-next-infra-stg-sites-cache-bucket-private-c7e5cf4"

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -46,3 +46,12 @@ jobs:
       app-s3-assets-domain-name: "isomer-user-content-uat.by.gov.sg"
       app-growthbook-client-key: "sdk-JCHWTUKA5qK7GAZA"
       app-intercom-app-id: "jv2tjc3g"
+
+  build_components:
+    name: Build and publish components 
+    uses: ./.github/workflows/build-components.yml
+    with:
+      aws-region: "ap-southeast-1"
+      aws-account-id: "343218177745"
+      cicd-role: "arn:aws:iam::343218177745:role/isomer-next-infra-uat-deploy-role"
+      s3-cache-bucket-name: "isomer-next-infra-uat-sites-cache-bucket-private-28d7dd9"

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -52,6 +52,5 @@ jobs:
     uses: ./.github/workflows/build-components.yml
     with:
       aws-region: "ap-southeast-1"
-      aws-account-id: "343218177745"
       cicd-role: "arn:aws:iam::343218177745:role/isomer-next-infra-uat-deploy-role"
       s3-cache-bucket-name: "isomer-next-infra-uat-sites-cache-bucket-private-28d7dd9"

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -123,7 +123,7 @@ if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
 
   echo "Installing workspace dependencies..."
   start_time=$(date +%s)
-  pnpm install --frozen-lockfile
+  pnpm install --frozen-lockfile --filter isomer-base-template...
   calculate_duration "$start_time"
 
   if [ "$RESTORED_STORE" -eq 0 ]; then
@@ -153,7 +153,7 @@ else
   # nothing needs to be built in a per-site job.
   echo "Re-linking workspace from cached store..."
   start_time=$(date +%s)
-  pnpm install --frozen-lockfile
+  pnpm install --frozen-lockfile --filter isomer-base-template...
   calculate_duration "$start_time"
 
   fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/$GIT_SHA/$COMPONENTS_DIST_TGZ" "$COMPONENTS_DIST_TGZ" packages/components ||
@@ -165,7 +165,7 @@ echo "Fetching from database..."
 start_time=$(date +%s)
 cd tooling/build/scripts/publishing
 pwd
-pnpm install --frozen-lockfile
+pnpm install --frozen-lockfile --filter publishing...
 pnpm run start
 calculate_duration "$start_time"
 

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -11,25 +11,19 @@ calculate_duration() {
   echo "Time taken: $duration seconds"
 }
 
-# Use the latest release tag unless one was provided in the env var
-if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
-  ##### This long command is used to get the latest release tag from the Isomer repository.
-  # git ls-remote: Lists references in a remote repository along with their commit hashes.
-  # --tags: Lists all tags in the repository.
-  # --sort='v:refname': Sorts the tags by version number according to the semantic versioning scheme
-  # tail -n1: Gets the last line of the output.
-  # awk '{print $2}': Prints the second column of the last line, which is the tag name.
-  # sed -E 's|refs/tags/||; s/\^.*$//': Removes the 'refs/tags/' prefix from the tag name.
-  # - If tag is annotated (maybe due to signing), the tag name will have a caret (^) and optional text after it.
-  ISOMER_BUILD_REPO_BRANCH=$(git ls-remote --tags --sort='v:refname' https://github.com/opengovsg/isomer.git | tail -n1 | awk '{print $2}' | sed -E 's|refs/tags/||; s/\^.*$//')
-  IS_USING_RELEASE_TAG=true
-fi
-
 # Cloning the repository
 echo "Cloning central repository..."
 start_time=$(date +%s)
 
-git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
+# NOTE: if no build repo branch was provided,
+# we will assume this is production and just clone from the bucket
+if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
+  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/latest/isomer.tar.gz .
+  tar -xzf isomer.tar.gz
+else
+  git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
+fi
+
 cd isomer/
 calculate_duration $start_time
 
@@ -50,7 +44,7 @@ pnpm config set store-dir .pnpm-store --location project
 
 ### Create a cache key for the current build ###
 # Assumption: All production related builds are using release tags e.g. v0.2.1
-if [[ -z "$IS_USING_RELEASE_TAG" ]]; then
+if [[ -z "$ISOMER_BUILD_REPO_BRANCH" ]]; then
   # If it's not a release tag, then it's a feature branch so we need to use a unique cache key
   # We use a combination of branch name and commit hash E.g. feat-buildsupercoolfeature-1a2b3c4d
   # This ensures that each unique feature branch and commit will have its own cache,

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -11,6 +11,42 @@ calculate_duration() {
   echo "Time taken: $duration seconds"
 }
 
+# Downloads $2 from S3 path $1 and extracts it into $3 (default: cwd), removing the
+# local tarball afterwards. Returns 1 - without tripping `set -e` - if the object
+# isn't in S3; callers decide whether that's a fallback or a fatal error.
+fetch_cached() {
+  local cache_path=$1 tarball=$2 extract_dir=${3:-.} start_time
+  echo "Fetching $tarball from cache..."
+  aws s3 cp --only-show-errors "$cache_path" "$tarball" || true
+  if [ ! -f "$tarball" ]; then
+    echo "$tarball not found in cache ($cache_path)"
+    return 1
+  fi
+  echo "$tarball found in cache ($cache_path)"
+  start_time=$(date +%s)
+  mkdir -p "$extract_dir"
+  tar --use-compress-program=zstd -xf "$tarball" -C "$extract_dir"
+  rm "$tarball"
+  calculate_duration "$start_time"
+}
+
+# Archives $3+ (passed straight through to `tar -c`) into $2 and uploads it to S3 path $1.
+cache_upload() {
+  local cache_path=$1 tarball=$2 start_time
+  shift 2
+  echo "Caching $tarball to S3..."
+  start_time=$(date +%s)
+  tar --use-compress-program="zstd -6" -cf "$tarball" "$@"
+  aws s3 cp --only-show-errors "$tarball" "$cache_path"
+  rm "$tarball"
+  calculate_duration "$start_time"
+}
+
+REPO_TGZ="isomer.tar.zst"
+STORE_TGZ="isomer-pnpm-store.tar.zst"
+TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
+COMPONENTS_DIST_TGZ="isomer-components-dist.tar.zst"
+
 # Cloning the repository
 echo "Cloning central repository..."
 start_time=$(date +%s)
@@ -18,8 +54,8 @@ start_time=$(date +%s)
 # NOTE: if no build repo branch was provided,
 # we will assume this is production and just clone from the bucket
 if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
-  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/latest/isomer.tar.zst .
-  tar --use-compress-program=zstd -xf isomer.tar.zst
+  fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/latest/$REPO_TGZ" "$REPO_TGZ" ||
+    { echo "Error: $REPO_TGZ not found in production cache"; exit 1; }
   cd isomer/
 
   # isomer.tar.zst is source-only (see build-components.yml); the pnpm store is archived
@@ -27,23 +63,16 @@ if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
   # "latest" so it's shared across every ref that happens to point at the same
   # commit. It's relinked into node_modules below, once pnpm is configured.
   GIT_SHA=$(cat .isomer-build-sha)
-  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/"$GIT_SHA"/isomer-pnpm-store.tar.zst .
-  tar --use-compress-program=zstd -xf isomer-pnpm-store.tar.zst
-  rm isomer-pnpm-store.tar.zst
+  fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/$GIT_SHA/$STORE_TGZ" "$STORE_TGZ" ||
+    { echo "Error: $STORE_TGZ not found for commit $GIT_SHA"; exit 1; }
 else
   # A manual/test build-components.yml run for this branch may have already archived
   # and published the repository to this ref-scoped prefix; reuse it if present instead
   # of re-cloning and re-installing from scratch.
-  REPO_TGZ="isomer.tar.zst"
   REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$ISOMER_BUILD_REPO_BRANCH/$REPO_TGZ"
-  aws s3 cp --only-show-errors "$REPO_CACHE_PATH" $REPO_TGZ || true
-  if [ -f "$REPO_TGZ" ]; then
-    echo "$REPO_TGZ found in cache for branch $ISOMER_BUILD_REPO_BRANCH"
-    tar --use-compress-program=zstd -xf $REPO_TGZ
-    rm $REPO_TGZ
+  if fetch_cached "$REPO_CACHE_PATH" "$REPO_TGZ"; then
     cd isomer/
   else
-    echo "$REPO_TGZ not found in cache for branch $ISOMER_BUILD_REPO_BRANCH"
     git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
     cd isomer/
     # Checkout specific branch
@@ -80,58 +109,25 @@ if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
   UNIQUE_CACHE_KEY="$ISOMER_BUILD_REPO_BRANCH-$COMMIT_SHA"
   echo "Unique cache key: $UNIQUE_CACHE_KEY"
 
-  # build-components.yml publishes a pnpm store archive keyed by commit SHA on every run
-  # (production or ref-scoped), independent of which branch/ref triggered it. If it already
-  # ran for this exact commit, reuse that instead of installing from the registry.
-  STORE_TGZ="isomer-pnpm-store.tar.zst"
-  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/"$COMMIT_SHA"/"$STORE_TGZ" . || true
-  if [ -f "$STORE_TGZ" ]; then
-    echo "$STORE_TGZ found in cache for commit $COMMIT_SHA"
-    start_time=$(date +%s)
-    tar --use-compress-program=zstd -xf "$STORE_TGZ"
-    rm "$STORE_TGZ"
-    calculate_duration "$start_time"
+  # Try the commit-scoped store build-components.yml may have already published for this
+  # exact commit (shared across every ref pointing at it, produced on every run whether
+  # production or ref-scoped), then fall back to this branch's own cache from a previous
+  # run. `pnpm install` below recreates node_modules from whichever store was restored -
+  # cheap when one was, a real registry install when neither was found.
+  TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
+  RESTORED_STORE=0
+  fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/$COMMIT_SHA/$STORE_TGZ" "$STORE_TGZ" && RESTORED_STORE=1
+  if [ "$RESTORED_STORE" -eq 0 ]; then
+    fetch_cached "$TEMPLATE_DEPS_CACHE_PATH" "$TEMPLATE_DEPS_TGZ" && RESTORED_STORE=1
+  fi
 
-    echo "Re-linking workspace from cached store..."
-    start_time=$(date +%s)
-    pnpm install --frozen-lockfile
-    calculate_duration "$start_time"
-  else
-    echo "$STORE_TGZ not found in cache for commit $COMMIT_SHA"
+  echo "Installing workspace dependencies..."
+  start_time=$(date +%s)
+  pnpm install --frozen-lockfile
+  calculate_duration "$start_time"
 
-    # Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
-    # pnpm keeps package bytes in a content-addressable store; `store-dir` is set above for this run only.
-    # We archive only `.pnpm-store`; `pnpm install` recreates node_modules from the store + lockfile.
-    TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
-    TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
-    echo "Fetching cached pnpm store..."
-    aws s3 cp --only-show-errors "$TEMPLATE_DEPS_CACHE_PATH" $TEMPLATE_DEPS_TGZ || true
-    if [ -f "$TEMPLATE_DEPS_TGZ" ]; then
-      echo "$TEMPLATE_DEPS_TGZ found in cache"
-      start_time=$(date +%s)
-      tar --use-compress-program=zstd -xf $TEMPLATE_DEPS_TGZ
-      rm $TEMPLATE_DEPS_TGZ
-      calculate_duration "$start_time"
-
-      echo "Re-linking workspace from cached store..."
-      start_time=$(date +%s)
-      pnpm install --frozen-lockfile
-      calculate_duration "$start_time"
-    else
-      echo "$TEMPLATE_DEPS_TGZ not found in cache"
-      echo "Installing workspace dependencies..."
-      start_time=$(date +%s)
-      pnpm install --frozen-lockfile
-      calculate_duration "$start_time"
-
-      echo "Caching pnpm store to S3..."
-      start_time=$(date +%s)
-      tar --use-compress-program="zstd -6" -cf $TEMPLATE_DEPS_TGZ .pnpm-store
-      aws s3 cp --only-show-errors $TEMPLATE_DEPS_TGZ "$TEMPLATE_DEPS_CACHE_PATH"
-      rm $TEMPLATE_DEPS_TGZ
-      echo "Cached pnpm store"
-      calculate_duration "$start_time"
-    fi
+  if [ "$RESTORED_STORE" -eq 0 ]; then
+    cache_upload "$TEMPLATE_DEPS_CACHE_PATH" "$TEMPLATE_DEPS_TGZ" .pnpm-store
   fi
 else
   # Production path: build-components.yml already populated the pnpm store and
@@ -152,31 +148,14 @@ fi
 
 # packages/components/dist is gitignored; Next resolves @opengovsg/isomer-components via workspace.
 # Cache dist separately from .pnpm-store: restoring plain files does not affect the content-addressable store or node_modules linking.
-COMPONENTS_DIST_TGZ="isomer-components-dist.tar.zst"
 COMPONENTS_DIST_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$COMPONENTS_DIST_TGZ"
-echo "Fetching cached isomer-components dist..."
-aws s3 cp --only-show-errors "$COMPONENTS_DIST_CACHE_PATH" $COMPONENTS_DIST_TGZ || true
-if [ -f "$COMPONENTS_DIST_TGZ" ]; then
-  echo "$COMPONENTS_DIST_TGZ found in cache"
-  start_time=$(date +%s)
-  mkdir -p packages/components
-  tar --use-compress-program=zstd -xf $COMPONENTS_DIST_TGZ -C packages/components
-  rm $COMPONENTS_DIST_TGZ
-  calculate_duration "$start_time"
-else
-  echo "$COMPONENTS_DIST_TGZ not found in cache"
+if ! fetch_cached "$COMPONENTS_DIST_CACHE_PATH" "$COMPONENTS_DIST_TGZ" packages/components; then
   echo "Building @opengovsg/isomer-components..."
   start_time=$(date +%s)
   pnpm --filter @opengovsg/isomer-components run build
   calculate_duration "$start_time"
 
-  echo "Caching isomer-components dist to S3..."
-  start_time=$(date +%s)
-  tar --use-compress-program="zstd -6" -cf $COMPONENTS_DIST_TGZ -C packages/components dist
-  aws s3 cp --only-show-errors $COMPONENTS_DIST_TGZ "$COMPONENTS_DIST_CACHE_PATH"
-  rm $COMPONENTS_DIST_TGZ
-  echo "Cached isomer-components dist"
-  calculate_duration "$start_time"
+  cache_upload "$COMPONENTS_DIST_CACHE_PATH" "$COMPONENTS_DIST_TGZ" -C packages/components dist
 fi
 
 # Fetch from database

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -66,7 +66,15 @@ if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
   # E.g. feat-buildsupercoolfeature-1a2b3c4d. This ensures that each unique
   # feature branch and commit will have its own cache, reducing manual cache
   # invalidation and human factor when testing on staging.
-  UNIQUE_CACHE_KEY="$ISOMER_BUILD_REPO_BRANCH-$(git rev-parse --short HEAD)"
+  # A ref-scoped cache hit above extracts an archive with no .git (build-components.yml
+  # excludes it), so `git rev-parse` would fail there; use the commit it recorded
+  # instead. The git-clone fallback has no such file but does have .git.
+  if [ -f ".isomer-build-sha" ]; then
+    COMMIT_SHA=$(cat .isomer-build-sha)
+  else
+    COMMIT_SHA=$(git rev-parse --short HEAD)
+  fi
+  UNIQUE_CACHE_KEY="$ISOMER_BUILD_REPO_BRANCH-$COMMIT_SHA"
   echo "Unique cache key: $UNIQUE_CACHE_KEY"
 
   # Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -129,33 +129,35 @@ if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
   if [ "$RESTORED_STORE" -eq 0 ]; then
     cache_upload "$TEMPLATE_DEPS_CACHE_PATH" "$TEMPLATE_DEPS_TGZ" .pnpm-store
   fi
+
+  # packages/components/dist is gitignored, so it's cached as its own tarball. Same
+  # two-tier lookup as the store above: a build-components.yml run for this exact
+  # commit first, then this branch's own cache from a previous publisher.sh run.
+  COMPONENTS_DIST_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$COMPONENTS_DIST_TGZ"
+  if fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/$COMMIT_SHA/$COMPONENTS_DIST_TGZ" "$COMPONENTS_DIST_TGZ" packages/components; then
+    :
+  elif fetch_cached "$COMPONENTS_DIST_CACHE_PATH" "$COMPONENTS_DIST_TGZ" packages/components; then
+    :
+  else
+    echo "Building @opengovsg/isomer-components..."
+    start_time=$(date +%s)
+    pnpm --filter @opengovsg/isomer-components run build
+    calculate_duration "$start_time"
+
+    cache_upload "$COMPONENTS_DIST_CACHE_PATH" "$COMPONENTS_DIST_TGZ" -C packages/components dist
+  fi
 else
-  # Production path: build-components.yml already populated the pnpm store and
-  # archived it alongside the repository (fetched above); relink node_modules
-  # from it here - cheap since every package is already in the store, no
-  # registry hits needed. Key the (still necessary) isomer-components dist
-  # cache by the actual release ref that build-components.yml resolved and
-  # recorded in the archive, not a fixed "latest" string - otherwise every
-  # release after the first would silently reuse an older release's stale
-  # dist build.
+  # Production path: build-components.yml already populated the pnpm store, archived it
+  # alongside the repository (fetched above), and built + published the isomer-components
+  # dist to the same commit-scoped prefix - relink node_modules and fetch the dist here;
+  # nothing needs to be built in a per-site job.
   echo "Re-linking workspace from cached store..."
   start_time=$(date +%s)
   pnpm install --frozen-lockfile
   calculate_duration "$start_time"
 
-  UNIQUE_CACHE_KEY=$(cat .isomer-release-ref)
-fi
-
-# packages/components/dist is gitignored; Next resolves @opengovsg/isomer-components via workspace.
-# Cache dist separately from .pnpm-store: restoring plain files does not affect the content-addressable store or node_modules linking.
-COMPONENTS_DIST_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$COMPONENTS_DIST_TGZ"
-if ! fetch_cached "$COMPONENTS_DIST_CACHE_PATH" "$COMPONENTS_DIST_TGZ" packages/components; then
-  echo "Building @opengovsg/isomer-components..."
-  start_time=$(date +%s)
-  pnpm --filter @opengovsg/isomer-components run build
-  calculate_duration "$start_time"
-
-  cache_upload "$COMPONENTS_DIST_CACHE_PATH" "$COMPONENTS_DIST_TGZ" -C packages/components dist
+  fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/$GIT_SHA/$COMPONENTS_DIST_TGZ" "$COMPONENTS_DIST_TGZ" packages/components ||
+    { echo "Error: $COMPONENTS_DIST_TGZ not found for commit $GIT_SHA"; exit 1; }
 fi
 
 # Fetch from database

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -22,11 +22,25 @@ if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
   tar --use-compress-program=zstd -xf isomer.tar.zst
   cd isomer/
 else
-  git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
-  cd isomer/
-  # Checkout specific branch
-  echo "Checking out branch..."
-  git checkout "$ISOMER_BUILD_REPO_BRANCH"
+  # A manual/test build-components.yml run for this branch may have already archived
+  # and published the repository to this ref-scoped prefix; reuse it if present instead
+  # of re-cloning and re-installing from scratch.
+  REPO_TGZ="isomer.tar.zst"
+  REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$ISOMER_BUILD_REPO_BRANCH/$REPO_TGZ"
+  aws s3 cp --only-show-errors "$REPO_CACHE_PATH" $REPO_TGZ || true
+  if [ -f "$REPO_TGZ" ]; then
+    echo "$REPO_TGZ found in cache for branch $ISOMER_BUILD_REPO_BRANCH"
+    tar --use-compress-program=zstd -xf $REPO_TGZ
+    rm $REPO_TGZ
+    cd isomer/
+  else
+    echo "$REPO_TGZ not found in cache for branch $ISOMER_BUILD_REPO_BRANCH"
+    git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
+    cd isomer/
+    # Checkout specific branch
+    echo "Checking out branch..."
+    git checkout "$ISOMER_BUILD_REPO_BRANCH"
+  fi
 fi
 
 calculate_duration "$start_time"

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -21,6 +21,12 @@ if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
   aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/latest/isomer.tar.zst .
   tar --use-compress-program=zstd -xf isomer.tar.zst
   cd isomer/
+
+  # isomer.tar.zst is source-only (see build-components.yml); the pnpm store is archived
+  # separately and relinked into node_modules below, once pnpm is configured.
+  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/latest/isomer-pnpm-store.tar.zst .
+  tar --use-compress-program=zstd -xf isomer-pnpm-store.tar.zst
+  rm isomer-pnpm-store.tar.zst
 else
   # A manual/test build-components.yml run for this branch may have already archived
   # and published the repository to this ref-scoped prefix; reuse it if present instead
@@ -97,13 +103,19 @@ if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
     calculate_duration "$start_time"
   fi
 else
-  # Production path: dependencies were already installed and archived by
-  # build-components.yml, then extracted above as part of isomer.tar.zst -
-  # no need to reinstall or fetch a separate deps cache. Key the (still
-  # necessary) isomer-components dist cache by the actual release ref that
-  # build-components.yml resolved and recorded in the archive, not a fixed
-  # "latest" string - otherwise every release after the first would silently
-  # reuse an older release's stale dist build.
+  # Production path: build-components.yml already populated the pnpm store and
+  # archived it alongside the repository (fetched above); relink node_modules
+  # from it here - cheap since every package is already in the store, no
+  # registry hits needed. Key the (still necessary) isomer-components dist
+  # cache by the actual release ref that build-components.yml resolved and
+  # recorded in the archive, not a fixed "latest" string - otherwise every
+  # release after the first would silently reuse an older release's stale
+  # dist build.
+  echo "Re-linking workspace from cached store..."
+  start_time=$(date +%s)
+  pnpm install --frozen-lockfile
+  calculate_duration "$start_time"
+
   UNIQUE_CACHE_KEY=$(cat .isomer-release-ref)
 fi
 

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -18,22 +18,20 @@ start_time=$(date +%s)
 # NOTE: if no build repo branch was provided,
 # we will assume this is production and just clone from the bucket
 if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
-  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/latest/isomer.tar.gz .
-  tar -xzf isomer.tar.gz
+  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/latest/isomer.tar.zst .
+  tar --use-compress-program=zstd -xf isomer.tar.zst
+  cd isomer/
 else
   git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
+  cd isomer/
+  # Checkout specific branch
+  echo "Checking out branch..."
+  git checkout "$ISOMER_BUILD_REPO_BRANCH"
 fi
 
-cd isomer/
-calculate_duration $start_time
+calculate_duration "$start_time"
 
-echo $(pwd)
-
-# Checkout specific branch
-echo "Checking out branch..."
-start_time=$(date +%s)
-git checkout $ISOMER_BUILD_REPO_BRANCH
-calculate_duration $start_time
+pwd
 
 corepack enable
 corepack install -g pnpm@11.5.1
@@ -42,51 +40,57 @@ corepack install -g pnpm@11.5.1
 # Do not set storeDir in pnpm-workspace.yaml: local dev keeps the default global store.
 pnpm config set store-dir .pnpm-store --location project
 
-### Create a cache key for the current build ###
-# Assumption: All production related builds are using release tags e.g. v0.2.1
-if [[ -z "$ISOMER_BUILD_REPO_BRANCH" ]]; then
-  # If it's not a release tag, then it's a feature branch so we need to use a unique cache key
-  # We use a combination of branch name and commit hash E.g. feat-buildsupercoolfeature-1a2b3c4d
-  # This ensures that each unique feature branch and commit will have its own cache,
-  # reducing manual cache invalidation and human factor when testing on staging
+if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
+  ### Create a cache key for the current build ###
+  # It's a feature branch, so use a combination of branch name and commit hash
+  # E.g. feat-buildsupercoolfeature-1a2b3c4d. This ensures that each unique
+  # feature branch and commit will have its own cache, reducing manual cache
+  # invalidation and human factor when testing on staging.
   UNIQUE_CACHE_KEY="$ISOMER_BUILD_REPO_BRANCH-$(git rev-parse --short HEAD)"
   echo "Unique cache key: $UNIQUE_CACHE_KEY"
+
+  # Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
+  # pnpm keeps package bytes in a content-addressable store; `store-dir` is set above for this run only.
+  # We archive only `.pnpm-store`; `pnpm install` recreates node_modules from the store + lockfile.
+  TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
+  TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
+  echo "Fetching cached pnpm store..."
+  aws s3 cp --only-show-errors "$TEMPLATE_DEPS_CACHE_PATH" $TEMPLATE_DEPS_TGZ || true
+  if [ -f "$TEMPLATE_DEPS_TGZ" ]; then
+    echo "$TEMPLATE_DEPS_TGZ found in cache"
+    start_time=$(date +%s)
+    tar --use-compress-program=zstd -xf $TEMPLATE_DEPS_TGZ
+    rm $TEMPLATE_DEPS_TGZ
+    calculate_duration "$start_time"
+
+    echo "Re-linking workspace from cached store..."
+    start_time=$(date +%s)
+    pnpm install --frozen-lockfile
+    calculate_duration "$start_time"
+  else
+    echo "$TEMPLATE_DEPS_TGZ not found in cache"
+    echo "Installing workspace dependencies..."
+    start_time=$(date +%s)
+    pnpm install --frozen-lockfile
+    calculate_duration "$start_time"
+
+    echo "Caching pnpm store to S3..."
+    start_time=$(date +%s)
+    tar --use-compress-program="zstd -6" -cf $TEMPLATE_DEPS_TGZ .pnpm-store
+    aws s3 cp --only-show-errors $TEMPLATE_DEPS_TGZ "$TEMPLATE_DEPS_CACHE_PATH"
+    rm $TEMPLATE_DEPS_TGZ
+    echo "Cached pnpm store"
+    calculate_duration "$start_time"
+  fi
 else
-  UNIQUE_CACHE_KEY=$ISOMER_BUILD_REPO_BRANCH
-fi
-
-# Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
-# pnpm keeps package bytes in a content-addressable store; `store-dir` is set above for this run only.
-# We archive only `.pnpm-store`; `pnpm install` recreates node_modules from the store + lockfile.
-TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
-TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
-echo "Fetching cached pnpm store..."
-aws s3 cp --only-show-errors $TEMPLATE_DEPS_CACHE_PATH $TEMPLATE_DEPS_TGZ || true
-if [ -f "$TEMPLATE_DEPS_TGZ" ]; then
-  echo "$TEMPLATE_DEPS_TGZ found in cache"
-  start_time=$(date +%s)
-  tar --use-compress-program=zstd -xf $TEMPLATE_DEPS_TGZ
-  rm $TEMPLATE_DEPS_TGZ
-  calculate_duration $start_time
-
-  echo "Re-linking workspace from cached store..."
-  start_time=$(date +%s)
-  pnpm install --frozen-lockfile
-  calculate_duration $start_time
-else
-  echo "$TEMPLATE_DEPS_TGZ not found in cache"
-  echo "Installing workspace dependencies..."
-  start_time=$(date +%s)
-  pnpm install --frozen-lockfile
-  calculate_duration $start_time
-
-  echo "Caching pnpm store to S3..."
-  start_time=$(date +%s)
-  tar --use-compress-program="zstd -6" -cf $TEMPLATE_DEPS_TGZ .pnpm-store
-  aws s3 cp --only-show-errors $TEMPLATE_DEPS_TGZ $TEMPLATE_DEPS_CACHE_PATH
-  rm $TEMPLATE_DEPS_TGZ
-  echo "Cached pnpm store"
-  calculate_duration $start_time
+  # Production path: dependencies were already installed and archived by
+  # build-components.yml, then extracted above as part of isomer.tar.zst -
+  # no need to reinstall or fetch a separate deps cache. Key the (still
+  # necessary) isomer-components dist cache by the actual release ref that
+  # build-components.yml resolved and recorded in the archive, not a fixed
+  # "latest" string - otherwise every release after the first would silently
+  # reuse an older release's stale dist build.
+  UNIQUE_CACHE_KEY=$(cat .isomer-release-ref)
 fi
 
 # packages/components/dist is gitignored; Next resolves @opengovsg/isomer-components via workspace.
@@ -94,38 +98,38 @@ fi
 COMPONENTS_DIST_TGZ="isomer-components-dist.tar.zst"
 COMPONENTS_DIST_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$COMPONENTS_DIST_TGZ"
 echo "Fetching cached isomer-components dist..."
-aws s3 cp --only-show-errors $COMPONENTS_DIST_CACHE_PATH $COMPONENTS_DIST_TGZ || true
+aws s3 cp --only-show-errors "$COMPONENTS_DIST_CACHE_PATH" $COMPONENTS_DIST_TGZ || true
 if [ -f "$COMPONENTS_DIST_TGZ" ]; then
   echo "$COMPONENTS_DIST_TGZ found in cache"
   start_time=$(date +%s)
   mkdir -p packages/components
   tar --use-compress-program=zstd -xf $COMPONENTS_DIST_TGZ -C packages/components
   rm $COMPONENTS_DIST_TGZ
-  calculate_duration $start_time
+  calculate_duration "$start_time"
 else
   echo "$COMPONENTS_DIST_TGZ not found in cache"
   echo "Building @opengovsg/isomer-components..."
   start_time=$(date +%s)
   pnpm --filter @opengovsg/isomer-components run build
-  calculate_duration $start_time
+  calculate_duration "$start_time"
 
   echo "Caching isomer-components dist to S3..."
   start_time=$(date +%s)
   tar --use-compress-program="zstd -6" -cf $COMPONENTS_DIST_TGZ -C packages/components dist
-  aws s3 cp --only-show-errors $COMPONENTS_DIST_TGZ $COMPONENTS_DIST_CACHE_PATH
+  aws s3 cp --only-show-errors $COMPONENTS_DIST_TGZ "$COMPONENTS_DIST_CACHE_PATH"
   rm $COMPONENTS_DIST_TGZ
   echo "Cached isomer-components dist"
-  calculate_duration $start_time
+  calculate_duration "$start_time"
 fi
 
 # Fetch from database
 echo "Fetching from database..."
 start_time=$(date +%s)
 cd tooling/build/scripts/publishing
-echo $(pwd)
+pwd
 pnpm install --frozen-lockfile
 pnpm run start
-calculate_duration $start_time
+calculate_duration "$start_time"
 
 # Prebuilding...
 echo "Prebuilding site..."
@@ -145,13 +149,13 @@ if [ ! -f "schema/not-found.json" ]; then
   echo "Creating not-found.json..."
   cp schema/_index.json schema/not-found.json
 fi
-echo $(pwd)
+pwd
 
 # Build
 echo "Building..."
 start_time=$(date +%s)
 pnpm run build:template
-calculate_duration $start_time
+calculate_duration "$start_time"
 
 # Check if the 'out' folder exists
 if [ ! -d "./out" ]; then
@@ -163,7 +167,7 @@ ls -al
 find ./out -type f | wc -l
 
 cd out/
-echo $(pwd)
+pwd
 ls -al
 
 # Publish to S3
@@ -182,13 +186,13 @@ echo "S3 sync concurrency: $S3_SYNC_CONCURRENCY"
 aws configure set default.s3.max_concurrent_requests $S3_SYNC_CONCURRENCY
 
 # Set all files to have 10 minutes of cache, except for those in the _next folder
-aws s3 sync --only-show-errors . s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest --delete --no-progress --cache-control "max-age=600" --exclude "_next/*"
+aws s3 sync --only-show-errors . s3://"$S3_BUCKET_NAME"/"$SITE_NAME"/"$CODEBUILD_BUILD_NUMBER"/latest --delete --no-progress --cache-control "max-age=600" --exclude "_next/*"
 
 # Set all files in the _next folder to be cached indefinitely (1 year) on users' browsers
 # Next.js uses unique content hashes in filenames, allowing updated content to have different filenames and invalidate the cache on new builds.
-aws s3 sync --only-show-errors _next s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest/_next --delete --no-progress --cache-control "max-age=31536000, public"
+aws s3 sync --only-show-errors _next s3://"$S3_BUCKET_NAME"/"$SITE_NAME"/"$CODEBUILD_BUILD_NUMBER"/latest/_next --delete --no-progress --cache-control "max-age=31536000, public"
 
-calculate_duration $start_time
+calculate_duration "$start_time"
 
 # Upload redirect objects AFTER the --delete sync so they are not swept away.
 # Each redirect becomes an empty index.html with x-amz-meta-redirect-destination metadata
@@ -205,16 +209,16 @@ echo "Uploading redirect files to S3..."
     --concurrency "$S3_SYNC_CONCURRENCY"
 ) || echo "Warning: some redirects failed to upload, continuing..."
 
-calculate_duration $start_time
+calculate_duration "$start_time"
 
 # Update CloudFront origin path
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
-aws cloudfront get-distribution --id $CLOUDFRONT_DISTRIBUTION_ID >distribution.json
+aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
 
 ETag=$(cat distribution.json | jq -r '.ETag')
 echo "ETag: $ETag"
 
 jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
 jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
-aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag
+aws cloudfront update-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" --distribution-config file://distribution-config.json --if-match "$ETag"

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -23,8 +23,11 @@ if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
   cd isomer/
 
   # isomer.tar.zst is source-only (see build-components.yml); the pnpm store is archived
-  # separately and relinked into node_modules below, once pnpm is configured.
-  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/latest/isomer-pnpm-store.tar.zst .
+  # separately, keyed by the commit SHA recorded in .isomer-build-sha rather than
+  # "latest" so it's shared across every ref that happens to point at the same
+  # commit. It's relinked into node_modules below, once pnpm is configured.
+  GIT_SHA=$(cat .isomer-build-sha)
+  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/"$GIT_SHA"/isomer-pnpm-store.tar.zst .
   tar --use-compress-program=zstd -xf isomer-pnpm-store.tar.zst
   rm isomer-pnpm-store.tar.zst
 else
@@ -72,23 +75,21 @@ if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
   if [ -f ".isomer-build-sha" ]; then
     COMMIT_SHA=$(cat .isomer-build-sha)
   else
-    COMMIT_SHA=$(git rev-parse --short HEAD)
+    COMMIT_SHA=$(git rev-parse HEAD)
   fi
   UNIQUE_CACHE_KEY="$ISOMER_BUILD_REPO_BRANCH-$COMMIT_SHA"
   echo "Unique cache key: $UNIQUE_CACHE_KEY"
 
-  # Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
-  # pnpm keeps package bytes in a content-addressable store; `store-dir` is set above for this run only.
-  # We archive only `.pnpm-store`; `pnpm install` recreates node_modules from the store + lockfile.
-  TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
-  TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
-  echo "Fetching cached pnpm store..."
-  aws s3 cp --only-show-errors "$TEMPLATE_DEPS_CACHE_PATH" $TEMPLATE_DEPS_TGZ || true
-  if [ -f "$TEMPLATE_DEPS_TGZ" ]; then
-    echo "$TEMPLATE_DEPS_TGZ found in cache"
+  # build-components.yml publishes a pnpm store archive keyed by commit SHA on every run
+  # (production or ref-scoped), independent of which branch/ref triggered it. If it already
+  # ran for this exact commit, reuse that instead of installing from the registry.
+  STORE_TGZ="isomer-pnpm-store.tar.zst"
+  aws s3 cp --only-show-errors s3://"$S3_CACHE_BUCKET_NAME"/isomer/"$COMMIT_SHA"/"$STORE_TGZ" . || true
+  if [ -f "$STORE_TGZ" ]; then
+    echo "$STORE_TGZ found in cache for commit $COMMIT_SHA"
     start_time=$(date +%s)
-    tar --use-compress-program=zstd -xf $TEMPLATE_DEPS_TGZ
-    rm $TEMPLATE_DEPS_TGZ
+    tar --use-compress-program=zstd -xf "$STORE_TGZ"
+    rm "$STORE_TGZ"
     calculate_duration "$start_time"
 
     echo "Re-linking workspace from cached store..."
@@ -96,19 +97,41 @@ if [[ -n "$ISOMER_BUILD_REPO_BRANCH" ]]; then
     pnpm install --frozen-lockfile
     calculate_duration "$start_time"
   else
-    echo "$TEMPLATE_DEPS_TGZ not found in cache"
-    echo "Installing workspace dependencies..."
-    start_time=$(date +%s)
-    pnpm install --frozen-lockfile
-    calculate_duration "$start_time"
+    echo "$STORE_TGZ not found in cache for commit $COMMIT_SHA"
 
-    echo "Caching pnpm store to S3..."
-    start_time=$(date +%s)
-    tar --use-compress-program="zstd -6" -cf $TEMPLATE_DEPS_TGZ .pnpm-store
-    aws s3 cp --only-show-errors $TEMPLATE_DEPS_TGZ "$TEMPLATE_DEPS_CACHE_PATH"
-    rm $TEMPLATE_DEPS_TGZ
-    echo "Cached pnpm store"
-    calculate_duration "$start_time"
+    # Shared S3 dependency cache (same bucket/prefix pattern is used by multiple CodeBuild projects).
+    # pnpm keeps package bytes in a content-addressable store; `store-dir` is set above for this run only.
+    # We archive only `.pnpm-store`; `pnpm install` recreates node_modules from the store + lockfile.
+    TEMPLATE_DEPS_TGZ="isomer-template-deps.tar.zst"
+    TEMPLATE_DEPS_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/$TEMPLATE_DEPS_TGZ"
+    echo "Fetching cached pnpm store..."
+    aws s3 cp --only-show-errors "$TEMPLATE_DEPS_CACHE_PATH" $TEMPLATE_DEPS_TGZ || true
+    if [ -f "$TEMPLATE_DEPS_TGZ" ]; then
+      echo "$TEMPLATE_DEPS_TGZ found in cache"
+      start_time=$(date +%s)
+      tar --use-compress-program=zstd -xf $TEMPLATE_DEPS_TGZ
+      rm $TEMPLATE_DEPS_TGZ
+      calculate_duration "$start_time"
+
+      echo "Re-linking workspace from cached store..."
+      start_time=$(date +%s)
+      pnpm install --frozen-lockfile
+      calculate_duration "$start_time"
+    else
+      echo "$TEMPLATE_DEPS_TGZ not found in cache"
+      echo "Installing workspace dependencies..."
+      start_time=$(date +%s)
+      pnpm install --frozen-lockfile
+      calculate_duration "$start_time"
+
+      echo "Caching pnpm store to S3..."
+      start_time=$(date +%s)
+      tar --use-compress-program="zstd -6" -cf $TEMPLATE_DEPS_TGZ .pnpm-store
+      aws s3 cp --only-show-errors $TEMPLATE_DEPS_TGZ "$TEMPLATE_DEPS_CACHE_PATH"
+      rm $TEMPLATE_DEPS_TGZ
+      echo "Cached pnpm store"
+      calculate_duration "$start_time"
+    fi
   fi
 else
   # Production path: build-components.yml already populated the pnpm store and

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -54,6 +54,7 @@ start_time=$(date +%s)
 # NOTE: if no build repo branch was provided,
 # we will assume this is production and just clone from the bucket
 if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
+  echo "ISOMER_BUILD_REPO_BRANCH unset; using production cache from s3://$S3_CACHE_BUCKET_NAME/isomer/latest/"
   fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/latest/$REPO_TGZ" "$REPO_TGZ" ||
     { echo "Error: $REPO_TGZ not found in production cache"; exit 1; }
   cd isomer/
@@ -63,16 +64,21 @@ if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
   # "latest" so it's shared across every ref that happens to point at the same
   # commit. It's relinked into node_modules below, once pnpm is configured.
   GIT_SHA=$(cat .isomer-build-sha)
+  echo "Repository archive commit SHA: $GIT_SHA"
   fetch_cached "s3://$S3_CACHE_BUCKET_NAME/isomer/$GIT_SHA/$STORE_TGZ" "$STORE_TGZ" ||
     { echo "Error: $STORE_TGZ not found for commit $GIT_SHA"; exit 1; }
 else
+  echo "ISOMER_BUILD_REPO_BRANCH=$ISOMER_BUILD_REPO_BRANCH; checking branch-scoped cache first"
   # A manual/test build-components.yml run for this branch may have already archived
   # and published the repository to this ref-scoped prefix; reuse it if present instead
   # of re-cloning and re-installing from scratch.
   REPO_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/isomer/refs/$ISOMER_BUILD_REPO_BRANCH/$REPO_TGZ"
+  echo "Branch cache path: $REPO_CACHE_PATH"
   if fetch_cached "$REPO_CACHE_PATH" "$REPO_TGZ"; then
+    echo "Using cached repository archive for branch $ISOMER_BUILD_REPO_BRANCH"
     cd isomer/
   else
+    echo "Branch cache miss; cloning from GitHub (branch=$ISOMER_BUILD_REPO_BRANCH)"
     git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
     cd isomer/
     # Checkout specific branch


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 5 | +346 | -100 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

### 📊 PR diff breakdown

<!-- linear:table-colwidths:200,200,200,200 -->
| Bucket | Files | +Lines | \-Lines |
| -- | -- | -- | -- |
| ⚙️ App | 5 | +340 | \-100 |
| 🧪 Test | 0 | +0 | \-0 |
| 📄 Doc | 0 | +0 | \-0 |
| 🚫 Ignore | 0 | +0 | \-0 |

## Problem

Closes [ISOM-2360](https://linear.app/ogp/issue/ISOM-2360/set-up-release-pipeline-to-publish-components-and-reduce-reliance-on)

The `@opengovsg/isomer-components` dist bundle is currently only built as a side effect of whichever per-site CodeBuild publish job happens to run first after a components version bump — `tooling/build/scripts/publisher.sh` builds it and caches it to S3 only if the shared S3 cache doesn't already have an entry for the current commit. That means the build (and the latency of building it) is entirely dependent on site-publish traffic, and there's no way to pre-warm the cache from GitHub itself.

## Solution

Added `.github/workflows/build-components.yml`, a new reusable workflow (`workflow_dispatch` for manual/backfill runs, `workflow_call` for wiring into other workflows) that ports the relevant parts of `publisher.sh`'s dependency and `isomer-components` caching logic:

* Resolves the `opengovsg/isomer` ref to build (an….. explicit input, or the latest release tag) and checks it out.
* Assumes the caller-supplied AWS role and installs pnpm with a project-local store (matching `publisher.sh`'s own setup), so the S3-cached pnpm store tarball stays self-contained.
* Computes the same cache key `publisher.sh` used (the release tag alone for auto-resolved tags, or `<ref>-<short-sha>` for an explicitly-passed ref) so this workflow and the existing CodeBuild site-publish jobs land in the exact same S3 cache locations and don't collide or duplicate work.
* Fetches or installs the pnpm dependency store, then fetches or builds the `isomer-components` dist tarball, publishing it to the shared S3 cache bucket.

Wired this into a new `build_components` job in `deploy_production.yml`, `deploy_staging.yml`, and `deploy_uat.yml`, each pointing at that environment's existing AWS account/role (reusing the same ones the app-deploy job in the same file already uses) and its own `isomer-next-infra-<env>-sites-cache-bucket-private-*` bucket. This job runs independently of (in parallel with, not blocking) the existing app-deploy job in each file, since publishing `isomer-components` to cache has nothing to do with deploying the Studio app itself.

Net effect: a components version bump gets built and cached from GitHub on every deploy, so the next site publish that needs it hits a warm cache instead of building it inline.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  * Details ...
- [X] No - this PR is backwards compatible

**Features**:

* New reusable `build-components.yml` workflow that builds and caches `@opengovsg/isomer-components` to the shared S3 cache bucket, callable manually or from another workflow.

**Improvements**:

* `deploy_production.yml`, `deploy_staging.yml`, `deploy_uat.yml` each gain a `build_components` job so every deploy also pre-warms the components cache for that environment, reducing reliance on a site-publish job being the one to build it.

**Bug Fixes**:

* None.

## Before & After Screenshots

**BEFORE**:

**AFTER**:

## Tests

* `actionlint` passes clean on all four changed workflow files.
* Recommend a manual `workflow_dispatch` run of `build-components.yml` against staging's role/bucket before relying on the automatic hookup, to confirm the assumed role has the S3 permissions this job needs (`s3:GetObject`/`s3:PutObject` on the cache bucket) — this wasn't verifiable locally since it requires real AWS credentials.
* After merge, confirm the `build_components` job succeeds on the next push to `staging` before trusting it on `production`/`uat`.

**New scripts**:

* None.

**New dependencies**:

* None.

**New dev dependencies**:

* None.

<details><summary>Greptile Summary</summary>

The PR moves production repository preparation into a reusable GitHub workflow and updates CodeBuild publishing to consume the resulting S3 archive.

* Adds environment-specific deploy jobs that populate the shared repository cache.
* Archives an installed checkout under the layout expected by the site publisher.
* Uses an embedded release ref to key downstream components-dist artifacts.

</details>

<details><summary>Confidence Score: 3/5</summary>

The PR is not yet safe to merge because it still leaves the first components build to a site publication and permits older release jobs to overwrite the latest repository cache.

The GitHub workflow never publishes the release-keyed components dist that its consumer requests, and independently grouped release jobs can complete out of order while writing the same mutable S3 object.

**Files Needing Attention:** .github/workflows/build-components.yml, .github/workflows/deploy_production.yml, tooling/build/scripts/publisher.sh

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| .github/workflows/build-components.yml | Adds repository archive publication, but omits components-dist prewarming and writes concurrent releases to one mutable latest key. |
| tooling/build/scripts/publisher.sh | Consumes the repository archive and fixes static dist keying, but still performs the first components build and accepts whichever release occupies the latest key. |
| .github/workflows/deploy_production.yml | Adds the reusable cache job, with per-release concurrency groups that do not serialize writes across release tags. |
| .github/workflows/deploy_staging.yml | Adds the reusable cache job; branch-scoped workflow concurrency prevents overlapping staging pushes. |
| .github/workflows/deploy_uat.yml | Adds the reusable cache job for UAT using the environment-specific role and bucket. |

</details>

<details><summary>Sequence Diagram</summary>

```mermaid
sequenceDiagram
    participant R1 as Older release workflow
    participant R2 as Newer release workflow
    participant S3 as S3 latest cache
    participant Site as Site CodeBuild
    R1->>R1: Install dependencies only
    R2->>R2: Install dependencies only
    R2->>S3: Upload newer isomer.tar.zst
    R1->>S3: Upload older isomer.tar.zst last
    Site->>S3: Download isomer/latest/isomer.tar.zst
    S3-->>Site: Older repository archive
    Site->>S3: Fetch release-keyed components dist
    alt Dist missing
        Site->>Site: Build isomer-components inline
    end
```

</details>

![Fix all with Greploop](https://camo.githubusercontent.com/48fd28226312684a5a79b977925f242a527e3b5d0283e1beead9075efd277bca/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e75732d656173742d312e616d617a6f6e6177732e636f6d2f6261646765732f466978416c6c496e477265704c6f6f702e7376673f763d32) ![Fix All in Claude Code](https://camo.githubusercontent.com/01d2e291016e102d7f6178db30864f6752af65fb38e6502c13a445293740dada/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f466978416c6c496e436c617564652e7376673f763d36) ![Fix All in Cursor](https://camo.githubusercontent.com/b6f4341ee60c4a3b63ebd105529591dcc6242bb7f74df26463b5c5d08320696b/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f466978416c6c496e437572736f722e7376673f763d36) ![Fix All in Conductor](https://camo.githubusercontent.com/0dfd0488b4c1fbf1d74bee4555f558d7d4b8e0472693fcd51f9e3b1b9843c103/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f466978416c6c496e436f6e647563746f722e7376673f763d36)

<details><summary>Prompt To Fix All With AI</summary>

```markdown
### Issue 1
.github/workflows/build-components.yml:97
**Components dist is never prewarmed**

When the first production site publication runs for an uncached release, this workflow has installed dependencies but has not built or uploaded `isomer-components-dist.tar.zst`, so `publisher.sh` still compiles the components package inline and retains the latency and site-publish dependency this workflow is intended to eliminate.

### Issue 2
.github/workflows/build-components.yml:129-130
**Latest archive permits stale overwrite**

If two production releases overlap and the older job uploads last, both jobs write to the same `isomer/latest/isomer.tar.zst` object without cross-release serialization or release validation, causing subsequent site publications to extract and publish the older repository.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
```

</details>

Reviews (5): Last reviewed commit: ["chore: fix code review findings"](<https://github.com/opengovsg/isomer/commit/cbd65d04948f56aa0911415c267e613a1f386fd0>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=54300185>)

> Greptile also left **2 inline comments** on this PR.