### PR TITLE
fix(editing-experience): allow opening Text blocks with legacy invalid content, block save instead

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/EditPageDrawer.tsx
@@ -1,9 +1,7 @@
-import type { IsomerComponent, ProseProps } from "@opengovsg/isomer-components"
-import { getComponentSchema } from "@opengovsg/isomer-components"
 import ComponentSelector from "~/components/PageEditor/ComponentSelector"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import { ajv } from "~/utils/ajv"
 
+import { inferAsProse } from "../../utils/inferAsProse"
 import TipTapProseComponent from "../TipTapProseComponent"
 import CollectionEditorStateDrawer from "./CollectionEditorStateDrawer"
 import ComplexEditorStateDrawer from "./ComplexEditorStateDrawer"
@@ -14,30 +12,12 @@ import RawJsonEditorModeStateDrawer from "./RawJsonEditorModeStateDrawer"
 import RootStateDrawer from "./RootStateDrawer"
 import SiderailOrderingEditorStateDrawer from "./SiderailOrderingEditorStateDrawer"
 
-const proseSchema = getComponentSchema({ component: "prose" })
-
-const validate = ajv.compile<ProseProps>(proseSchema)
-
 export function EditPageDrawer(): JSX.Element {
   const {
     previewPageState,
     drawerState: currState,
     currActiveIdx,
   } = useEditorDrawerContext()
-
-  const inferAsProse = (component?: IsomerComponent): ProseProps => {
-    if (!component) {
-      throw new Error("Expected component of type prose but got undefined")
-    }
-
-    if (validate(component)) {
-      return component
-    }
-
-    throw new Error(
-      `Expected component of type prose but got type ${component.type}`,
-    )
-  }
 
   switch (currState.state) {
     case "root":

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -1,5 +1,5 @@
 import type { ProseProps } from "@opengovsg/isomer-components"
-import type { EditorEvents, JSONContent } from "@tiptap/react"
+import type { JSONContent } from "@tiptap/react"
 import { Box, HStack, useDisclosure, VStack } from "@chakra-ui/react"
 import {
   Button,
@@ -60,14 +60,10 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
   const [hasTipTapSchemaError, setHasTipTapSchemaError] = useState(false)
 
   const toast = useToast()
-  const handleTipTapContentError = useCallback(
-    ({ editor }: EditorEvents["contentError"]) => {
-      setHasTipTapSchemaError(true)
-      setIsContentValid(false)
-      editor.setEditable(false, false)
-    },
-    [],
-  )
+  const handleTipTapContentError = useCallback(() => {
+    setHasTipTapSchemaError(true)
+    setIsContentValid(false)
+  }, [])
   const { pageId, siteId } = useQueryParse(pageSchema)
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -3,6 +3,7 @@ import type { JSONContent } from "@tiptap/react"
 import { Box, HStack, useDisclosure, VStack } from "@chakra-ui/react"
 import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
 import { isEqual } from "lodash-es"
+import { useState } from "react"
 import { BiTrash } from "react-icons/bi"
 import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
@@ -12,6 +13,7 @@ import { trpc } from "~/utils/trpc"
 
 import { useTextEditor } from "../hooks/useTextEditor"
 import { pageSchema } from "../schema"
+import { isValidProse } from "../utils/isValidProse"
 import { CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE } from "./constants"
 import { DeleteBlockModal } from "./DeleteBlockModal"
 import { DiscardChangesModal } from "./DiscardChangesModal"
@@ -44,6 +46,10 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
     setAddedBlockIndex,
   } = useEditorDrawerContext()
 
+  const [isContentValid, setIsContentValid] = useState(() =>
+    isValidProse(content),
+  )
+
   const toast = useToast()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
@@ -60,13 +66,13 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
 
   const updatePageState = (editorContent: JSONContent | undefined) => {
     const updatedBlocks = Array.from(previewPageState.content)
-    // TODO: actual validation
     updatedBlocks[currActiveIdx] = editorContent as ProseProps
     const newPageState = {
       ...previewPageState,
       content: updatedBlocks,
     }
     setPreviewPageState(newPageState)
+    setIsContentValid(isValidProse(editorContent))
   }
 
   const editor = useTextEditor({ data: content, handleChange: updatePageState })
@@ -179,6 +185,7 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
                   )
                 }}
                 isLoading={isPending}
