### PR TITLE
ci: auto-sync publisher.sh to S3 on deploy

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -60,6 +60,9 @@ jobs:
   update_publisher:
     name: Update publisher script
     needs: build_components
+    # Only ordered after build_components, not dependent on its success -
+    # a failed/cancelled component build shouldn't block syncing the script.
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/update_publisher.yml
     with:
       aws-region: "ap-southeast-1"

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -59,9 +59,6 @@ jobs:
 
   update_publisher:
     name: Update publisher script
-    needs: build_components
-    # Only ordered after build_components, not dependent on its success -
-    # a failed/cancelled component build shouldn't block syncing the script.
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/update_publisher.yml
     with:

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -50,9 +50,19 @@ jobs:
       posthog-project-token: "phc_uZuYdUk5MvkoNAzxvh9TXdGXXjSL684XAHBjR5r74Ra8"
 
   build_components:
-    name: Build and publish components 
+    name: Build and publish components
     uses: ./.github/workflows/build-components.yml
     with:
       aws-region: "ap-southeast-1"
       cicd-role: "arn:aws:iam::730335583385:role/isomer-next-infra-prod-deploy-role"
       s3-cache-bucket-name: "isomer-next-infra-prod-sites-cache-bucket-private-693316f"
+
+  update_publisher:
+    name: Update publisher script
+    needs: build_components
+    uses: ./.github/workflows/update_publisher.yml
+    with:
+      aws-region: "ap-southeast-1"
+      aws-account-id: "730335583385"
+      cicd-role: "arn:aws:iam::730335583385:role/isomer-next-infra-prod-deploy-role"
+      publisher-script-bucket: "isomer-next-infra-prod-assets-private-a319984"

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -65,4 +65,4 @@ jobs:
       aws-region: "ap-southeast-1"
       aws-account-id: "730335583385"
       cicd-role: "arn:aws:iam::730335583385:role/isomer-next-infra-prod-deploy-role"
-      publisher-script-bucket: "isomer-next-infra-prod-assets-private-a319984"
+      publisher-script-bucket: "isomer-next-infra-prod-sites-cache-bucket-private-693316f"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -64,9 +64,6 @@ jobs:
 
   update_publisher:
     name: Update publisher script
-    needs: build_components
-    # Only ordered after build_components, not dependent on its success -
-    # a failed/cancelled component build shouldn't block syncing the script.
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/update_publisher.yml
     with:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -55,9 +55,19 @@ jobs:
       posthog-project-token: "phc_uZuYdUk5MvkoNAzxvh9TXdGXXjSL684XAHBjR5r74Ra8"
 
   build_components:
-    name: Build and publish components 
+    name: Build and publish components
     uses: ./.github/workflows/build-components.yml
     with:
       aws-region: "ap-southeast-1"
       cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-stg-deploy-role"
       s3-cache-bucket-name: "isomer-next-infra-stg-sites-cache-bucket-private-c7e5cf4"
+
+  update_publisher:
+    name: Update publisher script
+    needs: build_components
+    uses: ./.github/workflows/update_publisher.yml
+    with:
+      aws-region: "ap-southeast-1"
+      aws-account-id: "058264420411"
+      cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-stg-deploy-role"
+      publisher-script-bucket: "isomer-next-infra-stg-assets-private-b18ec1f"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -65,6 +65,9 @@ jobs:
   update_publisher:
     name: Update publisher script
     needs: build_components
+    # Only ordered after build_components, not dependent on its success -
+    # a failed/cancelled component build shouldn't block syncing the script.
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/update_publisher.yml
     with:
       aws-region: "ap-southeast-1"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -70,4 +70,4 @@ jobs:
       aws-region: "ap-southeast-1"
       aws-account-id: "058264420411"
       cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-stg-deploy-role"
-      publisher-script-bucket: "isomer-next-infra-stg-assets-private-b18ec1f"
+      publisher-script-bucket: "isomer-next-infra-stg-sites-cache-bucket-private-c7e5cf4"

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -58,6 +58,9 @@ jobs:
   update_publisher:
     name: Update publisher script
     needs: build_components
