### PR TITLE
Upgrade content-disposition to v2 with named export

### DIFF
--- a/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
@@ -177,7 +177,7 @@ describe("asset.router", async () => {
         Bucket: expect.any(String),
         Key: expect.stringContaining("test-image.png"),
         ContentType: "image/png",
-        ContentDisposition: expect.stringMatching(/^inline; filename=".+"/),
+        ContentDisposition: expect.stringMatching(/^inline; filename=.+/),
         ContentLength: fileSize,
       })
     })
@@ -206,7 +206,7 @@ describe("asset.router", async () => {
         uploadConfig: {
           presignedPutUrl: "https://example.com/signed-url",
           contentType: "application/pdf",
-          contentDisposition: expect.stringMatching(/^inline; filename=".+"/),
+          contentDisposition: expect.stringMatching(/^inline; filename=.+/),
         },
       })
     })

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -84,7 +84,7 @@ describe("asset.service", () => {
 
     it("should preserve titles with path separators instead of truncating them", () => {
       const result = getContentDispositionForTitle("A/B\\C", "1/abc/doc.pdf")
-      expect(result).toBe(`inline; filename="A-B-C.pdf"`)
+      expect(result).toBe(`inline; filename=A-B-C.pdf`)
     })
 
     it("should emit valid headers for titles with RFC 5987 attr-chars ' ( ) *", () => {

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -49,7 +49,7 @@ describe("asset.service", () => {
   describe("getContentDispositionForKey", () => {
     it("should return inline with filename from key segment", () => {
       const result = getContentDispositionForKey("1/abc-uuid/test.png")
-      expect(result).toBe(`inline; filename="test.png"`)
+      expect(result).toBe(`inline; filename=test.png`)
     })
 
     it("should encode non-latin1 characters via RFC 5987 with a latin1 fallback", () => {
@@ -83,8 +83,6 @@ describe("asset.service", () => {
     })
 
     it("should preserve titles with path separators instead of truncating them", () => {
-      // content-disposition runs path.basename internally, which would truncate
-      // "A/B\\C" to "C"; path separators must be replaced before it is called.
       const result = getContentDispositionForTitle("A/B\\C", "1/abc/doc.pdf")
       expect(result).toBe(`inline; filename="A-B-C.pdf"`)
     })

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -2,7 +2,7 @@ import type { z } from "zod"
 import type { getPresignedPutUrlSchema } from "~/schemas/asset"
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
-import contentDisposition from "content-disposition"
+import { create as createContentDisposition } from "content-disposition"
 import { randomUUID } from "crypto"
 import filenamify from "filenamify"
 import { env } from "~/env.mjs"
@@ -62,7 +62,7 @@ export const getContentTypeFromKey = (key: string): string => {
  * Build Content-Disposition for signed upload (inline; filename for download hint).
  */
 export const getContentDispositionForKey = (key: string): string => {
-  return contentDisposition(getFilenameFromKey(key), { type: "inline" })
+  return createContentDisposition(getFilenameFromKey(key), { type: "inline" })
 }
 
 /**
@@ -75,11 +75,10 @@ export const getContentDispositionForTitle = (
   key: string,
 ): string => {
   const extension = getExtensionFromFilename(getFilenameFromKey(key))
-  // content-disposition runs path.basename on the filename, which would
-  // truncate a title containing "/" or "\" (e.g. "A/B" -> "B"). Replace path
-  // separators up front so the full title survives in the download filename.
+  // Strip path separators so a title like "A/B" can't be misread as a path
+  // segment in the resulting filename.
   const filename = `${title}${extension}`.replace(/[/\\]/g, "-")
-  return contentDisposition(filename, { type: "inline" })
+  return createContentDisposition(filename, { type: "inline" })
 }
 
 // Permissions for assets share the same permissions as resources preferentially

--- a/apps/studio/src/types/shims.d.ts
+++ b/apps/studio/src/types/shims.d.ts
@@ -10,14 +10,3 @@ declare module "jsdom" {
     readonly window: Window & typeof globalThis
   }
 }
-
-// content-disposition does not ship its own TypeScript declarations.
-// This minimal stub covers the subset used in asset.service.ts.
-declare module "content-disposition" {
-  interface Options {
-    type?: "attachment" | "inline"
-    fallback?: string | boolean
-  }
-  function contentDisposition(filename?: string, options?: Options): string
-  export = contentDisposition
-}


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +5 | -17 |
| 🧪 Test | 2 | +4 | -6 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The `content-disposition` package has been updated to v2, which changed from a default export to a named `create` export. The codebase needs to be updated to use the new API.

## Solution

**Breaking Changes**

- [ ] No - this PR is backwards compatible

**Improvements**:

- Updated import statement to use the named `create` export from `content-disposition` v2
- Removed the custom TypeScript declaration stub for `content-disposition` from `shims.d.ts` (the package now ships with proper TypeScript declarations)
- Updated all call sites to use `createContentDisposition` instead of `contentDisposition`
- Simplified comments to be more concise and focused on the actual behavior

**Bug Fixes**:

- Fixed regex patterns in tests to match the actual output format from `content-disposition` v2 (filenames are no longer quoted by default)

## Tests

Existing unit tests in `asset.service.test.ts` and `asset.router.test.ts` have been updated to reflect the new output format from `content-disposition` v2. All tests pass with the updated expectations.

https://claude.ai/code/session_01Tc91nGJuJAkMN4ohcKqgaX