### PR TITLE
fix(publishing): drop self-referential redirects at publish time (ISOM-2525)

### DIFF
--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -881,6 +881,66 @@ describe("folder.router", async () => {
         expect(redirects).toHaveLength(0)
       })
 
+      it("reclaims redirects that point back at descendants after a folder rename", async () => {
+        // Arrange — reproduces the folder-swap sequence from ISOM-2525. Pages
+        // were first moved from /students to /students1, creating exact
+        // /students/... redirects to those pages. Renaming the new folder back
+        // to /students makes those sources the pages' live URLs again.
+        const { site, folder, child } = await setupFolderWithPublishedChild({
+          folderPermalink: "students1",
+          childPermalink: "class-exam-timetable",
+        })
+        const { page: sibling } = await setupPageResource({
+          siteId: site.id,
+          parentId: folder.id,
+          resourceType: ResourceType.Page,
+          permalink: "quick-links-information",
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+        await db
+          .insertInto("Redirect")
+          .values(
+            [child, sibling].map((page) => ({
+              siteId: site.id,
+              source: `/students/${page.permalink}`,
+              destination: getReferenceLink({
+                siteId: String(site.id),
+                resourceId: page.id,
+              }),
+            })),
+          )
+          .execute()
+
+        // Act
+        await caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "Students",
+          permalink: "students",
+          shouldCreateRedirect: false,
+        })
+
+        // Assert — both self-referential redirects are soft-deleted in the
+        // rename transaction, so neither can shadow its now-live page.
+        const redirects = await db
+          .selectFrom("Redirect")
+          .select(["source", "deletedAt"])
+          .where("siteId", "=", site.id)
+          .orderBy("source")
+          .execute()
+        expect(redirects).toEqual([
+          {
+            source: "/students/class-exam-timetable",
+            deletedAt: expect.any(Date),
+          },
+          {
+            source: "/students/quick-links-information",
+            deletedAt: expect.any(Date),
+          },
+        ])
+      })
+
       it("allows moving a folder back to its old path, reclaiming its own wildcard", async () => {
         // Arrange — first move /old-folder -> /new-folder creates the wildcard
         // /old-folder/* -> folder.

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -74,7 +74,10 @@ SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
 // stripped to match getConvertedPermalink in index.ts. Non-reference
 // destinations (literal paths, external https URLs) pass through untouched. A
 // reference resolves to NULL — and the redirect is dropped — when nothing live
-// matches (deleted/unpublished target, or a reference to another site).
+// matches (deleted/unpublished target, or a reference to another site). A
+// redirect whose resolved destination is its own source is also dropped: this
+// can happen when a later folder rename moves the referenced page back onto the
+// URL the redirect originally preserved (ISOM-2525).
 export const GET_REDIRECTS = `
 WITH RECURSIVE
     -- Distinct resourceIds referenced by this site's own redirects. The
@@ -134,5 +137,22 @@ SELECT source, destination FROM (
         AND root."resourceId" = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
     WHERE redirect."siteId" = $1 AND redirect."deletedAt" IS NULL
 ) resolved_redirects
-WHERE resolved_redirects.destination IS NOT NULL;
+WHERE resolved_redirects.destination IS NOT NULL
+    -- Compare exact sources directly. For a wildcard, compare its prefix: the
+    -- edge resolver appends the matched remainder to the destination, so
+    -- "/students/*" -> "/students" loops too. Query/fragment suffixes are not
+    -- sent in the S3 object path and therefore cannot make a self-redirect safe.
+    AND LOWER(
+        CASE
+            WHEN RIGHT(resolved_redirects.source, 2) = '/*'
+            THEN LEFT(resolved_redirects.source, LENGTH(resolved_redirects.source) - 2)
+            ELSE resolved_redirects.source
+        END
+    ) <> LOWER(
+        REGEXP_REPLACE(
+            REGEXP_REPLACE(resolved_redirects.destination, '[?#].*$', ''),
+            '/+$',
+            ''
+        )
+    );
 `

--- a/tooling/build/scripts/publishing/tests/publishing.test.ts
+++ b/tooling/build/scripts/publishing/tests/publishing.test.ts
@@ -378,4 +378,33 @@ describe("redirects.json", () => {
       redirects.find((redirect) => redirect.source === "/ref-wrong-site"),
     ).toBeUndefined()
   })
+
+  it("drops a redirect whose reference resolves back to its own source", () => {
+    // Arrange / Act
+    const redirects = readOutput("redirects.json") as {
+      source: string
+      destination: string
+    }[]
+
+    // Assert — publishing this row would replace the live page object with a
+    // redirect to the same URL, causing the loop reported in ISOM-2525.
+    expect(
+      redirects.find((redirect) => redirect.source === "/about/our-team"),
+    ).toBeUndefined()
+  })
+
+  it("drops a wildcard whose folder reference resolves back to its own prefix", () => {
+    // Arrange / Act
+    const redirects = readOutput("redirects.json") as {
+      source: string
+      destination: string
+    }[]
+
+    // Assert — this exercises GET_REDIRECTS' wildcard prefix branch. The edge
+    // resolver would otherwise append each matched remainder to /about and
+    // redirect every /about/... request back to itself.
+    expect(
+      redirects.find((redirect) => redirect.source === "/about/*"),
+    ).toBeUndefined()
+  })
 })