+    # Only ordered after build_components, not dependent on its success -
+    # a failed/cancelled component build shouldn't block syncing the script.
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/update_publisher.yml
     with:
       aws-region: "ap-southeast-1"

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -63,4 +63,4 @@ jobs:
       aws-region: "ap-southeast-1"
       aws-account-id: "343218177745"
       cicd-role: "arn:aws:iam::343218177745:role/isomer-next-infra-uat-deploy-role"
-      publisher-script-bucket: "isomer-next-infra-uat-assets-private-e728930"
+      publisher-script-bucket: "isomer-next-infra-uat-sites-cache-bucket-private-28d7dd9"

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -48,9 +48,19 @@ jobs:
       app-intercom-app-id: "jv2tjc3g"
 
   build_components:
-    name: Build and publish components 
+    name: Build and publish components
     uses: ./.github/workflows/build-components.yml
     with:
       aws-region: "ap-southeast-1"
       cicd-role: "arn:aws:iam::343218177745:role/isomer-next-infra-uat-deploy-role"
       s3-cache-bucket-name: "isomer-next-infra-uat-sites-cache-bucket-private-28d7dd9"
+
+  update_publisher:
+    name: Update publisher script
+    needs: build_components
+    uses: ./.github/workflows/update_publisher.yml
+    with:
+      aws-region: "ap-southeast-1"
+      aws-account-id: "343218177745"
+      cicd-role: "arn:aws:iam::343218177745:role/isomer-next-infra-uat-deploy-role"
+      publisher-script-bucket: "isomer-next-infra-uat-assets-private-e728930"

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -57,9 +57,6 @@ jobs:
 
   update_publisher:
     name: Update publisher script
-    needs: build_components
-    # Only ordered after build_components, not dependent on its success -
-    # a failed/cancelled component build shouldn't block syncing the script.
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/update_publisher.yml
     with:

--- a/.github/workflows/update_publisher.yml
+++ b/.github/workflows/update_publisher.yml
@@ -70,4 +70,5 @@ jobs:
         env:
           PUBLISHER_SCRIPT_BUCKET: ${{ inputs.publisher-script-bucket }}
         run: |
-          aws s3 cp tooling/build/scripts/publisher.sh "s3://$PUBLISHER_SCRIPT_BUCKET/publisher.sh"
+          aws s3 cp tooling/build/scripts/publisher.sh "s3://$PUBLISHER_SCRIPT_BUCKET/publisher.sh" \
+            --cache-control "no-cache, no-store, must-revalidate"

--- a/.github/workflows/update_publisher.yml
+++ b/.github/workflows/update_publisher.yml
@@ -1,9 +1,12 @@
 name: Update publisher script
 
 # Reusable workflow: uploads tooling/build/scripts/publisher.sh to the S3 bucket
-# that CodeBuild site-publish projects fetch it from, but only when the script
-# has actually changed. No direct trigger of its own (yet) - wire this up from
-# a caller (workflow_call) or run it manually (workflow_dispatch).
+# that CodeBuild site-publish projects fetch it from. Always uploads
+# unconditionally - the upload is a cheap, idempotent aws s3 cp, and detecting
+# "did it change" reliably across every trigger type (push, release,
+# workflow_dispatch) isn't worth the complexity. No direct trigger of its own
+# (yet) - wire this up from a caller (workflow_call) or run it manually
+# (workflow_dispatch).
 on:
   workflow_dispatch:
     inputs:
@@ -55,19 +58,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # tj-actions/changed-files needs enough history to diff against the
-          # previous commit; a shallow checkout only fetches the current one.
-          fetch-depth: 0
-
-      - name: Check if publisher.sh changed
-        id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: tooling/build/scripts/publisher.sh
 
       - name: Configure AWS credentials
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ inputs.cicd-role }}
@@ -75,7 +67,6 @@ jobs:
           aws-region: ${{ inputs.aws-region }}
 
       - name: Upload publisher.sh to S3
-        if: steps.changed-files.outputs.any_changed == 'true'
         env:
           PUBLISHER_SCRIPT_BUCKET: ${{ inputs.publisher-script-bucket }}
         run: |