+                isDisabled={!isContentValid}
               >
                 Save changes
               </Button>

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -1,9 +1,14 @@
 import type { ProseProps } from "@opengovsg/isomer-components"
-import type { JSONContent } from "@tiptap/react"
+import type { EditorEvents, JSONContent } from "@tiptap/react"
 import { Box, HStack, useDisclosure, VStack } from "@chakra-ui/react"
-import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
+import {
+  Button,
+  IconButton,
+  Infobox,
+  useToast,
+} from "@opengovsg/design-system-react"
 import { isEqual } from "lodash-es"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import { BiTrash } from "react-icons/bi"
 import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
@@ -14,7 +19,10 @@ import { trpc } from "~/utils/trpc"
 import { useTextEditor } from "../hooks/useTextEditor"
 import { pageSchema } from "../schema"
 import { isValidProse } from "../utils/isValidProse"
-import { CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE } from "./constants"
+import {
+  CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
+  PROSE_CONTENT_LOAD_ERROR_MESSAGE,
+} from "./constants"
 import { DeleteBlockModal } from "./DeleteBlockModal"
 import { DiscardChangesModal } from "./DiscardChangesModal"
 import { DrawerHeader } from "./Drawer/DrawerHeader"
@@ -49,8 +57,17 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
   const [isContentValid, setIsContentValid] = useState(() =>
     isValidProse(content),
   )
+  const [hasTipTapSchemaError, setHasTipTapSchemaError] = useState(false)
 
   const toast = useToast()
+  const handleTipTapContentError = useCallback(
+    ({ editor }: EditorEvents["contentError"]) => {
+      setHasTipTapSchemaError(true)
+      setIsContentValid(false)
+      editor.setEditable(false, false)
+    },
+    [],
+  )
   const { pageId, siteId } = useQueryParse(pageSchema)
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
@@ -75,7 +92,11 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
     setIsContentValid(isValidProse(editorContent))
   }
 
-  const editor = useTextEditor({ data: content, handleChange: updatePageState })
+  const editor = useTextEditor({
+    data: content,
+    handleChange: updatePageState,
+    onContentError: handleTipTapContentError,
+  })
 
   const handleDeleteBlock = () => {
     const updatedBlocks = Array.from(savedPageState.content)
@@ -147,6 +168,13 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
           }}
           label={`Edit ${PROSE_COMPONENT_NAME}`}
         />
+        {hasTipTapSchemaError && (
+          <Box px="2rem" pt="1rem" w="full">
+            <Infobox variant="warning" size="sm" w="full">
+              {PROSE_CONTENT_LOAD_ERROR_MESSAGE}
+            </Infobox>
+          </Box>
+        )}
         <Box w="100%" overflow="auto" flex={1}>
           <TiptapTextEditor editor={editor} />
         </Box>

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -209,7 +209,7 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
                   )
                 }}
                 isLoading={isPending}
-                isDisabled={!isContentValid}
+                isDisabled={!isContentValid || hasTipTapSchemaError}
               >
                 Save changes
               </Button>

--- a/apps/studio/src/features/editing-experience/components/__tests__/TipTapProseComponent.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/__tests__/TipTapProseComponent.browser.test.tsx
@@ -58,12 +58,12 @@ vi.mock("../form-builder/renderers/TipTapEditor", () => ({
   TiptapTextEditor: () => <div data-testid="tiptap-editor" />,
 }))
 
-const VALID_PROSE: ProseProps = {
-  type: "prose",
+const VALID_PROSE = {
+  type: "prose" as const,
   content: [
     {
-      type: "paragraph",
-      content: [{ type: "text", text: "Hello world" }],
+      type: "paragraph" as const,
+      content: [{ type: "text" as const, text: "Hello world" }],
     },
   ],
 }
@@ -87,7 +87,7 @@ const renderComponent = () =>
         updatedAt={new Date()}
         title="About us"
       >
-        <TipTapProseComponent content={VALID_PROSE} />
+        <TipTapProseComponent content={VALID_PROSE as ProseProps} />
       </EditorDrawerProvider>
     </ThemeProvider>,
   )

