### PR TITLE
fix(components): support legacy "info" callout variant

### DIFF
--- a/packages/components/src/interfaces/complex/Callout.ts
+++ b/packages/components/src/interfaces/complex/Callout.ts
@@ -5,6 +5,7 @@ import { Type } from "@sinclair/typebox"
 import { CalloutProseSchema } from "../native/Prose"
 
 const CALLOUT_VARIANT_OPTIONS = {
+  Info: "info",
   Information: "information",
   GoodToKnow: "goodToKnow",
   Warning: "warning",

--- a/packages/components/src/templates/next/components/complex/Callout/Callout.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Callout/Callout.stories.tsx
@@ -41,6 +41,17 @@ export const Default: Story = {
   },
 }
 
+// Legacy variant value, kept for backward compatibility with content saved
+// before "info" was renamed to "information".
+export const Info: Story = {
+  args: {
+    site: generateSiteConfig(),
+    headingLevel: 2,
+    content,
+    variant: "info",
+  },
+}
+
 export const GoodToKnow: Story = {
   args: {
     site: generateSiteConfig(),

--- a/packages/components/src/templates/next/components/complex/Callout/Callout.tsx
+++ b/packages/components/src/templates/next/components/complex/Callout/Callout.tsx
@@ -10,6 +10,7 @@ const CALLOUT_CONFIG: Record<
   CalloutVariant,
   { label: string; icon?: IconType }
 > = {
+  info: { label: "Information" },
   information: { label: "Information" },
   goodToKnow: { label: "Positive update", icon: BiCheckCircle },
   warning: { label: "Warning", icon: BiErrorCircle },
@@ -27,6 +28,10 @@ const calloutStyles = tv({
   },
   variants: {
     variant: {
+      info: {
+        container:
+          "border-utility-feedback-info bg-utility-feedback-info-subtle",
+      },
       information: {
         container:
           "border-utility-feedback-info bg-utility-feedback-info-subtle",


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +6 | -0 |
| 🧪 Test | 1 | +11 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Content saved before the callout `info` variant was renamed to `information` used `variant: "info"`. That value is no longer a valid schema option, so this legacy content has no styling/label mapping in the renderer.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Add `info` back into `CalloutVariant` as a legacy, non-selectable value so existing content keeps rendering with the same styling and label as `information`.
- Add a Storybook story (`Info`) exercising the legacy `info` variant to document and visually verify this backward-compatibility path.

**Bug Fixes**:

- Prevent published pages that still reference `variant: "info"` from losing their callout styling/label.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores rendering support for the legacy Callout `info` variant and adds a Storybook example. However, runtime page validation remains out of sync with the expanded interface, so legacy pages still cannot be saved.

- Adds `info` to the Callout variant type.
- Maps `info` to the existing Information label and visual styling.
- Documents the compatibility path with a Storybook story.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until legacy `info` values are accepted or normalized during page validation without exposing them as a new editor choice.

The renderer now handles legacy callouts, but Studio's save path still rejects the same value because the runtime Callout schema excludes it.

**Files Needing Attention:** packages/components/src/interfaces/complex/Callout.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/components/src/interfaces/complex/Callout.ts | Expands the static variant union but leaves the runtime `oneOf` schema unchanged, causing legacy saves to fail validation. |
| packages/components/src/templates/next/components/complex/Callout/Callout.tsx | Correctly maps the legacy value to the same label and styling as `information`. |
| packages/components/src/templates/next/components/complex/Callout/Callout.stories.tsx | Adds a focused story demonstrating the legacy rendering path. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233263%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3263&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcomponents%2Fsrc%2Finterfaces%2Fcomplex%2FCallout.ts%3A8%0A**Legacy%20variant%20fails%20validation**%0A%0AWhen%20an%20existing%20page%20containing%20%60variant%3A%20%22info%22%60%20is%20edited%20and%20saved%2C%20the%20expanded%20TypeScript%20union%20permits%20the%20value%20but%20the%20runtime%20%60oneOf%60%20schema%20still%20rejects%20it%2C%20causing%20the%20save%20to%20fail%20with%20%60BAD_REQUEST%3A%20Schema%20validation%20failed.%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3263&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fcomponents%2Fsrc%2Finterfaces%2Fcomplex%2FCallout.ts%3A8%0A**Legacy%20variant%20fails%20validation**%0A%0AWhen%20an%20existing%20page%20containing%20%60variant%3A%20%22info%22%60%20is%20edited%20and%20saved%2C%20the%20expanded%20TypeScript%20union%20permits%20the%20value%20but%20the%20runtime%20%60oneOf%60%20schema%20still%20rejects%20it%2C%20causing%20the%20save%20to%20fail%20with%20%60BAD_REQUEST%3A%20Schema%20validation%20failed.%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3263&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22fix%2Fcallout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcallout%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcomponents%2Fsrc%2Finterfaces%2Fcomplex%2FCallout.ts%3A8%0A**Legacy%20variant%20fails%20validation**%0A%0AWhen%20an%20existing%20page%20containing%20%60variant%3A%20%22info%22%60%20is%20edited%20and%20saved%2C%20the%20expanded%20TypeScript%20union%20permits%20the%20value%20but%20the%20runtime%20%60oneOf%60%20schema%20still%20rejects%20it%2C%20causing%20the%20save%20to%20fail%20with%20%60BAD_REQUEST%3A%20Schema%20validation%20failed.%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/components/src/interfaces/complex/Callout.ts:8
**Legacy variant fails validation**

When an existing page containing `variant: "info"` is edited and saved, the expanded TypeScript union permits the value but the runtime `oneOf` schema still rejects it, causing the save to fail with `BAD_REQUEST: Schema validation failed.`

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add story"](https://github.com/opengovsg/isomer/commit/4aaef95a8e13522e503711a38e5a3580e8130352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58523700)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - packages/components/CLAUDE.md ([source](https://github.com/opengovsg/isomer/blob/main/packages/components/CLAUDE.md))

<!-- /greptile_comment -->