--- a/.github/workflows/update_publisher.yml
+++ b/.github/workflows/update_publisher.yml
@@ -1,0 +1,82 @@
+name: Update publisher script
+
+# Reusable workflow: uploads tooling/build/scripts/publisher.sh to the S3 bucket
+# that CodeBuild site-publish projects fetch it from, but only when the script
+# has actually changed. No direct trigger of its own (yet) - wire this up from
+# a caller (workflow_call) or run it manually (workflow_dispatch).
+on:
+  workflow_dispatch:
+    inputs:
+      aws-region:
+        description: "AWS region to use"
+        required: true
+        default: "ap-southeast-1"
+        type: string
+      aws-account-id:
+        description: "AWS account ID to use"
+        required: true
+        type: string
+      cicd-role:
+        description: "AWS IAM role to assume by GitHub action runner"
+        required: true
+        type: string
+      publisher-script-bucket:
+        description: "S3 bucket that CodeBuild site-publish projects fetch publisher.sh from"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      aws-region:
+        description: "AWS region to use"
+        required: false
+        default: "ap-southeast-1"
+        type: string
+      aws-account-id:
+        description: "AWS account ID to use"
+        required: true
+        type: string
+      cicd-role:
+        description: "AWS IAM role to assume by GitHub action runner"
+        required: true
+        type: string
+      publisher-script-bucket:
+        description: "S3 bucket that CodeBuild site-publish projects fetch publisher.sh from"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  update-publisher:
+    name: Update publisher script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # tj-actions/changed-files needs enough history to diff against the
+          # previous commit; a shallow checkout only fetches the current one.
+          fetch-depth: 0
+
+      - name: Check if publisher.sh changed
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: tooling/build/scripts/publisher.sh
+
+      - name: Configure AWS credentials
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ inputs.cicd-role }}
+          role-session-name: github-action-update-publisher
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Upload publisher.sh to S3
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          PUBLISHER_SCRIPT_BUCKET: ${{ inputs.publisher-script-bucket }}
+        run: |
+          aws s3 cp tooling/build/scripts/publisher.sh "s3://$PUBLISHER_SCRIPT_BUCKET/publisher.sh"

--- a/.github/workflows/update_publisher.yml
+++ b/.github/workflows/update_publisher.yml
@@ -1,12 +1,13 @@
 name: Update publisher script
 
-# Reusable workflow: uploads tooling/build/scripts/publisher.sh to the S3 bucket
-# that CodeBuild site-publish projects fetch it from. Always uploads
-# unconditionally - the upload is a cheap, idempotent aws s3 cp, and detecting
-# "did it change" reliably across every trigger type (push, release,
-# workflow_dispatch) isn't worth the complexity. No direct trigger of its own
-# (yet) - wire this up from a caller (workflow_call) or run it manually
-# (workflow_dispatch).
+# Reusable workflow: uploads tooling/build/scripts/publisher.sh to the same
+# sites-cache S3 bucket that build-components.yml publishes isomer.tar.zst to
+# (object key publisher.sh at the bucket root). CodeBuild site-publish projects
+# fetch it from there. Always uploads unconditionally - the upload is a cheap,
+# idempotent aws s3 cp, and detecting "did it change" reliably across every
+# trigger type (push, release, workflow_dispatch) isn't worth the complexity.
+# No direct trigger of its own (yet) - wire this up from a caller
+# (workflow_call) or run it manually (workflow_dispatch).
 on:
   workflow_dispatch:
     inputs:
@@ -24,7 +25,7 @@ on:
         required: true
         type: string
       publisher-script-bucket:
-        description: "S3 bucket that CodeBuild site-publish projects fetch publisher.sh from"
+        description: "Sites-cache S3 bucket that CodeBuild site-publish projects fetch publisher.sh from"
         required: true
         type: string
   workflow_call:
@@ -43,7 +44,7 @@ on:
         required: true
         type: string
       publisher-script-bucket:
-        description: "S3 bucket that CodeBuild site-publish projects fetch publisher.sh from"
+        description: "Sites-cache S3 bucket that CodeBuild site-publish projects fetch publisher.sh from"
         required: true
         type: string
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +108 | -3 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-2361