--- a/apps/studio/src/features/editing-experience/components/__tests__/TipTapProseComponent.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/__tests__/TipTapProseComponent.browser.test.tsx
@@ -1,0 +1,115 @@
+import type { IsomerSchema, ProseProps } from "@opengovsg/isomer-components"
+import type { EditorEvents, JSONContent } from "@tiptap/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { act, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
+import { theme } from "~/theme"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import TipTapProseComponent from "../TipTapProseComponent"
+
+const noop = vi.hoisted(() => vi.fn())
+
+const editorCallbacks = vi.hoisted(() => ({
+  handleChange: undefined as
+    | ((content: JSONContent | undefined) => void)
+    | undefined,
+  onContentError: undefined as
+    | ((props: EditorEvents["contentError"]) => void)
+    | undefined,
+}))
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { pageId: "1", siteId: "1" } }),
+}))
+
+vi.mock("~/utils/trpc", () => ({
+  trpc: {
+    page: {
+      updatePageBlob: {
+        useMutation: () => ({ mutate: noop, isPending: false }),
+      },
+    },
+    useUtils: () => ({
+      page: {
+        readPage: { invalidate: noop },
+        readPageAndBlob: { invalidate: noop },
+      },
+    }),
+  },
+}))
+
+vi.mock("../../hooks/useTextEditor", () => ({
+  useTextEditor: ({
+    handleChange,
+    onContentError,
+  }: {
+    handleChange: (content: JSONContent | undefined) => void
+    onContentError?: (props: EditorEvents["contentError"]) => void
+  }) => {
+    editorCallbacks.handleChange = handleChange
+    editorCallbacks.onContentError = onContentError
+    return {}
+  },
+}))
+
+vi.mock("../form-builder/renderers/TipTapEditor", () => ({
+  TiptapTextEditor: () => <div data-testid="tiptap-editor" />,
+}))
+
+const VALID_PROSE: ProseProps = {
+  type: "prose",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Hello world" }],
+    },
+  ],
+}
+
+const PAGE_STATE: IsomerSchema = {
+  version: "0.1.0",
+  layout: "content",
+  page: { title: "About us", description: "About us" },
+  content: [VALID_PROSE],
+}
+
+const renderComponent = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <EditorDrawerProvider
+        initialPageState={PAGE_STATE}
+        type={ResourceType.Page}
+        permalink="/about"
+        siteId={1}
+        pageId={1}
+        updatedAt={new Date()}
+        title="About us"
+      >
+        <TipTapProseComponent content={VALID_PROSE} />
+      </EditorDrawerProvider>
+    </ThemeProvider>,
+  )
+
+describe("TipTapProseComponent", () => {
+  it("keeps Save disabled after a TipTap schema error even if later content is valid prose", () => {
+    // Arrange
+    renderComponent()
+    const saveButton = screen.getByRole("button", { name: "Save changes" })
+    expect(saveButton).toBeEnabled()
+
+    // Act
+    act(() => {
+      editorCallbacks.onContentError?.({
+        error: new Error("invalid schema"),
+      } as EditorEvents["contentError"])
+    })
+    act(() => {
+      editorCallbacks.handleChange?.(VALID_PROSE)
+    })
+
+    // Assert
+    expect(saveButton).toBeDisabled()
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/constants.ts
@@ -9,3 +9,6 @@ export const COLLECTION_DISPLAY_SAVED_MESSAGE =
 
 export const FILTER_SAVED_MESSAGE =
   "Filter saved. Remember to publish the changes so that other users can use the new filter options."
+
+export const PROSE_CONTENT_LOAD_ERROR_MESSAGE =
+  "Some of this block's content could not be loaded. Fix it before saving."

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/selectTableCellContent.browser.test.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/selectTableCellContent.browser.test.ts
@@ -1,4 +1,5 @@
 import type { JSONContent } from "@tiptap/react"
+import { TableRow } from "@tiptap/extension-table-row"
 import { Editor } from "@tiptap/react"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { page, userEvent } from "vitest/browser"
@@ -9,7 +10,6 @@ import {
   IsomerTableCell,
   IsomerTableHeader,
   PROSE_EXTENSIONS,
-  TableRow,
 } from "../constants"
 import { selectTableCellContent } from "../selectTableCellContent"
 

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/tiptapContentCheck.test.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/tiptapContentCheck.test.ts
@@ -1,0 +1,53 @@
+import { Editor } from "@tiptap/react"
+import { describe, expect, it } from "vitest"
+
+import { BASE_EXTENSIONS, TEXT_EDITOR_EXTRA_EXTENSIONS } from "../constants"
+
+const proseEditorExtensions = [
+  ...BASE_EXTENSIONS,
+  ...TEXT_EDITOR_EXTRA_EXTENSIONS,
+]
+
+describe("TipTap enableContentCheck", () => {
+  it("should not emit contentError for stylized unicode", () => {
+    const content = {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "𝐎𝐟𝐟𝐢𝐜𝐢𝐚𝐥" }],
+        },
+      ],
+    }
+    let contentError: Error | undefined
+
+    const editor = new Editor({
+      extensions: proseEditorExtensions,
+      content,
+      enableContentCheck: true,
+      onContentError: ({ error }) => {
+        contentError = error
+      },
+    })
+
+    expect(contentError).toBeUndefined()
+    editor.destroy()
+  })
+
+  it("should emit contentError for empty prose content", () => {
+    const content = { type: "prose", content: [] }
+    let contentError: Error | undefined
+
+    const editor = new Editor({
+      extensions: proseEditorExtensions,
+      content,
+      enableContentCheck: true,
+      onContentError: ({ error }) => {
+        contentError = error
+      },
+    })
+
+    expect(contentError).toBeDefined()
+    editor.destroy()
+  })
+})

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/useTextEditor.test.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/useTextEditor.test.ts
@@ -4,25 +4,20 @@ import type { JSONContent } from "@tiptap/react"
 import { renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const useEditorMock = vi.fn()
+const useEditorMock = vi.fn((_options: unknown): object => ({}))
 
-vi.mock("@tiptap/react", async (importActual) => {
-  const actual = (await importActual()) as Record<string, unknown>
-  return {
-    ...actual,
-    useEditor: (...args: unknown[]) => useEditorMock(...args),
-  }
-})
+vi.mock("@tiptap/react", () => ({
+  useEditor: (options: unknown): object => useEditorMock(options),
+}))
 
 import { useTextEditor } from "../useTextEditor"
 
 describe("useTextEditor", () => {
   beforeEach(() => {
-    useEditorMock.mockReturnValue({})
+    useEditorMock.mockClear()
   })
 
   it("passes enableContentCheck and onContentError to useEditor", () => {
-    // Arrange
     const handleChange = vi.fn()
     const onContentError = vi.fn()
     const data: JSONContent = {
@@ -30,10 +25,8 @@ describe("useTextEditor", () => {
       content: [{ type: "paragraph" }],
     }
 
-    // Act
     renderHook(() => useTextEditor({ data, handleChange, onContentError }))
 
-    // Assert
     expect(useEditorMock).toHaveBeenCalledWith(
       expect.objectContaining({
         enableContentCheck: true,

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/useTextEditor.test.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/useTextEditor.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import type { JSONContent } from "@tiptap/react"
+import { renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const useEditorMock = vi.fn()
+
+vi.mock("@tiptap/react", async (importActual) => {
+  const actual = (await importActual()) as Record<string, unknown>
+  return {
+    ...actual,
+    useEditor: (...args: unknown[]) => useEditorMock(...args),
+  }
+})
+
+import { useTextEditor } from "../useTextEditor"
+
+describe("useTextEditor", () => {
+  beforeEach(() => {
+    useEditorMock.mockReturnValue({})
+  })
+
+  it("passes enableContentCheck and onContentError to useEditor", () => {
+    // Arrange
+    const handleChange = vi.fn()
+    const onContentError = vi.fn()
+    const data: JSONContent = {
+      type: "prose",
+      content: [{ type: "paragraph" }],
+    }
+
+    // Act
+    renderHook(() => useTextEditor({ data, handleChange, onContentError }))
+
+    // Assert
+    expect(useEditorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enableContentCheck: true,
+        onContentError,
+        content: data,
+      }),
+    )
+  })
+})

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -20,6 +20,7 @@ import { Superscript } from "@tiptap/extension-superscript"
 import { Table } from "@tiptap/extension-table"
 import { TableCell } from "@tiptap/extension-table-cell"
 import { TableHeader } from "@tiptap/extension-table-header"
+import { TableRow } from "@tiptap/extension-table-row"
 import { Text } from "@tiptap/extension-text"
 import { Underline } from "@tiptap/extension-underline"
 import { Plugin, PluginKey } from "@tiptap/pm/state"
@@ -31,7 +32,7 @@ import {
 } from "../../utils"
 import { selectTableCellContent } from "./selectTableCellContent"
 
-export { TableRow } from "@tiptap/extension-table-row"
+export { TableRow }
 
 export const HEADING_TYPE = "heading"
 export const PARAGRAPH_TYPE = "paragraph"

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -32,8 +32,6 @@ import {
 } from "../../utils"
 import { selectTableCellContent } from "./selectTableCellContent"
 
-export { TableRow }
-
 export const HEADING_TYPE = "heading"
 export const PARAGRAPH_TYPE = "paragraph"
 

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -162,3 +162,12 @@ export const IsomerHeading = Heading.extend({
 }).configure({
   levels: HEADING_LEVELS,
 })
+
+export const TEXT_EDITOR_EXTRA_EXTENSIONS: Extensions = [
+  ...PROSE_EXTENSIONS,
+  TableRow,
+  IsomerTable,
+  IsomerTableCell,
+  IsomerTableHeader,
+  IsomerHeading,
+]

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/useTextEditor.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/useTextEditor.ts
@@ -1,5 +1,5 @@
 import type { ControlProps } from "@jsonforms/core"
-import type { Extensions, JSONContent } from "@tiptap/react"
+import type { EditorEvents, Extensions, JSONContent } from "@tiptap/react"
 import CharacterCount from "@tiptap/extension-character-count"
 import { useEditor } from "@tiptap/react"
 import TextDirection from "tiptap-text-direction"
@@ -15,21 +15,25 @@ import {
   PARAGRAPH_TYPE,
   PROSE_EXTENSIONS,
   TableRow,
+  TEXT_EDITOR_EXTRA_EXTENSIONS,
 } from "./constants"
 
 export interface BaseEditorProps {
   data: ControlProps["data"]
   handleChange: (content: JSONContent | undefined) => void
+  onContentError?: (props: EditorEvents["contentError"]) => void
 }
 
 const useBaseEditor = ({
   data,
   handleChange,
+  onContentError,
   extensions,
 }: BaseEditorProps & { extensions: Extensions }) =>
   useEditor({
     immediatelyRender: false,
     shouldRerenderOnTransaction: true,
+    enableContentCheck: true,
     extensions: [
       ...BASE_EXTENSIONS,
       ...extensions,
@@ -39,6 +43,7 @@ const useBaseEditor = ({
     ],
     // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
     content: data,
+    onContentError,
     onUpdate: (e) => {
       const jsonContent = e.editor.getJSON()
       handleChange(jsonContent)
@@ -49,14 +54,7 @@ export type BaseEditorType = ReturnType<typeof useBaseEditor>
 export const useTextEditor = (props: BaseEditorProps) =>
   useBaseEditor({
     ...props,
-    extensions: [
-      ...PROSE_EXTENSIONS,
-      TableRow,
-      IsomerTable,
-      IsomerTableCell,
-      IsomerTableHeader,
-      IsomerHeading,
-    ],
+    extensions: TEXT_EDITOR_EXTRA_EXTENSIONS,
   })
 
 export const useCalloutEditor = (props: BaseEditorProps) =>

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/useTextEditor.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/useTextEditor.ts
@@ -1,6 +1,7 @@
 import type { ControlProps } from "@jsonforms/core"
 import type { EditorEvents, Extensions, JSONContent } from "@tiptap/react"
 import CharacterCount from "@tiptap/extension-character-count"
+import { TableRow } from "@tiptap/extension-table-row"
 import { useEditor } from "@tiptap/react"
 import TextDirection from "tiptap-text-direction"
 
@@ -14,7 +15,6 @@ import {
   IsomerTableHeader,
   PARAGRAPH_TYPE,
   PROSE_EXTENSIONS,
-  TableRow,
   TEXT_EDITOR_EXTRA_EXTENSIONS,
 } from "./constants"
 

--- a/apps/studio/src/features/editing-experience/utils/__tests__/inferAsProse.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/inferAsProse.test.ts
@@ -23,11 +23,7 @@ describe("inferAsProse", () => {
     expect(result).toBe(component)
   })
 
-  it("should return the component even when its text content contains stylized unicode or is otherwise schema-invalid", () => {
-    // Arrange
-    // Content that predates a content policy (or otherwise fails schema
-    // validation) should still be openable for editing, not crash the
-    // drawer. Schema validity is enforced separately at save-time, not here.
+  it("should return schema-invalid prose content without throwing", () => {
     const component: IsomerComponent = {
       type: "prose",
       content: [

--- a/apps/studio/src/features/editing-experience/utils/__tests__/inferAsProse.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/inferAsProse.test.ts
@@ -1,0 +1,71 @@
+import type { IsomerComponent } from "@opengovsg/isomer-components"
+import { describe, expect, it } from "vitest"
+
+import { inferAsProse } from "../inferAsProse"
+
+describe("inferAsProse", () => {
+  it("should return the component when it is a prose block with valid content", () => {
+    // Arrange
+    const component: IsomerComponent = {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    }
+
+    // Act
+    const result = inferAsProse(component)
+
+    // Assert
+    expect(result).toBe(component)
+  })
+
+  it("should return the component even when its text content contains stylized unicode or is otherwise schema-invalid", () => {
+    // Arrange
+    // Content that predates a content policy (or otherwise fails schema
+    // validation) should still be openable for editing, not crash the
+    // drawer. Schema validity is enforced separately at save-time, not here.
+    const component: IsomerComponent = {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "𝐎𝐟𝐟𝐢𝐜𝐢𝐚𝐥" }],
+        },
+      ],
+    }
+
+    // Act & Assert
+    expect(() => inferAsProse(component)).not.toThrow()
+  })
+
+  it("should throw when component is undefined", () => {
+    expect(() => inferAsProse(undefined)).toThrow(
+      "Expected component of type prose but got undefined",
+    )
+  })
+
+  it("should throw when component is not of type prose", () => {
+    // Arrange
+    const component: IsomerComponent = {
+      type: "callout",
+      content: {
+        type: "prose",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Hello world" }],
+          },
+        ],
+      },
+    }
+
+    // Act & Assert
+    expect(() => inferAsProse(component)).toThrow(
+      "Expected component of type prose but got type callout",
+    )
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/__tests__/isValidProse.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/isValidProse.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { isValidProse } from "../isValidProse"
+
+describe("isValidProse", () => {
+  it("should return true for valid prose content", () => {
+    // Arrange
+    const content = {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    }
+
+    // Act & Assert
+    expect(isValidProse(content)).toBe(true)
+  })
+
+  it("should return false when text content contains stylized unicode", () => {
+    // Arrange
+    const content = {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "𝐎𝐟𝐟𝐢𝐜𝐢𝐚𝐥" }],
+        },
+      ],
+    }
+
+    // Act & Assert
+    expect(isValidProse(content)).toBe(false)
+  })
+
+  it("should return false for structurally invalid content", () => {
+    // Arrange
+    // `content` requires at least one item, so an empty array is a genuine
+    // structural violation.
+    const content = {
+      type: "prose",
+      content: [],
+    }
+
+    // Act & Assert
+    expect(isValidProse(content)).toBe(false)
+  })
+
+  it("should return false for undefined", () => {
+    expect(isValidProse(undefined)).toBe(false)
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/inferAsProse.ts
+++ b/apps/studio/src/features/editing-experience/utils/inferAsProse.ts
@@ -11,10 +11,6 @@ export const inferAsProse = (component?: IsomerComponent): ProseProps => {
     )
   }
 
-  // NOTE: `ProseProps` also carries `site` (a render-time prop from
-  // `@opengovsg/isomer-components`), which `IsomerComponent` never has.
-  // TipTapProseComponent only reads the content schema fields off this
-  // value, so the cast is safe in practice despite being structurally
-  // unsound.
+  // ProseProps includes render-time `site`; TipTap only reads content fields.
   return component as ProseProps
 }

--- a/apps/studio/src/features/editing-experience/utils/inferAsProse.ts
+++ b/apps/studio/src/features/editing-experience/utils/inferAsProse.ts
@@ -1,0 +1,20 @@
+import type { IsomerComponent, ProseProps } from "@opengovsg/isomer-components"
+
+export const inferAsProse = (component?: IsomerComponent): ProseProps => {
+  if (!component) {
+    throw new Error("Expected component of type prose but got undefined")
+  }
+
+  if (component.type !== "prose") {
+    throw new Error(
+      `Expected component of type prose but got type ${component.type}`,
+    )
+  }
+
+  // NOTE: `ProseProps` also carries `site` (a render-time prop from
+  // `@opengovsg/isomer-components`), which `IsomerComponent` never has.
+  // TipTapProseComponent only reads the content schema fields off this
+  // value, so the cast is safe in practice despite being structurally
+  // unsound.
+  return component as ProseProps
+}

--- a/apps/studio/src/features/editing-experience/utils/isValidProse.ts
+++ b/apps/studio/src/features/editing-experience/utils/isValidProse.ts
@@ -1,0 +1,9 @@
+import type { ProseProps } from "@opengovsg/isomer-components"
+import { getComponentSchema } from "@opengovsg/isomer-components"
+import { ajv } from "~/utils/ajv"
+
+const proseSchema = getComponentSchema({ component: "prose" })
+
+const validate = ajv.compile<ProseProps>(proseSchema)
+
+export const isValidProse = (content: unknown): boolean => validate(content)


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 7 | +82 | -37 |
| 🧪 Test | 6 | +328 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

`IsomerString` now rejects stylized Unicode (e.g. "𝐎𝐟𝐟𝐢𝐜𝐢𝐚𝐥") on save, but Text blocks saved before this policy existed still contain such characters. Opening one of these legacy Text blocks in Studio threw inside `inferAsProse` (it ran full ajv validation and blocked navigation on any schema violation), so editors could not open the block to fix or edit it at all.

Closes https://linear.app/ogp/issue/ISOM-2349/template-handle-stylized-unicode-text-in-migrated-pages

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Text blocks now always open for editing regardless of whether their content currently satisfies the schema. `inferAsProse` (`apps/studio/src/features/editing-experience/utils/inferAsProse.ts`) is simplified from a full ajv-validating gate (which threw on any schema violation) to a plain `component.type === "prose"` runtime guard.
- Since opening no longer gates on validity, a client-side check now gates *saving* instead: a new `isValidProse` util (`apps/studio/src/features/editing-experience/utils/isValidProse.ts`) validates the block's content against the prose schema, and `TipTapProseComponent`'s "Save changes" button is disabled whenever it fails. Validity is recomputed on every edit and seeded from the block's existing content when it's first opened, so a block that's already invalid starts with Save disabled — before, the button had no validation-based disable state at all (tracked by a pre-existing `// TODO: actual validation` in the code).
- Complex (non-prose) blocks — Callout, Hero, Accordion, etc. — already behave this way today via JSONForms' per-field validation and Save-button disabling, so no change was needed there; this PR brings the Text block in line with that existing pattern.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

Rewrote `inferAsProse.test.ts` for the simplified type-guard behavior (returns the component for any prose-typed content, including stylized unicode; throws only when undefined or not type `"prose"`). Added `isValidProse.test.ts` covering valid content, stylized-unicode content, and structurally invalid content (e.g. empty `content` array).

**Manual Verification Steps**:

- [ ] Using the raw JSON editor (or a direct DB edit), set an existing Text block's content to include stylized unicode text (e.g. "𝐎𝐟𝐟𝐢𝐜𝐢𝐚𝐥"). Reload the page editor and click into that Text block from the block list — it should open normally instead of failing silently or erroring.
- [ ] With that same block open and unedited, confirm the "Save changes" button is disabled.
- [ ] Edit the offending text back to plain characters — confirm "Save changes" becomes enabled and the save succeeds.
- [ ] Open a Text block whose content is already valid — confirm "Save changes" is enabled immediately and edits save as before.
- [ ] Add a brand-new Text block, type some content, and confirm it opens and saves normally (no regression to the common path).







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR allows legacy schema-invalid Text blocks to open while moving prose-schema enforcement to the save workflow.
- Replaces opening-time AJV validation with a prose type guard.
- Validates current editor content and disables saving until it satisfies the prose schema.
- Enables TipTap content checking and surfaces malformed-content warnings.
- Adds focused coverage for legacy Unicode, structural validation, and editor configuration.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx | Adds save-time prose validation and a warning when TipTap cannot load some content. |
| apps/studio/src/features/editing-experience/hooks/useTextEditor/useTextEditor.ts | Enables TipTap content checking and forwards content errors without making the editor read-only. |
| apps/studio/src/features/editing-experience/utils/inferAsProse.ts | Narrows prose blocks by component type without rejecting legacy schema-invalid content. |
| apps/studio/src/features/editing-experience/utils/isValidProse.ts | Centralizes AJV-based prose validation for save-button gating. |

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(editing-experience): import Tab..."](https://github.com/opengovsg/isomer/commit/d9ea5cccd450eec29632f49c61ad15287c87c6e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54715639)</sub>

**Context used:**

- Knowledge Base — [Page authoring experience](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/page-authoring.md)

<!-- /greptile_comment -->