--- a/tooling/build/scripts/publishing/tests/seed.ts
+++ b/tooling/build/scripts/publishing/tests/seed.ts
@@ -353,6 +353,21 @@ export const seedPublishingSite = async () => {
     source: "/ref-page",
     destination: `[resource:${siteId}:${ourTeamPageId}]`,
   })
+  // Reproduces ISOM-2525: a redirect created before a folder rename now
+  // resolves to the exact same live URL as its source and must not be emitted.
+  await seedRedirect({
+    siteId,
+    source: "/about/our-team",
+    destination: `[resource:${siteId}:${ourTeamPageId}]`,
+  })
+  // Folder variant of the same failure: the wildcard resolver appends the
+  // matched remainder, so /about/* -> /about sends every request back to the
+  // exact path it started from.
+  await seedRedirect({
+    siteId,
+    source: "/about/*",
+    destination: `[resource:${siteId}:${aboutFolderId}]`,
+  })
   // A reference to an index page resolves to its folder (the "_index" segment
   // is stripped, matching what the editor displays)
   await seedRedirect({

--- a/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
+++ b/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   buildManifest,
+  isSelfReferentialRedirect,
   normalizeSource,
   parseUploadCliArgs,
   partitionRedirects,
@@ -116,6 +117,50 @@ describe("normalizeSource", () => {
   it("rejects malformed percent-encoding", () => {
     // Arrange / Act / Assert — a lone "%" is not a valid escape sequence
     expect(normalizeSource("/foo%bar")).toBeNull()
+  })
+})
+
+describe("isSelfReferentialRedirect", () => {
+  it("detects an exact redirect whose resource reference resolved back to its source", () => {
+    expect(
+      isSelfReferentialRedirect({
+        source: "/resources/students/class-exam-timetable",
+        destination: "/resources/students/class-exam-timetable",
+      }),
+    ).toBe(true)
+  })
+
+  it("compares the request path after percent-decoding and removing query or fragment suffixes", () => {
+    expect(
+      isSelfReferentialRedirect({
+        source: "/students/class%2Dexam%2Dtimetable",
+        destination: "/students/class-exam-timetable?year=2026#schedule",
+      }),
+    ).toBe(true)
+  })
+
+  it("detects a wildcard that points back at its own prefix", () => {
+    expect(
+      isSelfReferentialRedirect({
+        source: "/resources/students/*",
+        destination: "/resources/students",
+      }),
+    ).toBe(true)
+  })
+
+  it("allows redirects to a different internal path or an external URL", () => {
+    expect(
+      isSelfReferentialRedirect({
+        source: "/resources/students/*",
+        destination: "/resources/alumni",
+      }),
+    ).toBe(false)
+    expect(
+      isSelfReferentialRedirect({
+        source: "/resources/students",
+        destination: "https://www.example.gov.sg/resources/students",
+      }),
+    ).toBe(false)
   })
 })
 

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -99,6 +99,29 @@ export function normalizeSource(source: string): string | null {
   return trimmed
 }
 
+// A reference destination has already been resolved to a path by GET_REDIRECTS
+// before this script runs. Compare the paths as CloudFront will see them:
+// percent-decoded, slash-normalised and without a query/fragment (neither is
+// part of the S3 object key). For a wildcard, compare its prefix because the
+// edge resolver appends the matched remainder to the destination; e.g.
+// "/students/*" -> "/students" also redirects every request back to itself.
+// Exported for focused regression coverage of this final upload boundary.
+export function isSelfReferentialRedirect({
+  source,
+  destination,
+}: Redirect): boolean {
+  if (!destination.startsWith("/")) return false
+
+  const sourcePath = source.endsWith("/*") ? source.slice(0, -2) : source
+  const destinationPath = destination.split(/[?#]/, 1)[0]
+  const normalizedSource = normalizeSource(sourcePath)
+  const normalizedDestination = destinationPath
+    ? normalizeSource(destinationPath)
+    : null
+
+  return normalizedSource !== null && normalizedSource === normalizedDestination
+}
+
 export const MANIFEST_KEY_SUFFIX = "_redirects/manifest.json"
 
 // A stored source is a wildcard ("…/*") — those go in the manifest for the edge
@@ -235,7 +258,17 @@ async function main(): Promise<void> {
   // Partition BEFORE per-kind normalisation: wildcard sources must not go
   // through normalizeSource (it strips the leading slash and would mangle the
   // "/*"). Their stored sources are already canonical (written by the schema).
-  const { exact: rawExact, manifestEntries } = partitionRedirects(raw)
+  // GET_REDIRECTS drops self-references too, but enforce the invariant again at
+  // the final upload boundary. This also protects custom/stale redirects.json
+  // inputs and catches percent-encoded sources after CloudFront normalisation.
+  const publishable = raw.filter((redirect) => {
+    if (!isSelfReferentialRedirect(redirect)) return true
+    console.warn(
+      `Skipping self-referential redirect: ${redirect.source} -> ${redirect.destination}`,
+    )
+    return false
+  })
+  const { exact: rawExact, manifestEntries } = partitionRedirects(publishable)
 
   // Exact: normalise the S3 key (decode %-encoding, strip slashes, safety checks).
   const seen = new Set<string>()


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +56 | -3 |
| 🧪 Test | 4 | +149 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

A redirect whose destination resolves back to its own source takes the live page down.

At publish time, every exact redirect is written to S3 as a 0-byte object keyed by its source path, carrying the destination in `x-amz-meta-redirect-destination`. That object sits at exactly the same key a real page publishes to. So when a redirect's source and its resolved destination are the same path, the redirect object replaces the page and CloudFront answers every request for that URL with a redirect to itself — an infinite loop instead of the page.

This is reachable through ordinary editing. A page move mints a `/old/path -> [resource:…]` redirect that follows the page. If a later folder rename moves that same page back onto `/old/path`, the reference now resolves to the redirect's own source and the redirect starts shadowing the page it was created to preserve. That is what happened to the class exam timetable page.

The same failure exists for wildcards. The edge resolver appends the matched remainder to the destination, so `/students/* -> /students` sends `/students/anything` back to `/students/anything`.

Closes ISOM-2525

## Solution

Enforce "a redirect must not point at its own source" at both publish-time boundaries.

1. **`GET_REDIRECTS` (`tooling/build/scripts/publishing/queries.ts`)** — after each `[resource:…]` reference is resolved to a live permalink, drop any row whose destination now equals its source. Query strings and fragments are stripped before comparing because neither reaches the S3 object path, so neither can make a self-redirect safe. A wildcard is compared on its prefix (`/students/*` against `/students`) to match the edge resolver's remainder-appending behaviour.

2. **`uploadRedirects.ts`** — re-check the same invariant on the rows read from `redirects.json`, immediately before partitioning into exact objects and manifest entries, and log a warning for each row skipped. This is not redundant: it covers a stale or hand-written `redirects.json`, and it percent-decodes both sides (via the existing `normalizeSource`), which the SQL comparison cannot do. Sources are stored percent-encoded but CloudFront decodes the request path before fetching from S3, so `/a%2Db` and `/a-b` are the same object.

Studio already soft-deletes these redirects when a rename makes a descendant reclaim its own URL (`assertDescendantsNotShadowed`). This PR covers the rows that are already in that state in existing sites, which no rename will pass over again.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

A self-referential redirect is unreachable by construction — the loop means the URL serves nothing — so no working redirect stops working. The rows are left in the `Redirect` table and still appear on the Redirections page; only publishing skips them.

**Bug Fixes**:

- Redirects whose resolved destination equals their own source are no longer published, so the page at that URL is served instead of an infinite redirect loop.
- Wildcard redirects pointing back at their own prefix are excluded from the redirect manifest for the same reason.

**Improvements**:

- Skipped rows are logged in the build output (`Skipping self-referential redirect: <source> -> <destination>`), so the reason a redirect did not publish is visible in the build log rather than silent.

## Before & After Screenshots

Not applicable — this changes the publishing pipeline and has no UI surface.

**BEFORE**: requesting the affected URL returned `ERR_TOO_MANY_REDIRECTS`.

**AFTER**: the same URL serves the published page.

## Tests

Automated coverage added at both layers:

- `tooling/build/scripts/publishing/tests/publishing.test.ts` — two cases against a real Postgres container and the full publishing script, asserting that a self-referential exact redirect and a self-referential folder wildcard are both absent from the generated `redirects.json`. Seeded in `tests/seed.ts` as the ISOM-2525 reproduction.
- `tooling/build/scripts/publishing/tests/uploadRedirects.test.ts` — unit coverage of `isSelfReferentialRedirect` for the exact case, the percent-decoded/query-suffixed case, the wildcard-prefix case, and the two negatives (different internal path, external URL).
- `apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts` — regression test for the originating sequence: pages moved to `/students1`, then the folder renamed back to `/students`, asserting both descendant redirects are soft-deleted in the rename transaction.

Full suites run locally and passing: `pnpm test` and `pnpm test-ci:build` in `tooling/build/scripts/publishing` (45 + 4), and the `apps/studio` unit suite (1784 passed, 41 skipped).

**Manual Verification Steps**:

- [ ] On staging, pick a site with a published page in a folder — e.g. `/students/class-exam-timetable`.
- [ ] Move the page to a different folder (`/students1/class-exam-timetable`), leaving "create a redirect" enabled. Confirm a `/students/class-exam-timetable` redirect now appears on the Redirections page.
- [ ] Rename the `students1` folder back to `students`, so the page returns to `/students/class-exam-timetable` — the exact URL the redirect points at.
- [ ] Publish the site and wait for the build to finish.
- [ ] Open `https://<site>/students/class-exam-timetable` in a browser. Confirm the page renders, rather than failing with `ERR_TOO_MANY_REDIRECTS` or an equivalent redirect-loop error.
- [ ] Confirm redirects that are still valid continue to work: open the URL of an unrelated existing redirect on the same site and confirm it still lands on its destination.
- [ ] Repeat for the folder case: with a live `/about/*` wildcard whose destination resolves to `/about`, publish and confirm `/about/<any-child>` resolves normally instead of looping.

**New scripts**:

None.

**New dependencies**:

None.

**New dev dependencies**:

None.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR filters self-referential exact and wildcard redirects at query generation and immediately before upload, preventing redirect objects from shadowing their live destinations.
- Resolves resource-reference destinations before comparing redirect paths.
- Normalizes encoded paths, query strings, fragments, and wildcard prefixes at the upload boundary.
- Adds publishing and folder-rename regression coverage for the ISOM-2525 sequence.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR needs a fix before merging because its advertised upload-time protection still permits a root wildcard self-loop from custom or stale redirect input.

The DB-generated path rejects root wildcards, but the directly supported redirects-file input can pass `/* -> /` through the new guard and into the wildcard manifest, where it can redirect every matched request back to itself.

**Files Needing Attention:** tooling/build/scripts/publishing/uploadRedirects.ts and tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publishing/queries.ts | Adds SQL filtering for resolved exact and wildcard redirects that point back to their own source. |
| tooling/build/scripts/publishing/uploadRedirects.ts | Adds a final normalized self-reference filter, but fails to reject the root wildcard `/* -> /` for custom or stale input files. |
| tooling/build/scripts/publishing/tests/uploadRedirects.test.ts | Covers common exact, encoded, wildcard, and external destinations but omits the root-wildcard boundary case. |
| tooling/build/scripts/publishing/tests/publishing.test.ts | Verifies DB-derived exact and folder wildcard self-references are excluded from generated redirects. |
| tooling/build/scripts/publishing/tests/seed.ts | Seeds exact and wildcard reproductions of the reported redirect loop. |
| apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts | Adds regression coverage confirming folder renames soft-delete descendant redirects that reclaim their live URLs. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Redirect rows] --> B[GET_REDIRECTS]
  B --> C{Self-referential?}
  C -->|Yes| D[Drop row]
  C -->|No| E[redirects.json]
  E --> F[Upload-time normalization]
  F --> G{Self-referential?}
  G -->|Yes| H[Warn and skip]
  G -->|No, exact| I[S3 redirect object]
  G -->|No, wildcard| J[Redirect manifest]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233243%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3243&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2FuploadRedirects.ts%3A115-122%0A**Root%20wildcard%20bypasses%20loop%20guard**%0A%0AWhen%20a%20custom%20or%20stale%20%60redirects.json%60%20contains%20%60%2F*%20-%3E%20%2F%60%2C%20stripping%20the%20wildcard%20produces%20an%20empty%20path%20that%20%60normalizeSource%60%20rejects%2C%20so%20the%20new%20guard%20retains%20the%20row%20and%20emits%20it%20into%20the%20wildcard%20manifest%2C%20causing%20every%20matched%20URL%20to%20redirect%20to%20itself.%0A%0A%60%60%60suggestion%0A%20%20const%20sourcePath%20%3D%20source.endsWith%28%22%2F*%22%29%20%3F%20source.slice%280%2C%20-2%29%20%3A%20source%0A%20%20const%20destinationPath%20%3D%20destination.split%28%2F%5B%3F%23%5D%2F%2C%201%29%5B0%5D%0A%20%20const%20normalizedSource%20%3D%20sourcePath%20%3D%3D%3D%20%22%22%20%3F%20%22%22%20%3A%20normalizeSource%28sourcePath%29%0A%20%20const%20normalizedDestination%20%3D%0A%20%20%20%20destinationPath%20%3D%3D%3D%20%22%2F%22%0A%20%20%20%20%20%20%3F%20%22%22%0A%20%20%20%20%20%20%3A%20destinationPath%0A%20%20%20%20%20%20%20%20%3F%20normalizeSource%28destinationPath%29%0A%20%20%20%20%20%20%20%20%3A%20null%0A%0A%20%20return%20normalizedSource%20!%3D%3D%20null%20%26%26%20normalizedSource%20%3D%3D%3D%20normalizedDestination%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3243&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2FuploadRedirects.ts%3A115-122%0A**Root%20wildcard%20bypasses%20loop%20guard**%0A%0AWhen%20a%20custom%20or%20stale%20%60redirects.json%60%20contains%20%60%2F*%20-%3E%20%2F%60%2C%20stripping%20the%20wildcard%20produces%20an%20empty%20path%20that%20%60normalizeSource%60%20rejects%2C%20so%20the%20new%20guard%20retains%20the%20row%20and%20emits%20it%20into%20the%20wildcard%20manifest%2C%20causing%20every%20matched%20URL%20to%20redirect%20to%20itself.%0A%0A%60%60%60suggestion%0A%20%20const%20sourcePath%20%3D%20source.endsWith%28%22%2F*%22%29%20%3F%20source.slice%280%2C%20-2%29%20%3A%20source%0A%20%20const%20destinationPath%20%3D%20destination.split%28%2F%5B%3F%23%5D%2F%2C%201%29%5B0%5D%0A%20%20const%20normalizedSource%20%3D%20sourcePath%20%3D%3D%3D%20%22%22%20%3F%20%22%22%20%3A%20normalizeSource%28sourcePath%29%0A%20%20const%20normalizedDestination%20%3D%0A%20%20%20%20destinationPath%20%3D%3D%3D%20%22%2F%22%0A%20%20%20%20%20%20%3F%20%22%22%0A%20%20%20%20%20%20%3A%20destinationPath%0A%20%20%20%20%20%20%20%20%3F%20normalizeSource%28destinationPath%29%0A%20%20%20%20%20%20%20%20%3A%20null%0A%0A%20%20return%20normalizedSource%20!%3D%3D%20null%20%26%26%20normalizedSource%20%3D%3D%3D%20normalizedDestination%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3243&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feature%2Fisom-2525-investigate-redirect-loop-for-class-exam-timetable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fisom-2525-investigate-redirect-loop-for-class-exam-timetable%22.%0A%0A%23%23%23%20Issue%201%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2FuploadRedirects.ts%3A115-122%0A**Root%20wildcard%20bypasses%20loop%20guard**%0A%0AWhen%20a%20custom%20or%20stale%20%60redirects.json%60%20contains%20%60%2F*%20-%3E%20%2F%60%2C%20stripping%20the%20wildcard%20produces%20an%20empty%20path%20that%20%60normalizeSource%60%20rejects%2C%20so%20the%20new%20guard%20retains%20the%20row%20and%20emits%20it%20into%20the%20wildcard%20manifest%2C%20causing%20every%20matched%20URL%20to%20redirect%20to%20itself.%0A%0A%60%60%60suggestion%0A%20%20const%20sourcePath%20%3D%20source.endsWith%28%22%2F*%22%29%20%3F%20source.slice%280%2C%20-2%29%20%3A%20source%0A%20%20const%20destinationPath%20%3D%20destination.split%28%2F%5B%3F%23%5D%2F%2C%201%29%5B0%5D%0A%20%20const%20normalizedSource%20%3D%20sourcePath%20%3D%3D%3D%20%22%22%20%3F%20%22%22%20%3A%20normalizeSource%28sourcePath%29%0A%20%20const%20normalizedDestination%20%3D%0A%20%20%20%20destinationPath%20%3D%3D%3D%20%22%2F%22%0A%20%20%20%20%20%20%3F%20%22%22%0A%20%20%20%20%20%20%3A%20destinationPath%0A%20%20%20%20%20%20%20%20%3F%20normalizeSource%28destinationPath%29%0A%20%20%20%20%20%20%20%20%3A%20null%0A%0A%20%20return%20normalizedSource%20!%3D%3D%20null%20%26%26%20normalizedSource%20%3D%3D%3D%20normalizedDestination%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tooling/build/scripts/publishing/uploadRedirects.ts:115-122
**Root wildcard bypasses loop guard**

When a custom or stale `redirects.json` contains `/* -> /`, stripping the wildcard produces an empty path that `normalizeSource` rejects, so the new guard retains the row and emits it into the wildcard manifest, causing every matched URL to redirect to itself.

```suggestion
  const sourcePath = source.endsWith("/*") ? source.slice(0, -2) : source
  const destinationPath = destination.split(/[?#]/, 1)[0]
  const normalizedSource = sourcePath === "" ? "" : normalizeSource(sourcePath)
  const normalizedDestination =
    destinationPath === "/"
      ? ""
      : destinationPath
        ? normalizeSource(destinationPath)
        : null

  return normalizedSource !== null && normalizedSource === normalizedDestination
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(publishing): drop self-referential r..."](https://github.com/opengovsg/isomer/commit/cdf87820322936e99bee67b37c811e853862f383) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56954659)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->