### PR TITLE
fix(components): fall back to a default title for iframe embeds missing one

### DIFF
--- a/packages/components/src/templates/next/components/complex/Iframe/Iframe.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Iframe/Iframe.stories.tsx
@@ -47,3 +47,14 @@ export const FormSG: Story = {
     title: "Isomer Contact Us Form",
   },
 }
+
+// Simulates a blank title (e.g. legacy content saved before `title` was
+// required, which arrives as `undefined` and hits the same fallback).
+// The rendered iframe should still get a non-empty, descriptive title.
+export const MissingTitle: Story = {
+  args: {
+    content:
+      '<iframe style="border:0" height="450" width="600" src="https://www.onemap.gov.sg/minimap/minimap.html"></iframe>',
+    title: "",
+  },
+}

--- a/packages/components/src/utils/__tests__/getSanitizedIframeWithTitle.test.ts
+++ b/packages/components/src/utils/__tests__/getSanitizedIframeWithTitle.test.ts
@@ -39,6 +39,24 @@ describe("getSanitizedIframeWithTitle", () => {
     expect(getSanitizedIframeWithTitle("plain text", "Text embed")).toBeNull()
   })
 
+  it("falls back to a default title when title is an empty string", () => {
+    const iframe = getSanitizedIframeWithTitle(
+      '<iframe src="https://example.com"></iframe>',
+      "",
+    )
+
+    expect(iframe?.getAttribute("title")).toBe("Embedded content")
+  })
+
+  it("falls back to a default title when title is missing (legacy content)", () => {
+    const iframe = getSanitizedIframeWithTitle(
+      '<iframe src="https://example.com"></iframe>',
+      undefined,
+    )
+
+    expect(iframe?.getAttribute("title")).toBe("Embedded content")
+  })
+
   it("does not leak hooks across multiple calls", () => {
     for (let i = 0; i < 10; i++) {
       getSanitizedIframeWithTitle(

--- a/packages/components/src/utils/getSanitizedIframeWithTitle.ts
+++ b/packages/components/src/utils/getSanitizedIframeWithTitle.ts
@@ -22,9 +22,18 @@ const IFRAME_LAYOUT_ATTRIBUTES = {
   class: "absolute top-0 left-0 bottom-0 right-0",
 } as const
 
+// Fallback for iframe embeds saved before `title` existed on the schema, or
+// saved with a blank value — without this, legacy embeds render with no
+// accessible name (or literally `title="undefined"`), which a11y scanners
+// flag as "Frames and iframes must have descriptive titles".
+const DEFAULT_IFRAME_TITLE = "Embedded content"
+
 // Sanitize iframe embeds to remove any potentially harmful attributes
 // and to insert the minimal accessibility
-export const getSanitizedIframeWithTitle = (content: string, title: string) => {
+export const getSanitizedIframeWithTitle = (
+  content: string,
+  title: string | undefined,
+) => {
   const sanitizedFragment = DOMPurify.sanitize(content, {
     ALLOWED_TAGS: ["iframe"],
     ALLOWED_ATTR: IFRAME_ALLOWED_ATTRIBUTES,
@@ -37,7 +46,7 @@ export const getSanitizedIframeWithTitle = (content: string, title: string) => {
     return null
   }
 
-  iframe.setAttribute("title", title)
+  iframe.setAttribute("title", title || DEFAULT_IFRAME_TITLE)
   iframe.setAttribute("height", IFRAME_LAYOUT_ATTRIBUTES.height)
   iframe.setAttribute("width", IFRAME_LAYOUT_ATTRIBUTES.width)
   iframe.setAttribute("class", IFRAME_LAYOUT_ATTRIBUTES.class)


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +11 | -2 |
| 🧪 Test | 2 | +29 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
- Fixes [ISOM-2538](https://linear.app/ogp/issue/ISOM-2538/add-titles-to-existing-iframe-embeds): Oobee flagged a published page's OneMap iframe embed with "Frames and iframes must have descriptive titles".
- The `iframe` block's `title` field, editor form, and schema have supported setting a title since mid-2024 — but the render-time utility (`getSanitizedIframeWithTitle`) never defended against a falsy `title`. Legacy content saved before the field existed (or saved blank) has no `title` key at all, so it rendered with a literal `title="undefined"` attribute (since `setAttribute` stringifies `undefined`), which a11y scanners correctly flag.
- Adds the same `title || <default>` fallback already used by `Map.tsx` and `LiteYouTubeEmbed.tsx` for their respective embed types, using a generic `"Embedded content"` default for the catch-all `Iframe` component.
- No schema change, no DB migration needed — the published-site render path reads stored page JSON directly without re-validating against the schema, so this fix takes effect for existing legacy content on the next rebuild/publish of the affected page(s).

## Test plan
- [x] Added unit tests for empty-string and `undefined` title in `getSanitizedIframeWithTitle.test.ts` (initially failing, now passing)
- [x] Added a `MissingTitle` Storybook story for `Iframe` demonstrating the fallback
- [x] `pnpm typecheck` passes across the monorepo
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm format` passes
- [x] Full `vitest` suite for `packages/components` passes (560/560)
- [ ] Rebuild/republish the previously-flagged page once this merges, so the fix takes effect on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)