### PR TITLE
fix(studio): always take SearchSG clientId from the database

### DIFF
--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -42,6 +42,10 @@ const createCaller = createCallerFactory(siteRouter)
 const MOCK_SITE_NAME = "isobad"
 const MOCK_LOGO_URL = "https://isobad.com/logo.png"
 const MOCK_SEARCHSG_CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000"
+// A valid UUID that belongs to a different site's SearchSG project. Passing the
+// format check is what makes this dangerous: it reaches the SearchSG API.
+const MOCK_OTHER_SITE_SEARCHSG_CLIENT_ID =
+  "11111111-2222-3333-4444-555555555555"
 const MOCK_EGAZETTE_ALGOLIA_SEARCH = {
   type: "egazette-algolia",
   appId: "MOCK_APP_ID",
@@ -739,6 +743,37 @@ describe("site.router", async () => {
         result.url,
       )
     })
+    it("should not allow a site admin to enable searchSG with a supplied clientId", async () => {
+      // Arrange - no search integration, so there is no clientId in the DB to
+      // fall back on. The clientId is a valid UUID belonging to another site.
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.updateSiteConfig({
+        siteName: MOCK_SITE_NAME,
+        logoUrl: MOCK_LOGO_URL,
+        url: "https://www.isomer.gov.sg",
+        theme: "isomer-next",
+        siteId: site.id,
+        search: {
+          type: "searchSG",
+          clientId: MOCK_OTHER_SITE_SEARCHSG_CLIENT_ID,
+        },
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Cannot enable the SearchSG search integration. Contact Isomer Support to set it up.",
+        }),
+      )
+    })
     it("should not allow a site admin to switch search to egazette-algolia", async () => {
       // Arrange - site is not on egazette-algolia
       const { site } = await setupSite()
@@ -1018,6 +1053,71 @@ describe("site.router", async () => {
       await expect(result).rejects.toMatchObject({ code: "BAD_REQUEST" })
     })
 
+    it("should not allow a site admin to change the searchSG clientId", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await db
+        .updateTable("Site")
+        .set({
+          config: {
+            ...site.config,
+            search: { type: "searchSG", clientId: MOCK_SEARCHSG_CLIENT_ID },
+          },
+        })
+        .where("id", "=", site.id)
+        .execute()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act - submit another site's clientId
+      const result = await caller.updateSiteIntegrations({
+        siteId: site.id,
+        data: {
+          ...MOCK_INTEGRATION_DATA,
+          search: {
+            type: "searchSG",
+            clientId: MOCK_OTHER_SITE_SEARCHSG_CLIENT_ID,
+          },
+        },
+      })
+
+      // Assert - the stored clientId should be the original DB value
+      expect(result.config.search).toEqual({
+        type: "searchSG",
+        clientId: MOCK_SEARCHSG_CLIENT_ID,
+      })
+    })
+    it("should not allow a site admin to enable searchSG with a supplied clientId", async () => {
+      // Arrange - no search integration, so there is no clientId in the DB
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.updateSiteIntegrations({
+        siteId: site.id,
+        data: {
+          ...MOCK_INTEGRATION_DATA,
+          search: {
+            type: "searchSG",
+            clientId: MOCK_OTHER_SITE_SEARCHSG_CLIENT_ID,
+          },
+        },
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Cannot enable the SearchSG search integration. Contact Isomer Support to set it up.",
+        }),
+      )
+    })
     it("should throw 400 if downgrading search integration from searchSG to localSearch", async () => {
       // Arrange
       const { site } = await setupSite()

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -42,10 +42,11 @@ const createCaller = createCallerFactory(siteRouter)
 const MOCK_SITE_NAME = "isobad"
 const MOCK_LOGO_URL = "https://isobad.com/logo.png"
 const MOCK_SEARCHSG_CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000"
-// A valid UUID that belongs to a different site's SearchSG project. Passing the
-// format check is what makes this dangerous: it reaches the SearchSG API.
+// A UUID belonging to a different site's SearchSG project. It has to satisfy
+// `isValidSearchSGClientId` (RFC 4122, so version 4 and variant 8 here), because
+// clearing that check is what lets a tampered clientId reach the SearchSG API.
 const MOCK_OTHER_SITE_SEARCHSG_CLIENT_ID =
-  "11111111-2222-3333-4444-555555555555"
+  "11111111-2222-4333-8444-555555555555"
 const MOCK_EGAZETTE_ALGOLIA_SEARCH = {
   type: "egazette-algolia",
   appId: "MOCK_APP_ID",
@@ -742,6 +743,19 @@ describe("site.router", async () => {
         existingClientId,
         result.url,
       )
+    })
+    it("uses clientId fixtures that pass the SearchSG format check", () => {
+      // Guards the premise of the tampering tests below: a malformed clientId
+      // is rejected downstream anyway, so the fixtures have to be well-formed
+      // for those tests to cover the case that actually reaches SearchSG.
+      expect(
+        searchSgService.isValidSearchSGClientId(MOCK_SEARCHSG_CLIENT_ID),
+      ).toBe(true)
+      expect(
+        searchSgService.isValidSearchSGClientId(
+          MOCK_OTHER_SITE_SEARCHSG_CLIENT_ID,
+        ),
+      ).toBe(true)
     })
     it("should not allow a site admin to enable searchSG with a supplied clientId", async () => {
       // Arrange - no search integration, so there is no clientId in the DB to

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -43,7 +43,7 @@ import {
   getSiteConfig,
   getSiteTheme,
   normalizeAskgovConfig,
-  resolveEgazetteAlgoliaSearchConfig,
+  resolveSearchConfig,
   setSiteNotification,
   validateUserPermissionsForSite,
 } from "./site.service"
@@ -140,20 +140,12 @@ export const siteRouter = router({
       const normalizedConfig = normalizeAskgovConfig({ ...rest, siteName })
 
       const updatedConfig = await db.transaction().execute(async (tx) => {
-        // Preserve the existing clientId from DB - only admins can update it via setSiteConfigByAdmin
-        const searchConfig =
-          normalizedConfig.search?.type === "searchSG" &&
-          config.search?.type === "searchSG"
-            ? {
-                ...normalizedConfig.search,
-                clientId: config.search.clientId,
-              }
-            : // egazette-algolia is admin-managed; site admins cannot switch
-              // to/from it or tamper with its Algolia credentials.
-              resolveEgazetteAlgoliaSearchConfig(
-                config.search,
-                normalizedConfig.search,
-              )
+        // searchSG and egazette-algolia are admin-managed; their credentials
+        // always come from the DB, never from site-admin input.
+        const searchConfig = resolveSearchConfig(
+          config.search,
+          normalizedConfig.search,
+        )
 
         const updatedSite = await tx
           .updateTable("Site")
@@ -233,9 +225,9 @@ export const siteRouter = router({
           })
         }
 
-        // egazette-algolia is admin-managed; site admins cannot switch to/from
-        // it or tamper with its Algolia credentials.
-        const search = resolveEgazetteAlgoliaSearchConfig(
+        // searchSG and egazette-algolia are admin-managed; their credentials
+        // always come from the DB, never from site-admin input.
+        const search = resolveSearchConfig(
           site.config.search,
           normalizedData.search,
         )

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -45,6 +45,7 @@ export const validateUserPermissionsForSite = async ({
 type SiteSearchConfig = IsomerSiteConfigProps["search"]
 
 const EGAZETTE_ALGOLIA_SEARCH_TYPE = "egazette-algolia"
+const SEARCHSG_SEARCH_TYPE = "searchSG"
 
 export const normalizeAskgovConfig = (
   config: IsomerSiteConfigProps,
@@ -83,7 +84,7 @@ export const normalizeAskgovConfig = (
  * a `BAD_REQUEST` when the caller attempts to switch the search type to or from
  * `egazette-algolia`.
  */
-export const resolveEgazetteAlgoliaSearchConfig = (
+const resolveEgazetteAlgoliaSearchConfig = (
   existing: SiteSearchConfig,
   incoming: SiteSearchConfig,
 ): SiteSearchConfig => {
@@ -101,6 +102,51 @@ export const resolveEgazetteAlgoliaSearchConfig = (
   // egazette-algolia is admin-managed; never trust site-admin input for it.
   return wasEgazetteAlgolia ? existing : incoming
 }
+
+/**
+ * The SearchSG `clientId` identifies the site's SearchSG project and is
+ * provisioned out of band, so it may only be set by an Isomer admin via
+ * `setSiteConfigByAdmin` — the field is `readOnly` in the schema and the editor
+ * renders the whole SearchSG control disabled. It must therefore always come
+ * from the DB and never from the request: any valid UUID is accepted downstream
+ * by `updateSearchSGConfig`, so honouring an incoming `clientId` would let a
+ * site admin point this site at another agency's project and rename or restyle
+ * it.
+ *
+ * Returns the search config to persist, with the `clientId` taken from the DB.
+ * Throws a `BAD_REQUEST` when the caller tries to turn SearchSG on, since there
+ * is no provisioned `clientId` to fall back on in that case.
+ */
+const resolveSearchSGSearchConfig = (
+  existing: SiteSearchConfig,
+  incoming: SiteSearchConfig,
+): SiteSearchConfig => {
+  if (incoming?.type !== SEARCHSG_SEARCH_TYPE) return incoming
+
+  if (existing?.type !== SEARCHSG_SEARCH_TYPE) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message:
+        "Cannot enable the SearchSG search integration. Contact Isomer Support to set it up.",
+    })
+  }
+
+  return { ...incoming, clientId: existing.clientId }
+}
+
+/**
+ * Single entry point for reconciling a site admin's search config against the
+ * DB, covering both admin-managed variants. Every caller that persists a search
+ * config from user input must go through this.
+ */
+export const resolveSearchConfig = (
+  existing: SiteSearchConfig,
+  incoming: SiteSearchConfig,
+): SiteSearchConfig =>
+  resolveSearchSGSearchConfig(
+    existing,
+    resolveEgazetteAlgoliaSearchConfig(existing, incoming),
+  )
 
 export const getSiteConfig = async (db: SafeKysely, siteId: number) => {
   const { config } = await db


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +57 | -19 |
| 🧪 Test | 1 | +114 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The SearchSG `clientId` identifies a site's SearchSG project and is provisioned out of band, so only an Isomer admin may set it (via `setSiteConfigByAdmin`). Two paths let a site admin supply their own instead:

- `updateSiteIntegrations` had no preservation logic at all — the request's `clientId` went straight into the stored config.
- `updateSiteConfig` preserved the stored `clientId` only when the site was **already** on `searchSG`. Enabling `searchSG` for the first time fell through to the `else` branch, and `resolveEgazetteAlgoliaSearchConfig` returns the incoming config verbatim for every non-egazette type, so it did not cover this case.

`isValidSearchSGClientId` only checks the UUID format, so a site admin could submit a valid UUID belonging to another agency's project. `updateSearchSGConfig` then issues an authenticated PATCH against that project, letting them rename or restyle another agency's SearchSG site.

Reported by Hacktron on #3164; pre-existing on `main` and unrelated to that PR.

## Solution

Route both mutations through a single `resolveSearchConfig`, which always takes the `clientId` from the database and never from the request. Enabling SearchSG is rejected with a `BAD_REQUEST`, since there is no provisioned `clientId` to fall back on in that case — the editor renders the whole SearchSG control disabled (`JsonFormsSearchSGControl`, `enabled={false}`), so legitimate traffic only ever echoes back the stored config. `resolveEgazetteAlgoliaSearchConfig` is now private, so the egazette-only helper cannot be reached directly and re-introduce the gap.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - A site already on SearchSG keeps working, and its `clientId` is unchanged. The rejected path was not reachable from the editor.

**Bug Fixes**:

- A site admin can no longer set or change the SearchSG `clientId` through `updateSiteConfig` or `updateSiteIntegrations`.

## Tests

Three regression tests added to `site.router.test.ts`, each verified to fail before the fix and pass after:

- `updateSiteIntegrations` keeps the stored `clientId` when the request carries another site's UUID.
- `updateSiteIntegrations` rejects enabling SearchSG with a supplied `clientId`.
- `updateSiteConfig` rejects enabling SearchSG with a supplied `clientId` (the first-time-enable gap).

They use a valid UUID rather than the malformed value in the existing tests, since passing the format check is what makes the attack reach the SearchSG API. The full studio unit suite is green: 91 files, 1755 passed, 41 skipped.

**Manual Verification Steps**:

- [ ] On a site already using SearchSG, open Site settings → Integrations, change an unrelated field (e.g. the GTM ID) and save. Confirm it saves and the SearchSG client ID shown is unchanged.
- [ ] On the same site, save the Name and agency page. Confirm the SearchSG client ID in the DB is unchanged and, if the site name changed, that the SearchSG project name updates for the correct project.
- [ ] Confirm the SearchSG section of the Integrations page is still read-only.
- [ ] As an Isomer admin, set a SearchSG `clientId` via the admin config editor and confirm it still applies.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