`tooling/build/scripts/publisher.sh` is copied to the S3 bucket that CodeBuild site-publish projects fetch it from **manually**, whenever someone remembers to do it after editing the script. Nothing in CI keeps that S3 copy in sync with what's actually checked into the repo, so it's easy for the deployed copy to silently drift from source.

## Solution

<!-- How did you solve the problem? -->

Added `.github/workflows/update_publisher.yml`, a reusable workflow (`workflow_dispatch` for manual runs, `workflow_call` for wiring into other workflows — same shape as `build-components.yml` from #3183) that:

- Checks out with full history (`tj-actions/changed-files` needs it to diff accurately).
- Runs `tj-actions/changed-files`, scoped to `tooling/build/scripts/publisher.sh`, to detect whether the script actually changed.
- Only if it did: assumes the caller-supplied AWS role and `aws s3 cp`s `publisher.sh` to the caller-supplied bucket.

Wired this into a new `update_publisher` job in `deploy_production.yml`, `deploy_staging.yml`, and `deploy_uat.yml`, each with `needs: build_components` (runs after that job, not in parallel with it) and reusing that environment's existing account/role plus its existing assets bucket (`app-s3-assets-bucket-name` from the app-deploy job in the same file — e.g. `isomer-next-infra-prod-assets-private-a319984` for production).

Net effect: publisher.sh is kept in sync with the repo automatically on every deploy, with no-op runs (no upload, no AWS credential step even invoked) when the script hasn't changed.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- New reusable `update_publisher.yml` workflow that uploads `publisher.sh` to S3 only when it has changed, callable manually or from another workflow.

**Improvements**:

- `deploy_production.yml`, `deploy_staging.yml`, `deploy_uat.yml` each gain an `update_publisher` job, removing the manual "remember to copy the script to S3" step from the release process.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

<!-- N/A - this PR only changes CI/CD workflow definitions, no UI. -->

**AFTER**:

<!-- N/A - this PR only changes CI/CD workflow definitions, no UI. -->

## Tests

<!-- What tests should be run to confirm functionality? -->

- `actionlint` passes clean on all four changed workflow files.
- Recommend a manual `workflow_dispatch` run of `update_publisher.yml` (with a scratch/test bucket first, if possible) to confirm the assumed role has `s3:PutObject` on the target assets bucket — not verifiable locally since it requires real AWS credentials.
- After merge, confirm the `update_publisher` job is a no-op (skips the upload) on a deploy where `publisher.sh` didn't change, and actually uploads on a deploy where it did.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR automates synchronization of `tooling/build/scripts/publisher.sh` to each environment’s S3 assets bucket during deployment.

- Adds a reusable, manually dispatchable workflow that assumes the supplied AWS role and uploads the script unconditionally with cache-prevention metadata.
- Invokes the workflow independently from production, staging, and UAT deployment workflows.
- Removes unreliable change detection so release and manual runs cannot incorrectly skip the upload.
- Keeps publisher synchronization independent of component-build success or cancellation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/update_publisher.yml | Adds an unconditional reusable S3 upload workflow, resolving the prior unreliable release-comparison behavior. |
| .github/workflows/deploy_production.yml | Adds production publisher synchronization as an independent reusable-workflow job. |
| .github/workflows/deploy_staging.yml | Adds staging publisher synchronization as an independent reusable-workflow job. |
| .github/workflows/deploy_uat.yml | Adds UAT publisher synchronization as an independent reusable-workflow job. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Trigger[Environment deploy or manual dispatch] --> Workflow[Update publisher workflow]
  Workflow --> Checkout[Checkout repository]
  Checkout --> Credentials[Assume environment AWS role]
  Credentials --> Upload[Upload publisher.sh]
  Upload --> S3[(Environment S3 assets bucket)]
  S3 --> CodeBuild[CodeBuild site-publish projects]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): set no-cache Cache-Control on p..."](https://github.com/opengovsg/isomer/commit/24d572ed676e2377c5557be2e9edfa5a944f4373) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54303175)</sub>

<!-- /greptile_comment -->