### PR TITLE
📆 feat: Expand collection sort options to support date filters

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -30,6 +30,7 @@ export const JSON_FORMS_RANKING = {
   ChildrenPagesControl: 4,
   // NOTE: needs to have higher priority than anyof
   CollectionVariantControl: 4,
+  CollectionSortOrderControl: 4,
   // NOTE: needs to have higher priority than array
   ChildrenPagesOrderingControl: 5,
   // NOTE: needs to have higher priority than array

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -25,6 +25,8 @@ import {
   jsonFormsCollectionDropdownControlTester,
   JsonFormsCollectionVariantControl,
   jsonFormsCollectionVariantControlTester,
+  JsonFormsCollectionSortOrderControl,
+  jsonFormsCollectionSortOrderControlTester,
   JsonFormsColourPickerControl,
   jsonFormsColourPickerControlTester,
   JsonFormsConstControl,
@@ -209,6 +211,10 @@ export const renderers: JsonFormsRendererRegistryEntry[] = [
   {
     tester: jsonFormsCollectionVariantControlTester,
     renderer: JsonFormsCollectionVariantControl,
+  },
+  {
+    tester: jsonFormsCollectionSortOrderControlTester,
+    renderer: JsonFormsCollectionSortOrderControl,
   },
   {
     // NOTE: If we fall through all our previous testers,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
@@ -1,0 +1,85 @@
+import type { ControlProps, RankedTester } from "@jsonforms/core"
+import { Box, FormControl, Skeleton } from "@chakra-ui/react"
+import { rankWith, schemaMatches } from "@jsonforms/core"
+import { withJsonFormsControlProps } from "@jsonforms/react"
+import {
+  FormErrorMessage,
+  FormLabel,
+  SingleSelect,
+} from "@opengovsg/design-system-react"
+import {
+  getCollectionSortOptions,
+  resolveCollectionSortOrder,
+} from "@opengovsg/isomer-components"
+import { useEffect } from "react"
+import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { useCollectionTags } from "~/features/editing-experience/hooks/useCollectionTags"
+import { pageSchema } from "~/features/editing-experience/schema"
+import { useQueryParse } from "~/hooks/useQueryParse"
+
+import { getCustomErrorMessage } from "./utils"
+
+export const jsonFormsCollectionSortOrderControlTester: RankedTester = rankWith(
+  JSON_FORMS_RANKING.CollectionSortOrderControl,
+  schemaMatches((schema) => schema.format === "collection-sort-order"),
+)
+
+function JsonFormsCollectionSortOrderControl({
+  data,
+  label,
+  description,
+  required,
+  errors,
+  path,
+  enabled,
+  handleChange,
+}: ControlProps): JSX.Element {
+  const { siteId, pageId } = useQueryParse(pageSchema)
+  const { data: tagCategories = [], isLoading } = useCollectionTags({
+    resourceId: pageId,
+    siteId,
+  })
+  const resolvedValue = resolveCollectionSortOrder(
+    typeof data === "string" ? data : undefined,
+    tagCategories,
+  )
+
+  useEffect(() => {
+    if (isLoading) {
+      return
+    }
+
+    if (resolvedValue !== data) {
+      handleChange(path, resolvedValue)
+    }
+  }, [data, handleChange, isLoading, path, resolvedValue])
+
+  if (isLoading) {
+    return <Skeleton />
+  }
+
+  return (
+    <Box>
+      <FormControl isRequired={required} isInvalid={!!errors}>
+        <FormLabel description={description}>{label}</FormLabel>
+
+        <SingleSelect
+          value={resolvedValue}
+          name={label}
+          items={getCollectionSortOptions(tagCategories)}
+          isClearable={false}
+          isDisabled={!enabled}
+          onChange={(value) => {
+            handleChange(path, value)
+          }}
+        />
+
+        <FormErrorMessage>
+          {label} {getCustomErrorMessage(errors)}
+        </FormErrorMessage>
+      </FormControl>
+    </Box>
+  )
+}
+
+export default withJsonFormsControlProps(JsonFormsCollectionSortOrderControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
@@ -26,7 +26,7 @@ export const jsonFormsCollectionSortOrderControlTester: RankedTester = rankWith(
   schemaMatches((schema) => schema.format === "collection-sort-order"),
 )
 
-function JsonFormsCollectionSortOrderControl({
+export function JsonFormsCollectionSortOrderControlBase({
   data,
   label,
   description,
@@ -98,4 +98,6 @@ function JsonFormsCollectionSortOrderControl({
   )
 }
 
-export default withJsonFormsControlProps(JsonFormsCollectionSortOrderControl)
+export default withJsonFormsControlProps(
+  JsonFormsCollectionSortOrderControlBase,
+)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
@@ -5,6 +5,7 @@ import { withJsonFormsControlProps } from "@jsonforms/react"
 import {
   FormErrorMessage,
   FormLabel,
+  Infobox,
   SingleSelect,
 } from "@opengovsg/design-system-react"
 import {
@@ -35,27 +36,41 @@ function JsonFormsCollectionSortOrderControl({
   handleChange,
 }: ControlProps): JSX.Element {
   const { siteId, pageId } = useQueryParse(pageSchema)
-  const { data: tagCategories = [], isLoading } = useCollectionTags({
+  const {
+    data: tagCategories,
+    isLoading,
+    isSuccess,
+    isError,
+  } = useCollectionTags({
     resourceId: pageId,
     siteId,
   })
-  const resolvedValue = resolveCollectionSortOrder(
-    typeof data === "string" ? data : undefined,
-    tagCategories,
-  )
+  const sortOrder = typeof data === "string" ? data : undefined
+  const resolvedValue = isSuccess
+    ? resolveCollectionSortOrder(sortOrder, tagCategories)
+    : (sortOrder ?? "date-desc")
 
   useEffect(() => {
-    if (isLoading) {
+    if (!isSuccess) {
       return
     }
 
     if (resolvedValue !== data) {
       handleChange(path, resolvedValue)
     }
-  }, [data, handleChange, isLoading, path, resolvedValue])
+  }, [data, handleChange, isSuccess, path, resolvedValue])
 
   if (isLoading) {
     return <Skeleton />
+  }
+
+  if (isError) {
+    return (
+      <Infobox variant="warning" size="sm">
+        We couldn&apos;t load collection filters, so sort options are
+        unavailable. Refresh the page to try again.
+      </Infobox>
+    )
   }
 
   return (
@@ -66,7 +81,7 @@ function JsonFormsCollectionSortOrderControl({
         <SingleSelect
           value={resolvedValue}
           name={label}
-          items={getCollectionSortOptions(tagCategories)}
+          items={getCollectionSortOptions(tagCategories ?? [])}
           isClearable={false}
           isDisabled={!enabled}
           onChange={(value) => {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionSortOrderControl.tsx
@@ -9,13 +9,14 @@ import {
   SingleSelect,
 } from "@opengovsg/design-system-react"
 import {
-  getCollectionSortOptions,
+  DEFAULT_COLLECTION_SORT_ORDER,
   resolveCollectionSortOrder,
 } from "@opengovsg/isomer-components"
 import { useEffect } from "react"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { useCollectionTags } from "~/features/editing-experience/hooks/useCollectionTags"
 import { pageSchema } from "~/features/editing-experience/schema"
+import { getCollectionSortOptions } from "~/features/editing-experience/utils"
 import { useQueryParse } from "~/hooks/useQueryParse"
 
 import { getCustomErrorMessage } from "./utils"
@@ -37,7 +38,7 @@ function JsonFormsCollectionSortOrderControl({
 }: ControlProps): JSX.Element {
   const { siteId, pageId } = useQueryParse(pageSchema)
   const {
-    data: tagCategories,
+    data: tagCategories = [],
     isLoading,
     isSuccess,
     isError,
@@ -48,7 +49,7 @@ function JsonFormsCollectionSortOrderControl({
   const sortOrder = typeof data === "string" ? data : undefined
   const resolvedValue = isSuccess
     ? resolveCollectionSortOrder(sortOrder, tagCategories)
-    : (sortOrder ?? "date-desc")
+    : (sortOrder ?? DEFAULT_COLLECTION_SORT_ORDER)
 
   useEffect(() => {
     if (!isSuccess) {
@@ -81,7 +82,7 @@ function JsonFormsCollectionSortOrderControl({
         <SingleSelect
           value={resolvedValue}
           name={label}
-          items={getCollectionSortOptions(tagCategories ?? [])}
+          items={getCollectionSortOptions(tagCategories)}
           isClearable={false}
           isDisabled={!enabled}
           onChange={(value) => {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/__tests__/JsonFormsCollectionSortOrderControl.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/__tests__/JsonFormsCollectionSortOrderControl.browser.test.tsx
@@ -1,0 +1,205 @@
+import type { JsonFormsRendererRegistryEntry } from "@jsonforms/core"
+import type { CollectionTags } from "~/features/editing-experience/hooks/useCollectionTags"
+import { JsonForms } from "@jsonforms/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import {
+  DEFAULT_COLLECTION_SORT_ORDER,
+  TAG_CATEGORY_TYPE,
+} from "@opengovsg/isomer-components"
+import { Type } from "@sinclair/typebox"
+import { render, waitFor } from "@testing-library/react"
+import { useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { theme } from "~/theme"
+import { ajv } from "~/utils/ajv"
+
+import jsonFormsVerticalLayoutRenderer, {
+  jsonFormsVerticalLayoutTester,
+} from "../../layouts/JsonFormsVerticalLayout"
+import JsonFormsCollectionSortOrderControl, {
+  jsonFormsCollectionSortOrderControlTester,
+} from "../JsonFormsCollectionSortOrderControl"
+
+const useCollectionTags = vi.hoisted(() => vi.fn())
+
+vi.mock("~/hooks/useQueryParse", () => ({
+  useQueryParse: () => ({ siteId: 1, pageId: 1 }),
+}))
+
+vi.mock("~/features/editing-experience/hooks/useCollectionTags", () => ({
+  useCollectionTags,
+}))
+
+const EVENT_FILTER_ID = "550e8400-e29b-41d4-a716-446655440000"
+const DATE_FILTER_SORT_ORDER = `date-filter-${EVENT_FILTER_ID}-desc`
+const SORT_ORDER_WARNING =
+  "We couldn't load collection filters, so sort options are unavailable."
+
+const schema = Type.Object({
+  sortOrder: Type.String({
+    title: "Sort items by",
+    format: "collection-sort-order",
+  }),
+})
+
+const renderers: JsonFormsRendererRegistryEntry[] = [
+  {
+    tester: jsonFormsCollectionSortOrderControlTester,
+    renderer: JsonFormsCollectionSortOrderControl,
+  },
+  {
+    tester: jsonFormsVerticalLayoutTester,
+    renderer: jsonFormsVerticalLayoutRenderer,
+  },
+]
+
+const eventDateFilter: CollectionTags[number] = {
+  id: EVENT_FILTER_ID,
+  label: "Event date",
+  type: TAG_CATEGORY_TYPE.Date,
+  isRequired: false,
+  statusLabels: {
+    ENDED: "Event ended",
+    ONGOING: "Ongoing",
+    UPCOMING: "Upcoming",
+  },
+}
+
+const getEmittedSortOrders = (onChange: ReturnType<typeof vi.fn>): unknown[] =>
+  onChange.mock.calls.map((call) => {
+    const state = call[0] as { data?: { sortOrder?: unknown } }
+    return state.data?.sortOrder
+  })
+
+const SortOrderForm = ({
+  initialData,
+  onChange,
+}: {
+  initialData: { sortOrder: string }
+  onChange: (state: { data: { sortOrder: string } }) => void
+}) => {
+  const [data, setData] = useState(initialData)
+
+  return (
+    <JsonForms
+      schema={schema}
+      data={data}
+      renderers={renderers}
+      ajv={ajv}
+      middleware={(state, action, reducer) => {
+        const nextState = reducer(state, action)
+        // Parent UPDATE_CORE runs after this control's mount handleChange and
+        // would otherwise discard the rewrite; keep parent data in sync.
+        if (action.type === "jsonforms/UPDATE") {
+          setData(nextState.data as { sortOrder: string })
+        }
+        return nextState
+      }}
+      onChange={(state) => {
+        onChange(state)
+      }}
+    />
+  )
+}
+
+const renderForm = (initialData: { sortOrder: string }, onChange = vi.fn()) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <SortOrderForm initialData={initialData} onChange={onChange} />
+    </ThemeProvider>,
+  )
+
+describe("JsonFormsCollectionSortOrderControl", () => {
+  beforeEach(() => {
+    useCollectionTags.mockReset()
+  })
+
+  it("shows a skeleton while collection tags are loading", () => {
+    // Arrange
+    useCollectionTags.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isSuccess: false,
+      isError: false,
+    })
+
+    // Act
+    renderForm({ sortOrder: DATE_FILTER_SORT_ORDER })
+
+    // Assert
+    expect(document.querySelector(".chakra-skeleton")).not.toBeNull()
+    expect(document.body.textContent).not.toContain(SORT_ORDER_WARNING)
+  })
+
+  it("does not rewrite sort order when collection tags fail to load", async () => {
+    // Arrange
+    useCollectionTags.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+      isError: true,
+    })
+    const onChange = vi.fn()
+
+    // Act
+    renderForm({ sortOrder: DATE_FILTER_SORT_ORDER }, onChange)
+
+    // Assert
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(SORT_ORDER_WARNING)
+    })
+    expect(getEmittedSortOrders(onChange)).not.toContain(
+      DEFAULT_COLLECTION_SORT_ORDER,
+    )
+    for (const sortOrder of getEmittedSortOrders(onChange)) {
+      expect(sortOrder).toBe(DATE_FILTER_SORT_ORDER)
+    }
+  })
+
+  it("resets a stale date-filter sort to the default when tags load", async () => {
+    // Arrange
+    useCollectionTags.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    })
+    const onChange = vi.fn()
+
+    // Act
+    renderForm({ sortOrder: DATE_FILTER_SORT_ORDER }, onChange)
+
+    // Assert
+    await waitFor(() => {
+      expect(getEmittedSortOrders(onChange)).toContain(
+        DEFAULT_COLLECTION_SORT_ORDER,
+      )
+    })
+    expect(getEmittedSortOrders(onChange).at(-1)).toBe(
+      DEFAULT_COLLECTION_SORT_ORDER,
+    )
+  })
+
+  it("keeps a valid date-filter sort when the matching filter is present", async () => {
+    // Arrange
+    useCollectionTags.mockReturnValue({
+      data: [eventDateFilter],
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    })
+    const onChange = vi.fn()
+
+    // Act
+    renderForm({ sortOrder: DATE_FILTER_SORT_ORDER }, onChange)
+
+    // Assert
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Sort items by")
+      expect(getEmittedSortOrders(onChange).at(-1)).toBe(DATE_FILTER_SORT_ORDER)
+    })
+    expect(getEmittedSortOrders(onChange)).not.toContain(
+      DEFAULT_COLLECTION_SORT_ORDER,
+    )
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -152,6 +152,10 @@ export {
   default as JsonFormsCollectionVariantControl,
   jsonFormsCollectionVariantControlTester,
 } from "./JsonFormsCollectionVariantControl"
+export {
+  default as JsonFormsCollectionSortOrderControl,
+  jsonFormsCollectionSortOrderControlTester,
+} from "./JsonFormsCollectionSortOrderControl"
 
 export {
   default as JsonFormsPrefillLinkControl,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -154,6 +154,7 @@ export {
 } from "./JsonFormsCollectionVariantControl"
 export {
   default as JsonFormsCollectionSortOrderControl,
+  JsonFormsCollectionSortOrderControlBase,
   jsonFormsCollectionSortOrderControlTester,
 } from "./JsonFormsCollectionSortOrderControl"
 

--- a/apps/studio/src/features/editing-experience/utils/__tests__/getCollectionSortOptions.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/getCollectionSortOptions.test.ts
@@ -1,0 +1,71 @@
+import {
+  COLLECTION_SORT_ORDER,
+  TAG_CATEGORY_TYPE,
+} from "@opengovsg/isomer-components"
+
+import type { CollectionTags } from "../../hooks/useCollectionTags"
+import { getCollectionSortOptions } from "../getCollectionSortOptions"
+
+const EVENT_FILTER_ID = "550e8400-e29b-41d4-a716-446655440000"
+const DEADLINE_FILTER_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+const tagCategories: CollectionTags = [
+  {
+    id: EVENT_FILTER_ID,
+    label: "Event date",
+    type: TAG_CATEGORY_TYPE.Date,
+    isRequired: false,
+    statusLabels: {
+      ENDED: "Event ended",
+      ONGOING: "Ongoing",
+      UPCOMING: "Upcoming",
+    },
+  },
+  {
+    id: DEADLINE_FILTER_ID,
+    label: "Registration deadline",
+    type: TAG_CATEGORY_TYPE.Date,
+    isRequired: false,
+    statusLabels: {
+      ENDED: "Event ended",
+      ONGOING: "Ongoing",
+      UPCOMING: "Upcoming",
+    },
+  },
+  {
+    id: "c70df43e-8bff-46a5-889a-3a35e5f6a702",
+    label: "Topic",
+    isRequired: true,
+    options: [{ id: "some-option-id", label: "Technology" }],
+  },
+]
+
+describe("getCollectionSortOptions", () => {
+  it("returns only the four base options when there are no date filters", () => {
+    // Arrange / Act
+    const options = getCollectionSortOptions()
+
+    // Assert
+    expect(options).toHaveLength(4)
+    expect(options[0]).toEqual({
+      value: COLLECTION_SORT_ORDER.DateDesc,
+      label: "By article date, newest → oldest",
+    })
+  })
+
+  it("adds newest and oldest options for each date filter", () => {
+    // Arrange / Act
+    const options = getCollectionSortOptions(tagCategories)
+
+    // Assert
+    expect(options).toHaveLength(8)
+    expect(options[4]).toEqual({
+      value: `date-filter-${EVENT_FILTER_ID}-desc`,
+      label: "By Event date, newest → oldest",
+    })
+    expect(options[6]).toEqual({
+      value: `date-filter-${DEADLINE_FILTER_ID}-desc`,
+      label: "By Registration deadline, newest → oldest",
+    })
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/getCollectionSortOptions.ts
+++ b/apps/studio/src/features/editing-experience/utils/getCollectionSortOptions.ts
@@ -1,0 +1,51 @@
+import {
+  COLLECTION_SORT_ORDER,
+  isDateFilter,
+} from "@opengovsg/isomer-components"
+
+import type { CollectionTags } from "../hooks/useCollectionTags"
+
+const BASE_COLLECTION_SORT_OPTIONS = [
+  {
+    value: COLLECTION_SORT_ORDER.DateDesc,
+    label: "By article date, newest → oldest",
+  },
+  {
+    value: COLLECTION_SORT_ORDER.DateAsc,
+    label: "By article date, oldest → newest",
+  },
+  {
+    value: COLLECTION_SORT_ORDER.TitleAsc,
+    label: "By title, A → Z",
+  },
+  {
+    value: COLLECTION_SORT_ORDER.TitleDesc,
+    label: "By title, Z → A",
+  },
+] as const
+
+// Must match `COLLECTION_SORT_ORDER_PATTERN` in isomer-components:
+// `date-filter-{uuid}-asc|desc`
+const encodeDateFilterSortOrder = (
+  filterId: string,
+  direction: "asc" | "desc",
+): string => `date-filter-${filterId}-${direction}`
+
+export const getCollectionSortOptions = (
+  tagCategories: CollectionTags = [],
+): { value: string; label: string }[] => {
+  const dateFilterOptions = tagCategories
+    .filter(isDateFilter)
+    .flatMap((filter) => [
+      {
+        value: encodeDateFilterSortOrder(filter.id, "desc"),
+        label: `By ${filter.label}, newest → oldest`,
+      },
+      {
+        value: encodeDateFilterSortOrder(filter.id, "asc"),
+        label: `By ${filter.label}, oldest → newest`,
+      },
+    ])
+
+  return [...BASE_COLLECTION_SORT_OPTIONS, ...dateFilterOptions]
+}

--- a/apps/studio/src/features/editing-experience/utils/index.ts
+++ b/apps/studio/src/features/editing-experience/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./createTableSelectionBorderPlugin"
 export * from "./getBlockElement"
+export * from "./getCollectionSortOptions"
 export * from "./getDgsIdFromString"
 export * from "./getHtmlWithRelativeReferenceLinks"
 export * from "./getSelectedCellBorderClasses"

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -15,6 +15,10 @@ export {
   DGS_REQUEST_MAX_BYTES,
   getAskgovIdFromString,
 } from "./utils"
+export {
+  getCollectionSortOptions,
+  resolveCollectionSortOrder,
+} from "./templates/next/layouts/Collection/utils/collectionSortOrder"
 export * from "./schemas"
 export * from "./types"
 export * from "./interfaces"

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -14,11 +14,8 @@ export {
   formatBytes,
   DGS_REQUEST_MAX_BYTES,
   getAskgovIdFromString,
-} from "./utils"
-export {
-  getCollectionSortOptions,
   resolveCollectionSortOrder,
-} from "./templates/next/layouts/Collection/utils/collectionSortOrder"
+} from "./utils"
 export * from "./schemas"
 export * from "./types"
 export * from "./interfaces"

--- a/packages/components/src/templates/next/components/internal/Filter/Filter.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Filter/Filter.stories.tsx
@@ -312,9 +312,12 @@ export const DateFilterDateRangeOnlyMobileDrawer: Story = {
     await userEvent.click(
       await canvas.findByRole("button", { name: /filter results/i }),
     )
-    // Drawer renders in a portal outside the story canvas.
+    // Drawer renders in a portal outside the story canvas. Scope to the
+    // dialog so we don't also match the desktop aside (hidden in DOM on mobile).
     // oxlint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await assertDateFilterControls(within(canvasElement.parentElement!), {
+    const screen = within(canvasElement.parentElement!)
+    const dialog = await screen.findByRole("dialog")
+    await assertDateFilterControls(within(dialog), {
       showStatusLabelsFilter: false,
       showDateRangeFilter: true,
     })

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
@@ -1,0 +1,101 @@
+import type { CollectionPagePageProps } from "~/types/page"
+import { describe, expect, it } from "vitest"
+import { DATE_FILTER_STATUS_ID, TAG_CATEGORY_TYPE } from "~/types/constants"
+import { COLLECTION_SORT_ORDER_PATTERN } from "~/utils/validation"
+
+import {
+  getCollectionSortOptions,
+  parseCollectionSortOrder,
+  resolveCollectionSortOrder,
+} from "../collectionSortOrder"
+
+const EVENT_FILTER_ID = "550e8400-e29b-41d4-a716-446655440000"
+const DEADLINE_FILTER_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+const tagCategories: NonNullable<CollectionPagePageProps["tagCategories"]> = [
+  {
+    id: EVENT_FILTER_ID,
+    label: "Event date",
+    type: TAG_CATEGORY_TYPE.Date,
+    isRequired: false,
+    statusLabels: [
+      { id: DATE_FILTER_STATUS_ID.Ended, label: "Event ended" },
+      { id: DATE_FILTER_STATUS_ID.Ongoing, label: "Ongoing" },
+      { id: DATE_FILTER_STATUS_ID.Upcoming, label: "Upcoming" },
+    ],
+  },
+  {
+    id: DEADLINE_FILTER_ID,
+    label: "Registration deadline",
+    type: TAG_CATEGORY_TYPE.Date,
+    isRequired: false,
+    statusLabels: [
+      { id: DATE_FILTER_STATUS_ID.Ended, label: "Event ended" },
+      { id: DATE_FILTER_STATUS_ID.Ongoing, label: "Ongoing" },
+      { id: DATE_FILTER_STATUS_ID.Upcoming, label: "Upcoming" },
+    ],
+  },
+]
+
+describe("collectionSortOrder", () => {
+  const sortOrderPattern = new RegExp(COLLECTION_SORT_ORDER_PATTERN)
+
+  it("accepts syntactically valid sort orders", () => {
+    expect(sortOrderPattern.test("date-desc")).toBe(true)
+    expect(sortOrderPattern.test("title-asc")).toBe(true)
+    expect(sortOrderPattern.test(`date-filter-${EVENT_FILTER_ID}-desc`)).toBe(
+      true,
+    )
+    expect(sortOrderPattern.test("totally-made-up")).toBe(false)
+    expect(sortOrderPattern.test("date-filter-not-a-uuid-desc")).toBe(false)
+  })
+
+  it("parses base and date-filter sort orders", () => {
+    expect(parseCollectionSortOrder("date-desc")).toEqual({
+      kind: "date",
+      direction: "desc",
+    })
+    expect(parseCollectionSortOrder("title-asc")).toEqual({
+      kind: "title",
+      direction: "asc",
+    })
+    expect(
+      parseCollectionSortOrder(`date-filter-${EVENT_FILTER_ID}-desc`),
+    ).toEqual({
+      kind: "date-filter",
+      filterId: EVENT_FILTER_ID,
+      direction: "desc",
+    })
+  })
+
+  it("builds base options plus two per date filter", () => {
+    expect(getCollectionSortOptions()).toHaveLength(4)
+
+    const options = getCollectionSortOptions(tagCategories)
+
+    expect(options).toHaveLength(8)
+    expect(options[4]).toEqual({
+      value: `date-filter-${EVENT_FILTER_ID}-desc`,
+      label: "By Event date, newest → oldest",
+    })
+    expect(options[6]).toEqual({
+      value: `date-filter-${DEADLINE_FILTER_ID}-desc`,
+      label: "By Registration deadline, newest → oldest",
+    })
+  })
+
+  it("falls back to date-desc for missing or stale sort orders", () => {
+    expect(resolveCollectionSortOrder(undefined, tagCategories)).toBe(
+      "date-desc",
+    )
+    expect(
+      resolveCollectionSortOrder(`date-filter-${EVENT_FILTER_ID}-desc`, []),
+    ).toBe("date-desc")
+    expect(
+      resolveCollectionSortOrder(
+        `date-filter-${DEADLINE_FILTER_ID}-asc`,
+        tagCategories,
+      ),
+    ).toBe(`date-filter-${DEADLINE_FILTER_ID}-asc`)
+  })
+})

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
@@ -76,6 +76,25 @@ describe("collectionSortOrder", () => {
     })
   })
 
+  it("parses remaining base and date-filter directions", () => {
+    // Arrange / Act / Assert
+    expect(parseCollectionSortOrder(COLLECTION_SORT_ORDER.DateAsc)).toEqual({
+      kind: "date",
+      direction: "asc",
+    })
+    expect(parseCollectionSortOrder(COLLECTION_SORT_ORDER.TitleDesc)).toEqual({
+      kind: "title",
+      direction: "desc",
+    })
+    expect(
+      parseCollectionSortOrder(`date-filter-${EVENT_FILTER_ID}-asc`),
+    ).toEqual({
+      kind: "date-filter",
+      filterId: EVENT_FILTER_ID,
+      direction: "asc",
+    })
+  })
+
   it("falls back to date-desc when sortOrder is missing or malformed", () => {
     // Arrange / Act / Assert
     expect(parseCollectionSortOrder(undefined)).toEqual({
@@ -119,5 +138,38 @@ describe("collectionSortOrder", () => {
         tagCategories,
       ),
     ).toBe(`date-filter-${DEADLINE_FILTER_ID}-asc`)
+  })
+
+  it("keeps every base sort order unchanged when tagCategories is provided", () => {
+    // Arrange / Act / Assert
+    expect(
+      resolveCollectionSortOrder(COLLECTION_SORT_ORDER.DateDesc, tagCategories),
+    ).toBe(COLLECTION_SORT_ORDER.DateDesc)
+    expect(
+      resolveCollectionSortOrder(COLLECTION_SORT_ORDER.DateAsc, tagCategories),
+    ).toBe(COLLECTION_SORT_ORDER.DateAsc)
+    expect(
+      resolveCollectionSortOrder(COLLECTION_SORT_ORDER.TitleAsc, tagCategories),
+    ).toBe(COLLECTION_SORT_ORDER.TitleAsc)
+    expect(
+      resolveCollectionSortOrder(
+        COLLECTION_SORT_ORDER.TitleDesc,
+        tagCategories,
+      ),
+    ).toBe(COLLECTION_SORT_ORDER.TitleDesc)
+  })
+
+  it("falls back when the date-filter UUID is absent from a populated tagCategories list", () => {
+    // Arrange
+    const unknownFilterId = "00000000-0000-0000-0000-000000000000"
+
+    // Act
+    const result = resolveCollectionSortOrder(
+      `date-filter-${unknownFilterId}-desc`,
+      tagCategories,
+    )
+
+    // Assert
+    expect(result).toBe(DEFAULT_COLLECTION_SORT_ORDER)
   })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
@@ -1,6 +1,6 @@
 import type { CollectionPagePageProps } from "~/types/page"
 import { describe, expect, it } from "vitest"
-import { DATE_FILTER_STATUS_ID, TAG_CATEGORY_TYPE } from "~/types/constants"
+import { DATE_FILTER_STATUS, TAG_CATEGORY_TYPE } from "~/types/constants"
 import { COLLECTION_SORT_ORDER_PATTERN } from "~/utils/validation"
 
 import {
@@ -18,22 +18,22 @@ const tagCategories: NonNullable<CollectionPagePageProps["tagCategories"]> = [
     label: "Event date",
     type: TAG_CATEGORY_TYPE.Date,
     isRequired: false,
-    statusLabels: [
-      { id: DATE_FILTER_STATUS_ID.Ended, label: "Event ended" },
-      { id: DATE_FILTER_STATUS_ID.Ongoing, label: "Ongoing" },
-      { id: DATE_FILTER_STATUS_ID.Upcoming, label: "Upcoming" },
-    ],
+    statusLabels: {
+      [DATE_FILTER_STATUS.Ended.id]: "Event ended",
+      [DATE_FILTER_STATUS.Ongoing.id]: "Ongoing",
+      [DATE_FILTER_STATUS.Upcoming.id]: "Upcoming",
+    },
   },
   {
     id: DEADLINE_FILTER_ID,
     label: "Registration deadline",
     type: TAG_CATEGORY_TYPE.Date,
     isRequired: false,
-    statusLabels: [
-      { id: DATE_FILTER_STATUS_ID.Ended, label: "Event ended" },
-      { id: DATE_FILTER_STATUS_ID.Ongoing, label: "Ongoing" },
-      { id: DATE_FILTER_STATUS_ID.Upcoming, label: "Upcoming" },
-    ],
+    statusLabels: {
+      [DATE_FILTER_STATUS.Ended.id]: "Event ended",
+      [DATE_FILTER_STATUS.Ongoing.id]: "Ongoing",
+      [DATE_FILTER_STATUS.Upcoming.id]: "Upcoming",
+    },
   },
 ]
 

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/collectionSortOrder.test.ts
@@ -1,10 +1,14 @@
 import type { CollectionPagePageProps } from "~/types/page"
 import { describe, expect, it } from "vitest"
-import { DATE_FILTER_STATUS, TAG_CATEGORY_TYPE } from "~/types/constants"
+import {
+  COLLECTION_SORT_ORDER,
+  DATE_FILTER_STATUS,
+  DEFAULT_COLLECTION_SORT_ORDER,
+  TAG_CATEGORY_TYPE,
+} from "~/types/constants"
 import { COLLECTION_SORT_ORDER_PATTERN } from "~/utils/validation"
 
 import {
-  getCollectionSortOptions,
   parseCollectionSortOrder,
   resolveCollectionSortOrder,
 } from "../collectionSortOrder"
@@ -41,8 +45,11 @@ describe("collectionSortOrder", () => {
   const sortOrderPattern = new RegExp(COLLECTION_SORT_ORDER_PATTERN)
 
   it("accepts syntactically valid sort orders", () => {
-    expect(sortOrderPattern.test("date-desc")).toBe(true)
-    expect(sortOrderPattern.test("title-asc")).toBe(true)
+    // Arrange / Act / Assert
+    expect(sortOrderPattern.test(COLLECTION_SORT_ORDER.DateDesc)).toBe(true)
+    expect(sortOrderPattern.test(COLLECTION_SORT_ORDER.DateAsc)).toBe(true)
+    expect(sortOrderPattern.test(COLLECTION_SORT_ORDER.TitleAsc)).toBe(true)
+    expect(sortOrderPattern.test(COLLECTION_SORT_ORDER.TitleDesc)).toBe(true)
     expect(sortOrderPattern.test(`date-filter-${EVENT_FILTER_ID}-desc`)).toBe(
       true,
     )
@@ -51,11 +58,12 @@ describe("collectionSortOrder", () => {
   })
 
   it("parses base and date-filter sort orders", () => {
-    expect(parseCollectionSortOrder("date-desc")).toEqual({
+    // Arrange / Act / Assert
+    expect(parseCollectionSortOrder(COLLECTION_SORT_ORDER.DateDesc)).toEqual({
       kind: "date",
       direction: "desc",
     })
-    expect(parseCollectionSortOrder("title-asc")).toEqual({
+    expect(parseCollectionSortOrder(COLLECTION_SORT_ORDER.TitleAsc)).toEqual({
       kind: "title",
       direction: "asc",
     })
@@ -68,29 +76,43 @@ describe("collectionSortOrder", () => {
     })
   })
 
-  it("builds base options plus two per date filter", () => {
-    expect(getCollectionSortOptions()).toHaveLength(4)
-
-    const options = getCollectionSortOptions(tagCategories)
-
-    expect(options).toHaveLength(8)
-    expect(options[4]).toEqual({
-      value: `date-filter-${EVENT_FILTER_ID}-desc`,
-      label: "By Event date, newest → oldest",
+  it("falls back to date-desc when sortOrder is missing or malformed", () => {
+    // Arrange / Act / Assert
+    expect(parseCollectionSortOrder(undefined)).toEqual({
+      kind: "date",
+      direction: "desc",
     })
-    expect(options[6]).toEqual({
-      value: `date-filter-${DEADLINE_FILTER_ID}-desc`,
-      label: "By Registration deadline, newest → oldest",
+    expect(parseCollectionSortOrder("totally-made-up")).toEqual({
+      kind: "date",
+      direction: "desc",
+    })
+    expect(parseCollectionSortOrder("date-filter-not-a-uuid-desc")).toEqual({
+      kind: "date",
+      direction: "desc",
+    })
+    expect(parseCollectionSortOrder("DATE-DESC")).toEqual({
+      kind: "date",
+      direction: "desc",
     })
   })
 
-  it("falls back to date-desc for missing or stale sort orders", () => {
+  it("falls back to date-desc for missing, malformed, or stale sort orders", () => {
+    // Arrange / Act / Assert
     expect(resolveCollectionSortOrder(undefined, tagCategories)).toBe(
-      "date-desc",
+      DEFAULT_COLLECTION_SORT_ORDER,
+    )
+    expect(resolveCollectionSortOrder("totally-made-up", tagCategories)).toBe(
+      DEFAULT_COLLECTION_SORT_ORDER,
     )
     expect(
       resolveCollectionSortOrder(`date-filter-${EVENT_FILTER_ID}-desc`, []),
-    ).toBe("date-desc")
+    ).toBe(DEFAULT_COLLECTION_SORT_ORDER)
+    expect(
+      resolveCollectionSortOrder(
+        `date-filter-${EVENT_FILTER_ID}-desc`,
+        undefined,
+      ),
+    ).toBe(DEFAULT_COLLECTION_SORT_ORDER)
     expect(
       resolveCollectionSortOrder(
         `date-filter-${DEADLINE_FILTER_ID}-asc`,

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
@@ -485,4 +485,98 @@ describe("sortCollectionItems", () => {
       expect(sortedTwo.map((item) => item.date)).toEqual(expectedDates)
     })
   })
+
+  describe("sortBy date filter", () => {
+    const filterId = "550e8400-e29b-41d4-a716-446655440000"
+
+    it("should sort items by a date filter start date (newest first)", () => {
+      const items = [
+        createItem({
+          title: "Oldest",
+          dateTagged: [{ id: filterId, date: "2023-01-01" }],
+        }),
+        createItem({
+          title: "Newest",
+          dateTagged: [{ id: filterId, date: "2023-12-31" }],
+        }),
+        createItem({
+          title: "Middle",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+      ]
+
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: `date-filter-${filterId}-desc`,
+      })
+
+      expect(sorted.map((item) => item.title)).toEqual([
+        "Newest",
+        "Middle",
+        "Oldest",
+      ])
+    })
+
+    it("should place items without the date filter value at the end", () => {
+      const items = [
+        createItem({
+          title: "No date",
+        }),
+        createItem({
+          title: "Has date",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+      ]
+
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: `date-filter-${filterId}-asc`,
+      })
+
+      expect(sorted.map((item) => item.title)).toEqual(["Has date", "No date"])
+    })
+
+    it("should use title A → Z as a tiebreaker for the same date filter date", () => {
+      const items = [
+        createItem({
+          title: "Zebra",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+        createItem({
+          title: "Alpha",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+      ]
+
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: `date-filter-${filterId}-desc`,
+      })
+
+      expect(sorted.map((item) => item.title)).toEqual(["Alpha", "Zebra"])
+    })
+
+    it("should fall back to publish date when both items lack the date filter value", () => {
+      const items = [
+        createItem({
+          title: "Older publish",
+          date: new Date("2023-01-01"),
+        }),
+        createItem({
+          title: "Newer publish",
+          date: new Date("2023-12-31"),
+        }),
+      ]
+
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: `date-filter-${filterId}-desc`,
+      })
+
+      expect(sorted.map((item) => item.title)).toEqual([
+        "Newer publish",
+        "Older publish",
+      ])
+    })
+  })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
@@ -556,6 +556,37 @@ describe("sortCollectionItems", () => {
       expect(sorted.map((item) => item.title)).toEqual(["Alpha", "Zebra"])
     })
 
+    it("should sort by last modified when date filter dates and titles are equal", () => {
+      const items = [
+        createItem({
+          title: "Same title",
+          lastModified: "2025-01-01T12:00:00Z",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+        createItem({
+          title: "Same title",
+          lastModified: "2025-03-01T12:00:00Z",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+        createItem({
+          title: "Same title",
+          lastModified: "2025-02-01T12:00:00Z",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+      ]
+
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: `date-filter-${filterId}-desc`,
+      })
+
+      expect(sorted.map((item) => item.lastModified)).toEqual([
+        "2025-03-01T12:00:00Z",
+        "2025-02-01T12:00:00Z",
+        "2025-01-01T12:00:00Z",
+      ])
+    })
+
     it("should fall back to publish date when both items lack the date filter value", () => {
       const items = [
         createItem({

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
@@ -517,6 +517,37 @@ describe("sortCollectionItems", () => {
       ])
     })
 
+    it("should sort items by a date filter start date (oldest first)", () => {
+      // Arrange
+      const items = [
+        createItem({
+          title: "Oldest",
+          dateTagged: [{ id: filterId, date: "2023-01-01" }],
+        }),
+        createItem({
+          title: "Newest",
+          dateTagged: [{ id: filterId, date: "2023-12-31" }],
+        }),
+        createItem({
+          title: "Middle",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+      ]
+
+      // Act
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: `date-filter-${filterId}-asc`,
+      })
+
+      // Assert
+      expect(sorted.map((item) => item.title)).toEqual([
+        "Oldest",
+        "Middle",
+        "Newest",
+      ])
+    })
+
     it("should place items without the date filter value at the end", () => {
       const items = [
         createItem({
@@ -585,6 +616,31 @@ describe("sortCollectionItems", () => {
         "2025-02-01T12:00:00Z",
         "2025-01-01T12:00:00Z",
       ])
+    })
+
+    it("should sort by last modified rather than title when date filter dates are equal", () => {
+      // Arrange
+      const items = [
+        createItem({
+          title: "Alpha",
+          lastModified: "2025-01-01T12:00:00Z",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+        createItem({
+          title: "Zebra",
+          lastModified: "2025-03-01T12:00:00Z",
+          dateTagged: [{ id: filterId, date: "2023-06-15" }],
+        }),
+      ]
+
+      // Act
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: `date-filter-${filterId}-desc`,
+      })
+
+      // Assert
+      expect(sorted.map((item) => item.title)).toEqual(["Zebra", "Alpha"])
     })
 
     it("should fall back to publish date when both items lack the date filter value", () => {

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/sortCollectionItems.test.ts
@@ -610,4 +610,28 @@ describe("sortCollectionItems", () => {
       ])
     })
   })
+
+  describe("malformed sortOrder", () => {
+    it("should sort by published date newest first instead of trusting dirty data", () => {
+      // Arrange
+      const items = [
+        createItem({ title: "Oldest", date: new Date("2023-01-01") }),
+        createItem({ title: "Newest", date: new Date("2023-12-31") }),
+        createItem({ title: "Middle", date: new Date("2023-06-15") }),
+      ]
+
+      // Act
+      const sorted = sortCollectionItems({
+        items,
+        sortOrder: "totally-made-up",
+      })
+
+      // Assert
+      expect(sorted.map((item) => item.title)).toEqual([
+        "Newest",
+        "Middle",
+        "Oldest",
+      ])
+    })
+  })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/collectionSortOrder.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/collectionSortOrder.ts
@@ -1,0 +1,120 @@
+import type { CollectionPagePageProps } from "~/types/page"
+import { isDateFilter } from "~/types/page"
+
+const DEFAULT_COLLECTION_SORT_ORDER = "date-desc"
+const DATE_FILTER_SORT_ORDER_PREFIX = "date-filter-"
+
+type CollectionSortDirection = "asc" | "desc"
+
+type ParsedCollectionSortOrder =
+  | { kind: "date"; direction: CollectionSortDirection }
+  | { kind: "title"; direction: CollectionSortDirection }
+  | {
+      kind: "date-filter"
+      filterId: string
+      direction: CollectionSortDirection
+    }
+
+const BASE_COLLECTION_SORT_OPTIONS = [
+  {
+    value: "date-desc",
+    label: "By article date, newest → oldest",
+  },
+  {
+    value: "date-asc",
+    label: "By article date, oldest → newest",
+  },
+  {
+    value: "title-asc",
+    label: "By title, A → Z",
+  },
+  {
+    value: "title-desc",
+    label: "By title, Z → A",
+  },
+] as const
+
+const encodeDateFilterSortOrder = (
+  filterId: string,
+  direction: CollectionSortDirection,
+): string => `${DATE_FILTER_SORT_ORDER_PREFIX}${filterId}-${direction}`
+
+const parseCollectionSortOrder = (
+  sortOrder: string | undefined,
+): ParsedCollectionSortOrder => {
+  if (!sortOrder) {
+    return { kind: "date", direction: "desc" }
+  }
+
+  if (sortOrder.startsWith(DATE_FILTER_SORT_ORDER_PREFIX)) {
+    const direction: CollectionSortDirection = sortOrder.endsWith("-asc")
+      ? "asc"
+      : "desc"
+    const filterId = sortOrder.slice(
+      DATE_FILTER_SORT_ORDER_PREFIX.length,
+      sortOrder.length - `-${direction}`.length,
+    )
+
+    return { kind: "date-filter", filterId, direction }
+  }
+
+  const [sortBy, direction] = sortOrder.split("-") as [
+    "date" | "title",
+    CollectionSortDirection,
+  ]
+
+  if (sortBy === "title") {
+    return { kind: "title", direction }
+  }
+
+  return { kind: "date", direction }
+}
+
+const isBaseCollectionSortOrder = (
+  sortOrder: string,
+): sortOrder is (typeof BASE_COLLECTION_SORT_OPTIONS)[number]["value"] =>
+  BASE_COLLECTION_SORT_OPTIONS.some(({ value }) => value === sortOrder)
+
+export const getCollectionSortOptions = (
+  tagCategories?: CollectionPagePageProps["tagCategories"],
+): { value: string; label: string }[] => {
+  const dateFilterOptions =
+    tagCategories?.filter(isDateFilter).flatMap((filter) => [
+      {
+        value: encodeDateFilterSortOrder(filter.id, "desc"),
+        label: `By ${filter.label}, newest → oldest`,
+      },
+      {
+        value: encodeDateFilterSortOrder(filter.id, "asc"),
+        label: `By ${filter.label}, oldest → newest`,
+      },
+    ]) ?? []
+
+  return [...BASE_COLLECTION_SORT_OPTIONS, ...dateFilterOptions]
+}
+
+export const resolveCollectionSortOrder = (
+  sortOrder: string | undefined,
+  tagCategories?: CollectionPagePageProps["tagCategories"],
+): string => {
+  if (!sortOrder) {
+    return DEFAULT_COLLECTION_SORT_ORDER
+  }
+
+  if (isBaseCollectionSortOrder(sortOrder)) {
+    return sortOrder
+  }
+
+  const parsed = parseCollectionSortOrder(sortOrder)
+  if (parsed.kind !== "date-filter") {
+    return DEFAULT_COLLECTION_SORT_ORDER
+  }
+
+  const filterExists = tagCategories
+    ?.filter(isDateFilter)
+    .some(({ id }) => id === parsed.filterId)
+
+  return filterExists ? sortOrder : DEFAULT_COLLECTION_SORT_ORDER
+}
+
+export { parseCollectionSortOrder }

--- a/packages/components/src/templates/next/layouts/Collection/utils/collectionSortOrder.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/collectionSortOrder.ts
@@ -1,8 +1,18 @@
 import type { CollectionPagePageProps } from "~/types/page"
+import {
+  COLLECTION_SORT_ORDER,
+  DEFAULT_COLLECTION_SORT_ORDER,
+  type CollectionSortOrder,
+} from "~/types/constants"
 import { isDateFilter } from "~/types/page"
+import { COLLECTION_SORT_ORDER_PATTERN } from "~/utils/validation"
 
-const DEFAULT_COLLECTION_SORT_ORDER = "date-desc"
-const DATE_FILTER_SORT_ORDER_PREFIX = "date-filter-"
+const COLLECTION_SORT_ORDER_REGEX = new RegExp(COLLECTION_SORT_ORDER_PATTERN)
+const DATE_FILTER_SORT_ORDER_REGEX =
+  /^date-filter-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-(asc|desc)$/
+const BASE_COLLECTION_SORT_ORDERS = new Set<string>(
+  Object.values(COLLECTION_SORT_ORDER),
+)
 
 type CollectionSortDirection = "asc" | "desc"
 
@@ -15,47 +25,39 @@ type ParsedCollectionSortOrder =
       direction: CollectionSortDirection
     }
 
-const BASE_COLLECTION_SORT_OPTIONS = [
-  {
-    value: "date-desc",
-    label: "By article date, newest → oldest",
-  },
-  {
-    value: "date-asc",
-    label: "By article date, oldest → newest",
-  },
-  {
-    value: "title-asc",
-    label: "By title, A → Z",
-  },
-  {
-    value: "title-desc",
-    label: "By title, Z → A",
-  },
-] as const
+const DEFAULT_PARSED_COLLECTION_SORT_ORDER: ParsedCollectionSortOrder = {
+  kind: "date",
+  direction: "desc",
+}
 
-const encodeDateFilterSortOrder = (
-  filterId: string,
-  direction: CollectionSortDirection,
-): string => `${DATE_FILTER_SORT_ORDER_PREFIX}${filterId}-${direction}`
+const isBaseCollectionSortOrder = (
+  sortOrder: string,
+): sortOrder is CollectionSortOrder =>
+  BASE_COLLECTION_SORT_ORDERS.has(sortOrder)
 
-const parseCollectionSortOrder = (
+const getDateFilters = (
+  tagCategories: CollectionPagePageProps["tagCategories"],
+) => (Array.isArray(tagCategories) ? tagCategories.filter(isDateFilter) : [])
+
+export const parseCollectionSortOrder = (
   sortOrder: string | undefined,
 ): ParsedCollectionSortOrder => {
-  if (!sortOrder) {
-    return { kind: "date", direction: "desc" }
+  if (!sortOrder || !COLLECTION_SORT_ORDER_REGEX.test(sortOrder)) {
+    return DEFAULT_PARSED_COLLECTION_SORT_ORDER
   }
 
-  if (sortOrder.startsWith(DATE_FILTER_SORT_ORDER_PREFIX)) {
-    const direction: CollectionSortDirection = sortOrder.endsWith("-asc")
-      ? "asc"
-      : "desc"
-    const filterId = sortOrder.slice(
-      DATE_FILTER_SORT_ORDER_PREFIX.length,
-      sortOrder.length - `-${direction}`.length,
-    )
-
-    return { kind: "date-filter", filterId, direction }
+  const dateFilterMatch = DATE_FILTER_SORT_ORDER_REGEX.exec(sortOrder)
+  const filterId = dateFilterMatch?.[1]
+  const dateFilterDirection = dateFilterMatch?.[2]
+  if (
+    filterId &&
+    (dateFilterDirection === "asc" || dateFilterDirection === "desc")
+  ) {
+    return {
+      kind: "date-filter",
+      filterId,
+      direction: dateFilterDirection,
+    }
   }
 
   const [sortBy, direction] = sortOrder.split("-") as [
@@ -70,34 +72,11 @@ const parseCollectionSortOrder = (
   return { kind: "date", direction }
 }
 
-const isBaseCollectionSortOrder = (
-  sortOrder: string,
-): sortOrder is (typeof BASE_COLLECTION_SORT_OPTIONS)[number]["value"] =>
-  BASE_COLLECTION_SORT_OPTIONS.some(({ value }) => value === sortOrder)
-
-export const getCollectionSortOptions = (
-  tagCategories?: CollectionPagePageProps["tagCategories"],
-): { value: string; label: string }[] => {
-  const dateFilterOptions =
-    tagCategories?.filter(isDateFilter).flatMap((filter) => [
-      {
-        value: encodeDateFilterSortOrder(filter.id, "desc"),
-        label: `By ${filter.label}, newest → oldest`,
-      },
-      {
-        value: encodeDateFilterSortOrder(filter.id, "asc"),
-        label: `By ${filter.label}, oldest → newest`,
-      },
-    ]) ?? []
-
-  return [...BASE_COLLECTION_SORT_OPTIONS, ...dateFilterOptions]
-}
-
 export const resolveCollectionSortOrder = (
   sortOrder: string | undefined,
   tagCategories?: CollectionPagePageProps["tagCategories"],
 ): string => {
-  if (!sortOrder) {
+  if (!sortOrder || !COLLECTION_SORT_ORDER_REGEX.test(sortOrder)) {
     return DEFAULT_COLLECTION_SORT_ORDER
   }
 
@@ -110,11 +89,9 @@ export const resolveCollectionSortOrder = (
     return DEFAULT_COLLECTION_SORT_ORDER
   }
 
-  const filterExists = tagCategories
-    ?.filter(isDateFilter)
-    .some(({ id }) => id === parsed.filterId)
+  const filterExists = getDateFilters(tagCategories).some(
+    ({ id }) => id === parsed.filterId,
+  )
 
   return filterExists ? sortOrder : DEFAULT_COLLECTION_SORT_ORDER
 }
-
-export { parseCollectionSortOrder }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -4,6 +4,7 @@ import type { CollectionPagePageProps } from "~/types/page"
 import { getParsedDate } from "~/utils/getParsedDate"
 import { getSitemapAsArray } from "~/utils/getSitemapAsArray"
 
+import { resolveCollectionSortOrder } from "./collectionSortOrder"
 import { getDateFilterDisplayEntries } from "./getDateFilterDisplayEntries"
 import { getPillAndPlaintextTags } from "./getPillAndPlaintextTags"
 import { getTagsFromTagged } from "./getTagsFromTagged"
@@ -177,7 +178,9 @@ export const getCollectionItems = ({
 
   return sortCollectionItems({
     items: transformedItems,
-    sortOrder,
+    sortOrder: sortOrder
+      ? resolveCollectionSortOrder(sortOrder, tagCategories)
+      : undefined,
     sortBy,
     sortDirection,
   })

--- a/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
@@ -1,6 +1,8 @@
 import type { AllCardProps } from "~/interfaces"
+import { parseISO } from "date-fns"
 
 import type { GetCollectionItemsProps } from "./getCollectionItems"
+import { parseCollectionSortOrder } from "./collectionSortOrder"
 
 interface SortCollectionItemsProps extends Pick<
   GetCollectionItemsProps,
@@ -9,15 +11,7 @@ interface SortCollectionItemsProps extends Pick<
   items: AllCardProps[]
 }
 
-// Helper types to extract the sortBy and sortDirection from sortOrder
-type FirstPart<T extends string> = T extends `${infer F}-${string}` ? F : never
-type SecondPart<T extends string> = T extends `${string}-${infer S}` ? S : never
-type SortBy =
-  | FirstPart<NonNullable<GetCollectionItemsProps["sortOrder"]>>
-  | GetCollectionItemsProps["sortBy"]
-type SortDirection =
-  | SecondPart<NonNullable<GetCollectionItemsProps["sortOrder"]>>
-  | GetCollectionItemsProps["sortDirection"]
+type SortDirection = NonNullable<SortCollectionItemsProps["sortDirection"]>
 
 const getLastModifiedDate = (item: AllCardProps): Date | undefined => {
   if (!item.lastModified) {
@@ -36,7 +30,7 @@ const getLastModifiedDate = (item: AllCardProps): Date | undefined => {
 const compareDates = (
   a: AllCardProps,
   b: AllCardProps,
-  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
+  sortDirection: SortDirection,
 ): number => {
   // Type assertion because TS control-flow narrowing only works when
   // check is done inline and not when we define the variable
@@ -57,7 +51,7 @@ const compareDates = (
 const compareTitles = (
   a: AllCardProps,
   b: AllCardProps,
-  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
+  sortDirection: SortDirection,
 ): number => {
   switch (sortDirection) {
     case "asc":
@@ -73,7 +67,7 @@ const compareTitles = (
 const compareLastModified = (
   a: AllCardProps,
   b: AllCardProps,
-  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
+  sortDirection: SortDirection,
 ): number => {
   const aLastModified = getLastModifiedDate(a)
   const bLastModified = getLastModifiedDate(b)
@@ -96,13 +90,110 @@ const compareLastModified = (
   return 0
 }
 
+const getDateFilterStartTime = (
+  item: AllCardProps,
+  filterId: string,
+): number | undefined => {
+  const dateValue = item.dateTagged?.find(({ id }) => id === filterId)?.date
+
+  if (!dateValue) {
+    return undefined
+  }
+
+  return parseISO(dateValue).getTime()
+}
+
+const compareUndatedItemsByPublishDate = (
+  a: AllCardProps,
+  b: AllCardProps,
+  sortDirection: SortDirection,
+): number => {
+  const bothHaveDates = a.date instanceof Date && b.date instanceof Date
+  const bothSameDate = a.date?.getTime() === b.date?.getTime()
+  const bothSameLastModified =
+    getLastModifiedDate(a)?.getTime() === getLastModifiedDate(b)?.getTime()
+  const bothSameTitle = a.title === b.title
+  const aNoDate = a.date === undefined
+  const bNoDate = b.date === undefined
+
+  if (bothHaveDates && !bothSameDate) {
+    return compareDates(a, b, sortDirection)
+  }
+
+  if (bothHaveDates && bothSameDate && !bothSameLastModified) {
+    return compareLastModified(a, b, sortDirection)
+  }
+
+  if (bothHaveDates && bothSameDate && bothSameLastModified) {
+    return compareTitles(a, b, "asc")
+  }
+
+  if (aNoDate && bNoDate && !bothSameTitle) {
+    return compareTitles(a, b, "asc")
+  }
+
+  if (aNoDate && bNoDate && bothSameTitle) {
+    return compareLastModified(a, b, sortDirection)
+  }
+
+  if (aNoDate) {
+    return 1
+  }
+
+  if (bNoDate) {
+    return -1
+  }
+
+  return a.date instanceof Date ? -1 : 1
+}
+
+const compareDateFilterStartDates = (
+  a: AllCardProps,
+  b: AllCardProps,
+  filterId: string,
+  sortDirection: SortDirection,
+): number => {
+  const aDate = getDateFilterStartTime(a, filterId)
+  const bDate = getDateFilterStartTime(b, filterId)
+  const aNoDate = aDate === undefined
+  const bNoDate = bDate === undefined
+
+  if (aNoDate && bNoDate) {
+    return compareUndatedItemsByPublishDate(a, b, sortDirection)
+  }
+
+  if (aNoDate) {
+    return 1
+  }
+
+  if (bNoDate) {
+    return -1
+  }
+
+  if (aDate !== bDate) {
+    switch (sortDirection) {
+      case "asc":
+        return aDate >= bDate ? 1 : -1
+      case "desc":
+        return aDate <= bDate ? 1 : -1
+      default:
+        const _: never = sortDirection
+        return 1
+    }
+  }
+
+  return compareTitles(a, b, "asc")
+}
+
 // Sort by published date, followed by last modified date, tiebreaker by title
 // If published date is not available, sort by title first, followed by last
 // modified date
 const sortCollectionItemsByDate = ({
   items,
   sortDirection = "desc",
-}: Omit<SortCollectionItemsProps, "sortBy">) => {
+}: Omit<SortCollectionItemsProps, "sortBy" | "sortOrder"> & {
+  sortDirection?: SortDirection
+}) => {
   return items.sort((a, b) => {
     const bothHaveDates = a.date instanceof Date && b.date instanceof Date
     const bothSameDate = a.date?.getTime() === b.date?.getTime()
@@ -156,7 +247,9 @@ const sortCollectionItemsByDate = ({
 const sortCollectionItemsByTitle = ({
   items,
   sortDirection = "asc",
-}: Omit<SortCollectionItemsProps, "sortBy">) => {
+}: Omit<SortCollectionItemsProps, "sortBy" | "sortOrder"> & {
+  sortDirection?: SortDirection
+}) => {
   return items.sort((a, b) => {
     const bothSameTitle = a.title === b.title
     const bothHaveDates = a.date instanceof Date && b.date instanceof Date
@@ -199,31 +292,57 @@ const sortCollectionItemsByTitle = ({
   })
 }
 
+const sortCollectionItemsByDateFilter = ({
+  items,
+  filterId,
+  sortDirection = "desc",
+}: {
+  items: AllCardProps[]
+  filterId: string
+  sortDirection?: SortDirection
+}) =>
+  items.sort((a, b) =>
+    compareDateFilterStartDates(a, b, filterId, sortDirection),
+  )
+
 export const sortCollectionItems = ({
   items,
   sortOrder,
   sortBy,
   sortDirection,
 }: SortCollectionItemsProps): AllCardProps[] => {
-  const derivedSortBy = sortOrder ? (sortOrder.split("-")[0] as SortBy) : sortBy
-  const derivedSortDirection = sortOrder
-    ? (sortOrder.split("-")[1] as SortDirection)
-    : sortDirection
+  const parsedSortOrder = parseCollectionSortOrder(sortOrder)
 
-  switch (derivedSortBy) {
+  if (!sortOrder) {
+    switch (sortBy) {
+      case "title":
+        return sortCollectionItemsByTitle({ items, sortDirection })
+      case "date":
+      case undefined:
+      default:
+        return sortCollectionItemsByDate({ items, sortDirection })
+    }
+  }
+
+  switch (parsedSortOrder.kind) {
     case "date":
-    case undefined:
       return sortCollectionItemsByDate({
         items,
-        sortDirection: derivedSortDirection,
+        sortDirection: parsedSortOrder.direction,
       })
     case "title":
       return sortCollectionItemsByTitle({
         items,
-        sortDirection: derivedSortDirection,
+        sortDirection: parsedSortOrder.direction,
+      })
+    case "date-filter":
+      return sortCollectionItemsByDateFilter({
+        items,
+        filterId: parsedSortOrder.filterId,
+        sortDirection: parsedSortOrder.direction,
       })
     default:
-      const _: never = derivedSortBy
+      const _: never = parsedSortOrder
       return []
   }
 }

--- a/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
@@ -182,6 +182,13 @@ const compareDateFilterStartDates = (
     }
   }
 
+  const bothSameLastModified =
+    getLastModifiedDate(a)?.getTime() === getLastModifiedDate(b)?.getTime()
+
+  if (!bothSameLastModified) {
+    return compareLastModified(a, b, sortDirection)
+  }
+
   return compareTitles(a, b, "asc")
 }
 

--- a/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
@@ -103,7 +103,7 @@ const getDateFilterStartTime = (
   return parseISO(dateValue).getTime()
 }
 
-const compareUndatedItemsByPublishDate = (
+const compareByPublishDate = (
   a: AllCardProps,
   b: AllCardProps,
   sortDirection: SortDirection,
@@ -159,7 +159,7 @@ const compareDateFilterStartDates = (
   const bNoDate = bDate === undefined
 
   if (aNoDate && bNoDate) {
-    return compareUndatedItemsByPublishDate(a, b, sortDirection)
+    return compareByPublishDate(a, b, sortDirection)
   }
 
   if (aNoDate) {
@@ -185,63 +185,15 @@ const compareDateFilterStartDates = (
   return compareTitles(a, b, "asc")
 }
 
-// Sort by published date, followed by last modified date, tiebreaker by title
+// Sort by published date, followed by last modified date, tiebreaker by title.
 // If published date is not available, sort by title first, followed by last
-// modified date
+// modified date.
 const sortCollectionItemsByDate = ({
   items,
   sortDirection = "desc",
 }: Omit<SortCollectionItemsProps, "sortBy" | "sortOrder"> & {
   sortDirection?: SortDirection
-}) => {
-  return items.sort((a, b) => {
-    const bothHaveDates = a.date instanceof Date && b.date instanceof Date
-    const bothSameDate = a.date?.getTime() === b.date?.getTime()
-    const bothSameLastModified =
-      getLastModifiedDate(a)?.getTime() === getLastModifiedDate(b)?.getTime()
-    const bothSameTitle = a.title === b.title
-    const aNoDate = a.date === undefined
-    const bNoDate = b.date === undefined
-
-    // ===== Scenario 1: Both items have published dates =====
-    // Sort by first priority: Published date
-    if (bothHaveDates && !bothSameDate) {
-      return compareDates(a, b, sortDirection)
-    }
-
-    // Sort by second priority: Last modified date
-    if (bothHaveDates && bothSameDate && !bothSameLastModified) {
-      return compareLastModified(a, b, sortDirection)
-    }
-
-    // Sort by third priority: Title
-    if (bothHaveDates && bothSameDate && bothSameLastModified) {
-      return compareTitles(a, b, "asc") // Always sort titles in ascending order
-    }
-
-    // ===== Scenario 2: Both items do not have published dates =====
-    // Sort by first priority: Title
-    if (aNoDate && bNoDate && !bothSameTitle) {
-      return compareTitles(a, b, "asc") // Always sort titles in ascending order
-    }
-
-    // Sort by second priority: Last modified date
-    if (aNoDate && bNoDate && bothSameTitle) {
-      return compareLastModified(a, b, sortDirection)
-    }
-
-    // ===== Scenario 3: One item has a published date, the other does not =====
-    // If one has a date and the other does not, place the one with a date first
-    if (aNoDate) {
-      return 1 // Place items without dates at the end
-    } else if (bNoDate) {
-      return -1 // Place items without dates at the end
-    }
-
-    // This should never be reached
-    return a.date instanceof Date ? -1 : 1
-  })
-}
+}) => items.sort((a, b) => compareByPublishDate(a, b, sortDirection))
 
 // Sort by title, followed by published date, tiebreaker by last modified date
 const sortCollectionItemsByTitle = ({

--- a/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/sortCollectionItems.ts
@@ -11,8 +11,6 @@ interface SortCollectionItemsProps extends Pick<
   items: AllCardProps[]
 }
 
-type SortDirection = NonNullable<SortCollectionItemsProps["sortDirection"]>
-
 const getLastModifiedDate = (item: AllCardProps): Date | undefined => {
   if (!item.lastModified) {
     return undefined
@@ -30,7 +28,7 @@ const getLastModifiedDate = (item: AllCardProps): Date | undefined => {
 const compareDates = (
   a: AllCardProps,
   b: AllCardProps,
-  sortDirection: SortDirection,
+  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
 ): number => {
   // Type assertion because TS control-flow narrowing only works when
   // check is done inline and not when we define the variable
@@ -51,7 +49,7 @@ const compareDates = (
 const compareTitles = (
   a: AllCardProps,
   b: AllCardProps,
-  sortDirection: SortDirection,
+  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
 ): number => {
   switch (sortDirection) {
     case "asc":
@@ -67,7 +65,7 @@ const compareTitles = (
 const compareLastModified = (
   a: AllCardProps,
   b: AllCardProps,
-  sortDirection: SortDirection,
+  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
 ): number => {
   const aLastModified = getLastModifiedDate(a)
   const bLastModified = getLastModifiedDate(b)
@@ -106,7 +104,7 @@ const getDateFilterStartTime = (
 const compareByPublishDate = (
   a: AllCardProps,
   b: AllCardProps,
-  sortDirection: SortDirection,
+  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
 ): number => {
   const bothHaveDates = a.date instanceof Date && b.date instanceof Date
   const bothSameDate = a.date?.getTime() === b.date?.getTime()
@@ -151,7 +149,7 @@ const compareDateFilterStartDates = (
   a: AllCardProps,
   b: AllCardProps,
   filterId: string,
-  sortDirection: SortDirection,
+  sortDirection: NonNullable<SortCollectionItemsProps["sortDirection"]>,
 ): number => {
   const aDate = getDateFilterStartTime(a, filterId)
   const bDate = getDateFilterStartTime(b, filterId)
@@ -198,17 +196,14 @@ const compareDateFilterStartDates = (
 const sortCollectionItemsByDate = ({
   items,
   sortDirection = "desc",
-}: Omit<SortCollectionItemsProps, "sortBy" | "sortOrder"> & {
-  sortDirection?: SortDirection
-}) => items.sort((a, b) => compareByPublishDate(a, b, sortDirection))
+}: Omit<SortCollectionItemsProps, "sortBy" | "sortOrder">) =>
+  items.sort((a, b) => compareByPublishDate(a, b, sortDirection))
 
 // Sort by title, followed by published date, tiebreaker by last modified date
 const sortCollectionItemsByTitle = ({
   items,
   sortDirection = "asc",
-}: Omit<SortCollectionItemsProps, "sortBy" | "sortOrder"> & {
-  sortDirection?: SortDirection
-}) => {
+}: Omit<SortCollectionItemsProps, "sortBy" | "sortOrder">) => {
   return items.sort((a, b) => {
     const bothSameTitle = a.title === b.title
     const bothHaveDates = a.date instanceof Date && b.date instanceof Date
@@ -258,7 +253,7 @@ const sortCollectionItemsByDateFilter = ({
 }: {
   items: AllCardProps[]
   filterId: string
-  sortDirection?: SortDirection
+  sortDirection?: NonNullable<SortCollectionItemsProps["sortDirection"]>
 }) =>
   items.sort((a, b) =>
     compareDateFilterStartDates(a, b, filterId, sortDirection),

--- a/packages/components/src/types/constants.ts
+++ b/packages/components/src/types/constants.ts
@@ -34,7 +34,11 @@ export const resolveTagCategoryDisplay = (
   display?: TagCategoryDisplay,
 ): TagCategoryDisplay => display ?? DEFAULT_TAG_CATEGORY_DISPLAY
 
-// tagCategories entry is "text" (option list) or "date" (status buckets).
+// A `tagCategories` entry is either a "text" filter (admin-defined option
+// list, the original mechanism) or a "date" filter (computed ended/ongoing/
+// upcoming status). Legacy persisted entries omit `type` entirely — read
+// missing/`undefined` as `Text` for backward compatibility, same pattern as
+// `resolveTagCategoryDisplay` above.
 export const TAG_CATEGORY_TYPE = {
   Text: "text",
   Date: "date",

--- a/packages/components/src/types/constants.ts
+++ b/packages/components/src/types/constants.ts
@@ -34,11 +34,7 @@ export const resolveTagCategoryDisplay = (
   display?: TagCategoryDisplay,
 ): TagCategoryDisplay => display ?? DEFAULT_TAG_CATEGORY_DISPLAY
 
-// A `tagCategories` entry is either a "text" filter (admin-defined option
-// list, the original mechanism) or a "date" filter (computed ended/ongoing/
-// upcoming status). Legacy persisted entries omit `type` entirely — read
-// missing/`undefined` as `Text` for backward compatibility, same pattern as
-// `resolveTagCategoryDisplay` above.
+// tagCategories entry is "text" (option list) or "date" (status buckets).
 export const TAG_CATEGORY_TYPE = {
   Text: "text",
   Date: "date",

--- a/packages/components/src/types/constants.ts
+++ b/packages/components/src/types/constants.ts
@@ -72,3 +72,15 @@ export const DEFAULT_DATE_FILTER_SIDEBAR_VISIBILITY = {
   showStatusLabelsFilter: true,
   showDateRangeFilter: true,
 } as const
+
+export const COLLECTION_SORT_ORDER = {
+  DateDesc: "date-desc",
+  DateAsc: "date-asc",
+  TitleAsc: "title-asc",
+  TitleDesc: "title-desc",
+} as const
+
+export type CollectionSortOrder =
+  (typeof COLLECTION_SORT_ORDER)[keyof typeof COLLECTION_SORT_ORDER]
+
+export const DEFAULT_COLLECTION_SORT_ORDER = COLLECTION_SORT_ORDER.DateDesc

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -41,12 +41,6 @@ const TagCategoryUuidSchema = generateUuidSchema({
     "This is the uuid of a single tag category and will be used to uniquely identify it.",
 })
 
-const DateFilterStatusIdSchema = Type.Union([
-  Type.Literal(DATE_FILTER_STATUS_ID.Ended),
-  Type.Literal(DATE_FILTER_STATUS_ID.Ongoing),
-  Type.Literal(DATE_FILTER_STATUS_ID.Upcoming),
-])
-
 const tagCategoryLabelSchemaObject = {
   label: Type.String({
     title: "Filter name",

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -81,14 +81,11 @@ const dateFilterIsRequiredSchemaObject = {
 const TextFilterSchema = Type.Object(
   {
     ...tagCategoryLabelSchemaObject,
-    // Optional for backward compatibility — every pre-existing `tagCategories`
-    // entry was a text filter before date filters existed. Must stay
-    // `"text"` or absent (never `"date"`) so this branch and `DateFilterSchema`
-    // remain mutually exclusive for `oneOf` resolution.
+    ...tagCategoryIsRequiredSchemaObject,
+    // Optional on old rows. Must be "text" or absent so oneOf picks TextFilterSchema.
     type: Type.Optional(
       Type.Literal(TAG_CATEGORY_TYPE.Text, { format: "hidden" }),
     ),
-    ...tagCategoryIsRequiredSchemaObject,
     // Optional for backward compatibility. Missing/`undefined` must be read as
     // `DEFAULT_TAG_CATEGORY_DISPLAY` via `resolveTagCategoryDisplay`.
     // Omit JSON Schema `default`: Studio AJV runs with useDefaults, which would apply the

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -11,6 +11,7 @@ import {
 } from "~/interfaces"
 import { imageSchemaObject } from "~/schemas/internal"
 import {
+  COLLECTION_SORT_ORDER_PATTERN,
   REF_HREF_PATTERN,
   TRIMMED_NON_EMPTY_STRING_REGEX,
   TRIMMED_STRING_OR_EMPTY_REGEX,
@@ -39,6 +40,12 @@ const TagCategoryUuidSchema = generateUuidSchema({
   description:
     "This is the uuid of a single tag category and will be used to uniquely identify it.",
 })
+
+const DateFilterStatusIdSchema = Type.Union([
+  Type.Literal(DATE_FILTER_STATUS_ID.Ended),
+  Type.Literal(DATE_FILTER_STATUS_ID.Ongoing),
+  Type.Literal(DATE_FILTER_STATUS_ID.Upcoming),
+])
 
 const tagCategoryLabelSchemaObject = {
   label: Type.String({
@@ -80,11 +87,14 @@ const dateFilterIsRequiredSchemaObject = {
 const TextFilterSchema = Type.Object(
   {
     ...tagCategoryLabelSchemaObject,
-    ...tagCategoryIsRequiredSchemaObject,
-    // Optional on old rows. Must be "text" or absent so oneOf picks TextFilterSchema.
+    // Optional for backward compatibility — every pre-existing `tagCategories`
+    // entry was a text filter before date filters existed. Must stay
+    // `"text"` or absent (never `"date"`) so this branch and `DateFilterSchema`
+    // remain mutually exclusive for `oneOf` resolution.
     type: Type.Optional(
       Type.Literal(TAG_CATEGORY_TYPE.Text, { format: "hidden" }),
     ),
+    ...tagCategoryIsRequiredSchemaObject,
     // Optional for backward compatibility. Missing/`undefined` must be read as
     // `DEFAULT_TAG_CATEGORY_DISPLAY` via `resolveTagCategoryDisplay`.
     // Omit JSON Schema `default`: Studio AJV runs with useDefaults, which would apply the
@@ -362,24 +372,16 @@ export const CollectionPagePageSchema = Type.Intersect([
       ),
     ),
     sortOrder: Type.Optional(
-      Type.Union(
-        [
-          Type.Literal("date-desc", {
-            title: "By article date, newest → oldest",
-          }),
-          Type.Literal("date-asc", {
-            title: "By article date, oldest → newest",
-          }),
-          Type.Literal("title-asc", { title: "By title, A → Z" }),
-          Type.Literal("title-desc", { title: "By title, Z → A" }),
-        ],
-        {
-          title: "Sort items by",
-          description: "This might take a while to reflect on the preview.",
-          type: "string",
-          default: "date-desc",
+      Type.String({
+        title: "Sort items by",
+        description: "This might take a while to reflect on the preview.",
+        format: "collection-sort-order",
+        pattern: COLLECTION_SORT_ORDER_PATTERN,
+        errorMessage: {
+          pattern: "must be a valid collection sort order",
         },
-      ),
+        default: "date-desc",
+      }),
     ),
     // Deprecated, will be replaced with sortOrder above
     defaultSortBy: Type.Optional(

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -19,6 +19,7 @@ import {
 
 import {
   DATE_FILTER_STATUS,
+  DEFAULT_COLLECTION_SORT_ORDER,
   TAG_CATEGORY_DISPLAY_OPTIONS,
   TAG_CATEGORY_TYPE,
   type DateFilterStatusId,
@@ -371,7 +372,7 @@ export const CollectionPagePageSchema = Type.Intersect([
         errorMessage: {
           pattern: "must be a valid collection sort order",
         },
-        default: "date-desc",
+        default: DEFAULT_COLLECTION_SORT_ORDER,
       }),
     ),
     // Deprecated, will be replaced with sortOrder above

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -41,3 +41,4 @@ export {
 } from "./validation"
 
 export { createChildrenPagesComparator } from "./createChildrenPagesComparator"
+export { resolveCollectionSortOrder } from "../templates/next/layouts/Collection/utils/collectionSortOrder"

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -293,3 +293,12 @@ export const ASKGOV_ID_OR_URL_REGEX = `^\\s*(?:${ASKGOV_AGENCY_ID_REGEX}|${ASKGO
 // NOTE: Official documentation does not specify allowed length,
 // so we use ^GTM-[A-Z0-9]+$ (one or more chars) for future proofing.
 export const GTM_ID_STRING_REGEX = "^(GTM|G|GT)-[A-Z0-9]+$"
+
+// Collection page `sortOrder`: the four base literals, or
+// `date-filter-{uuid}-asc|desc` for a published date filter.
+// ✅ "date-desc"
+// ✅ "date-filter-550e8400-e29b-41d4-a716-446655440000-asc"
+// ❌ "totally-made-up"
+// ❌ "date-filter-not-a-uuid-desc"
+export const COLLECTION_SORT_ORDER_PATTERN =
+  "^(date-desc|date-asc|title-asc|title-desc|date-filter-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-(?:asc|desc))$"

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -295,7 +295,7 @@ export const ASKGOV_ID_OR_URL_REGEX = `^\\s*(?:${ASKGOV_AGENCY_ID_REGEX}|${ASKGO
 export const GTM_ID_STRING_REGEX = "^(GTM|G|GT)-[A-Z0-9]+$"
 
 // Collection page `sortOrder`: the four base literals, or
-// `date-filter-{uuid}-asc|desc` for a published date filter.
+// `date-filter-{uuid}-asc|desc` for a collection date filter (tag category of type date).
 // ✅ "date-desc"
 // ✅ "date-filter-550e8400-e29b-41d4-a716-446655440000-asc"
 // ❌ "totally-made-up"

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -1,3 +1,5 @@
+import { COLLECTION_SORT_ORDER } from "~/types/constants"
+
 const ALLOWED_URL_REGEXES = {
   external: "^https:\\/\\/",
   phone: "^tel:",
@@ -294,11 +296,11 @@ export const ASKGOV_ID_OR_URL_REGEX = `^\\s*(?:${ASKGOV_AGENCY_ID_REGEX}|${ASKGO
 // so we use ^GTM-[A-Z0-9]+$ (one or more chars) for future proofing.
 export const GTM_ID_STRING_REGEX = "^(GTM|G|GT)-[A-Z0-9]+$"
 
-// Collection page `sortOrder`: the four base literals, or
-// `date-filter-{uuid}-asc|desc` for a collection date filter (tag category of type date).
-// ✅ "date-desc"
+// Collection page `sortOrder`: one of the four `COLLECTION_SORT_ORDER`
+// literals, or `date-filter-{uuid}-asc|desc` for a collection date filter
+// (tag category of type date).
+// ✅ COLLECTION_SORT_ORDER.DateDesc ("date-desc")
 // ✅ "date-filter-550e8400-e29b-41d4-a716-446655440000-asc"
 // ❌ "totally-made-up"
 // ❌ "date-filter-not-a-uuid-desc"
-export const COLLECTION_SORT_ORDER_PATTERN =
-  "^(date-desc|date-asc|title-asc|title-desc|date-filter-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-(?:asc|desc))$"
+export const COLLECTION_SORT_ORDER_PATTERN = `^(${COLLECTION_SORT_ORDER.DateDesc}|${COLLECTION_SORT_ORDER.DateAsc}|${COLLECTION_SORT_ORDER.TitleAsc}|${COLLECTION_SORT_ORDER.TitleDesc}|date-filter-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-(?:asc|desc))$`


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 14 | +443 | -84 |
| 🧪 Test | 5 | +661 | -2 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes partial-date sort fallback when sorting collections by a date-filter value (#3264).

Items without the selected date filter now chain through publish-date / last-modified ordering (same as `sortCollectionItemsByDate`) instead of title-only fallback.

Also addresses review feedback:
- Gate sort-order normalization on successful tag query load; surface query errors in Studio
- Reuse shared `compareByPublishDate` comparator
- Tiebreak equal date-filter dates by last-modified before title
- Clarify validation comment for date-filter sort pattern

## Test plan

- [x] `pnpm test:unit` — `sortCollectionItems.test.ts` (including new publish-date fallback and last-modified tiebreaker cases)
- [x] `pnpm typecheck --filter @opengovsg/isomer-components`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bf8486f-fc71-47fc-93c5-7747598ad230?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bf8486f-fc71-47fc-93c5-7747598ad230&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







## /show-me to help explain what this PR does

This PR turns collection `sortOrder` from a fixed 4-option enum into an open, pattern-validated string, so each configured **date filter** (tag category) gets its own newest-to-oldest / oldest-to-newest sort option.

```mermaid
flowchart LR
    subgraph Schema["packages/components/src/types/page.ts"]
        S1["sortOrder: Type.Literal union<br/>(date-desc | date-asc | title-asc | title-desc)"] -. rewritten to .-> S2["sortOrder: Type.String<br/>pattern: COLLECTION_SORT_ORDER_PATTERN"]
    end

    S2 --> Editor

    subgraph Editor["Studio editor"]
        Tags["useCollectionTags()"] --> Opts["getCollectionSortOptions(tagCategories)"]
        Opts --> Control["JsonFormsCollectionSortOrderControl<br/>(SingleSelect)"]
        Control -->|resolveCollectionSortOrder| Control
    end

    Control -->|saved value| Value["sortOrder string,<br/>e.g. date-filter-550e8400...-desc"]

    Value --> Parse["parseCollectionSortOrder()"]
    Parse -->|kind: date| SortDate["sortCollectionItemsByDate"]
    Parse -->|kind: title| SortTitle["sortCollectionItemsByTitle"]
    Parse -->|kind: date-filter, filterId| SortFilter["sortCollectionItemsByDateFilter"]
```

**New value shape** (`packages/components/src/utils/validation.ts`):

```
COLLECTION_SORT_ORDER_PATTERN matches:
  date-desc | date-asc | title-asc | title-desc          (unchanged 4 base options)
  date-filter-{uuid}-asc | date-filter-{uuid}-desc        (new: one per date-filter tag category)
```

**Dispatch, before vs after** (`sortCollectionItems.ts`):

```diff
- const derivedSortBy = sortOrder ? sortOrder.split("-")[0] : sortBy
- const derivedSortDirection = sortOrder ? sortOrder.split("-")[1] : sortDirection
- switch (derivedSortBy) {
-   case "date": return sortCollectionItemsByDate({ items, sortDirection: derivedSortDirection })
-   case "title": return sortCollectionItemsByTitle({ items, sortDirection: derivedSortDirection })
- }
+ const parsedSortOrder = parseCollectionSortOrder(sortOrder)
+ switch (parsedSortOrder.kind) {
+   case "date": return sortCollectionItemsByDate({ items, sortDirection: parsedSortOrder.direction })
+   case "title": return sortCollectionItemsByTitle({ items, sortDirection: parsedSortOrder.direction })
+   case "date-filter":
+     return sortCollectionItemsByDateFilter({
+       items,
+       filterId: parsedSortOrder.filterId,
+       sortDirection: parsedSortOrder.direction,
+     })
+ }
```

The old code read `sortOrder.split("-")[0]`, which returns `"date"` for a value like `date-filter-550e8400-...-desc` — it couldn't distinguish a date-filter sort from a plain date sort, let alone recover the filter id. `parseCollectionSortOrder` replaces that naive split with a real parser.

**Files touched:**

```
packages/components/src/
├── types/constants.ts                  # + COLLECTION_SORT_ORDER, DEFAULT_COLLECTION_SORT_ORDER
├── types/page.ts                       # sortOrder: literal union -> pattern-validated string
├── utils/validation.ts                 # + COLLECTION_SORT_ORDER_PATTERN (base | date-filter-{uuid}-asc|desc)
└── templates/next/layouts/Collection/utils/
    ├── collectionSortOrder.ts          # NEW: parseCollectionSortOrder / resolveCollectionSortOrder
    └── sortCollectionItems.ts          # + sortCollectionItemsByDateFilter, dispatch by parsed.kind

apps/studio/src/features/editing-experience/
├── utils/getCollectionSortOptions.ts   # NEW: base 4 options + one asc/desc pair per date-filter tag category
└── components/form-builder/renderers/controls/
    └── JsonFormsCollectionSortOrderControl.tsx   # NEW: dropdown driven by useCollectionTags,
                                                   #      auto-resolves stale sortOrder via resolveCollectionSortOrder
```

`resolveCollectionSortOrder` is what keeps a saved `sortOrder` from going stale: if a page was sorted by a date filter that's since been deleted, it silently falls back to `DEFAULT_COLLECTION_SORT_ORDER` instead of crashing the editor or leaving an invalid value in the schema.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62267109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The production changes appear safe to merge, with one non-blocking reliability issue in a Storybook interaction helper.

<details><summary><h3>Summary</h3></summary>

This PR adds collection sorting by configured date-filter categories and hardens related editor and published-site behavior.
- Extends collection sort-order validation, parsing, option generation, and rendering dispatch for date-filter UUIDs.
- Preserves publish-date and last-modified fallback ordering for cards without the selected date value.
- Gates Studio normalization on successful tag loading and surfaces query failures.
- Includes follow-up Storybook, date-filter availability, and siderail coverage changes.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Tags[Collection tag categories] --> Options[Generate base and date-filter sort options]
  Options --> Studio[Studio sort-order control]
  Studio --> Schema[Pattern-validated sortOrder]
  Schema --> Parser[Parse collection sort order]
  Parser -->|date| Publish[Sort by publish date]
  Parser -->|title| Title[Sort by title]
  Parser -->|date-filter UUID| FilterDate[Sort by tagged date]
  FilterDate -->|missing tagged date| Publish
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix(components): scope mobile date filte..."](https://github.com/opengovsg/isomer/commit/1d3d3dd9319d3f35c0ec5848cfa81a6db59f56f8)</sub>

<!-- /greptile_comment -->