### PR TITLE
feat(navbar,footer): add "Move to" reorder fallback for browsers that block drag-and-drop

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/components/DraggableLinkButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/DraggableLinkButton.tsx
@@ -18,6 +18,7 @@ import { getResourceIdFromReferenceLink } from "@opengovsg/isomer-components"
 import {
   BiDotsHorizontalRounded,
   BiGridVertical,
+  BiMove,
   BiPencil,
   BiSolidErrorCircle,
   BiTrash,
@@ -58,6 +59,7 @@ interface DraggableLinkButtonProps extends Omit<
   "selected" | "enabled" | "handleSelect" | "removeItem" | "translations"
 > {
   onDeleteItem: () => void
+  onMoveItem: () => void
   resetLink: () => void
 }
 
@@ -68,6 +70,7 @@ const DraggableLinkButton = forwardRef<DraggableLinkButtonProps, "div">(
       dragHandleProps,
       setSelectedIndex,
       onDeleteItem,
+      onMoveItem,
       isError,
       index,
       path,
@@ -230,6 +233,16 @@ const DraggableLinkButton = forwardRef<DraggableLinkButtonProps, "div">(
                     >
                       <Icon as={BiPencil} />
                       <Text textStyle="body-2">Edit link</Text>
+                    </Flex>
+                  </MenuItem>
+                  <MenuItem onClick={onMoveItem}>
+                    <Flex
+                      alignItems="center"
+                      gap="0.5rem"
+                      color="base.content.strong"
+                    >
+                      <Icon as={BiMove} />
+                      <Text textStyle="body-2">Move to</Text>
                     </Flex>
                   </MenuItem>
                   <MenuItem onClick={onDeleteItem}>

--- a/apps/studio/src/features/editing-experience/components/form-builder/components/MovePositionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/MovePositionModal.tsx
@@ -1,0 +1,112 @@
+import {
+  Box,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+import { Fragment } from "react"
+import { BiPlus } from "react-icons/bi"
+
+export interface MovePositionModalSibling {
+  key: string
+  label: string
+}
+
+interface MovePositionModalProps {
+  isOpen: boolean
+  label: string
+  /** Ordered list of the other items in the same list, excluding the one being moved */
+  siblings: MovePositionModalSibling[]
+  onClose: () => void
+  /** Index (0..siblings.length) of the slot to insert the moved item before */
+  onMove: (targetIndex: number) => void
+}
+
+export const MovePositionModal = ({
+  isOpen,
+  label,
+  siblings,
+  onClose,
+  onMove,
+}: MovePositionModalProps): JSX.Element => {
+  const handleMove = (targetIndex: number) => {
+    onMove(targetIndex)
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader mr="3.5rem">Move “{label}”</ModalHeader>
+        <ModalCloseButton size="lg" />
+
+        <ModalBody>
+          {siblings.length === 0 ? (
+            <Text textStyle="body-2" textColor="base.content.medium">
+              There’s nothing else here to move “{label}” relative to.
+            </Text>
+          ) : (
+            <VStack align="stretch" spacing={0}>
+              <InsertionPoint onClick={() => handleMove(0)} />
+
+              {siblings.map((sibling, index) => (
+                <Fragment key={sibling.key}>
+                  <Box
+                    px="0.75rem"
+                    py="0.5rem"
+                    borderWidth="1px"
+                    borderStyle="solid"
+                    borderColor="base.divider.medium"
+                    borderRadius="0.375rem"
+                    bgColor="utility.ui"
+                  >
+                    <Text
+                      textStyle="body-2"
+                      textColor="base.content.default"
+                      noOfLines={1}
+                    >
+                      {sibling.label}
+                    </Text>
+                  </Box>
+
+                  <InsertionPoint onClick={() => handleMove(index + 1)} />
+                </Fragment>
+              ))}
+            </VStack>
+          )}
+        </ModalBody>
+
+        <ModalFooter>
+          <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+const InsertionPoint = ({ onClick }: { onClick: () => void }) => (
+  <HStack
+    as="button"
+    type="button"
+    onClick={onClick}
+    w="full"
+    justifyContent="center"
+    py="0.375rem"
+    color="interaction.main.default"
+    _hover={{ color: "interaction.main.hover" }}
+    layerStyle="focusRing"
+  >
+    <BiPlus />
+    <Text textStyle="caption-2">Move here</Text>
+  </HStack>
+)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkArrayControl.tsx
@@ -38,7 +38,7 @@ import {
   withJsonFormsArrayLayoutProps,
 } from "@jsonforms/react"
 import { Button } from "@opengovsg/design-system-react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   BiDirections,
   BiLeftArrowAlt,
@@ -48,6 +48,7 @@ import {
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 
 import DraggableLinkButton from "../../components/DraggableLinkButton"
+import { MovePositionModal } from "../../components/MovePositionModal"
 import { FORM_BUILDER_PARENT_ID } from "../../constants"
 import { useBuilderErrors } from "../../ErrorProvider"
 
@@ -261,10 +262,12 @@ function JsonFormsArrayLinkControl({
   uischema,
   description,
 }: ArrayLayoutProps) {
+  const ctx = useJsonForms()
   const { hasErrorAt } = useBuilderErrors()
   const [selectedIndex, setSelectedIndex] = useState<number>()
   const [selectedPathForDeletion, setSelectedPathForDeletion] =
     useState<string>()
+  const [selectedIndexForMove, setSelectedIndexForMove] = useState<number>()
 
   const isRemoveItemDisabled =
     arraySchema.minItems !== undefined && data <= arraySchema.minItems
@@ -303,6 +306,22 @@ function JsonFormsArrayLinkControl({
       }
     },
     [moveUp, moveDown],
+  )
+  const siblingLabels = useMemo(
+    () =>
+      [...Array(data).keys()].map(
+        (index) =>
+          computeChildLabel(
+            ctx.core?.data,
+            composePaths(path, `${index}`),
+            "",
+            schema,
+            ctx.core?.schema ?? {},
+            ctx.i18n?.translate ?? ((s) => s),
+            uischema,
+          ) || "Untitled link",
+      ),
+    [ctx.core?.data, ctx.core?.schema, ctx.i18n, data, path, schema, uischema],
   )
   const handleDeleteItem = () => {
     if (selectedPathForDeletion === undefined) return
@@ -372,6 +391,26 @@ function JsonFormsArrayLinkControl({
         path={selectedPathForDeletion ?? ""}
         schema={schema}
         uischema={getChildUiSchema(selectedPathForDeletion ?? "")}
+      />
+
+      <MovePositionModal
+        isOpen={selectedIndexForMove !== undefined}
+        label={
+          selectedIndexForMove !== undefined
+            ? (siblingLabels[selectedIndexForMove] ?? "")
+            : ""
+        }
+        siblings={siblingLabels
+          .map((itemLabel, index) => ({ key: `${index}`, label: itemLabel }))
+          .filter((_, index) => index !== selectedIndexForMove)}
+        onClose={() => setSelectedIndexForMove(undefined)}
+        onMove={(targetIndex) => {
+          if (selectedIndexForMove === undefined) {
+            return
+          }
+
+          handleMoveItem(path, selectedIndexForMove, targetIndex)
+        }}
       />
 
       <VStack spacing="0.375rem" align="start">
@@ -475,6 +514,7 @@ function JsonFormsArrayLinkControl({
                           onDeleteItem={() =>
                             setSelectedPathForDeletion(childPath)
                           }
+                          onMoveItem={() => setSelectedIndexForMove(index)}
                           resetLink={() => {
                             handleRemoveItem(path, index)()
                           }}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/JsonFormsNavbarControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/JsonFormsNavbarControl.tsx
@@ -5,6 +5,7 @@ import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/clo
 import { extractInstruction } from "@atlaskit/pragmatic-drag-and-drop-hitbox/list-item"
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine"
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
+import { reorder } from "@atlaskit/pragmatic-drag-and-drop/reorder"
 import {
   Accordion,
   Box,
@@ -27,7 +28,7 @@ import {
 import { useJsonForms, withJsonFormsArrayLayoutProps } from "@jsonforms/react"
 import { Infobox } from "@opengovsg/design-system-react"
 import { get } from "lodash-es"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { BiPlusCircle } from "react-icons/bi"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 
@@ -102,6 +103,37 @@ function JsonFormsNavbarControl({
       )
     },
     [arraySchema.maxItems, ctx, data, path],
+  )
+
+  const handleMoveTo = useCallback(
+    (arrPath: string, fromIndex: number, toIndex: number) => {
+      if (fromIndex === toIndex) {
+        return
+      }
+
+      ctx.dispatch?.(
+        Actions.update(arrPath, (prevData) =>
+          reorder({
+            list: prevData as NavbarItems["items"],
+            startIndex: fromIndex,
+            finishIndex: toIndex,
+          }),
+        ),
+      )
+    },
+    [ctx],
+  )
+
+  const allTopLevelItems = useMemo(
+    () =>
+      [...Array(data).keys()].map((i) => {
+        const item = get(ctx.core?.data, composePaths(path, String(i))) as
+          | PartialDeep<NavbarItems["items"][number]>
+          | undefined
+
+        return { name: item?.name }
+      }),
+    [ctx.core?.data, data, path],
   )
 
   const isOverMaxItems = isFirstLevelLinksOverLimit(data, arraySchema.maxItems)
@@ -298,7 +330,19 @@ function JsonFormsNavbarControl({
                           handleRemove(path, index)
                         }
                       }}
+                      moveItem={(targetIndex, subItemIndex) => {
+                        if (subItemIndex !== undefined) {
+                          handleMoveTo(
+                            [childPath, "items"].join("."),
+                            subItemIndex,
+                            targetIndex,
+                          )
+                        } else {
+                          handleMoveTo(path, index, targetIndex)
+                        }
+                      }}
                       subItems={childItem.items}
+                      allTopLevelItems={allTopLevelItems}
                     />
                   )
                 })}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/JsonFormsNavbarControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/JsonFormsNavbarControl.tsx
@@ -5,7 +5,6 @@ import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/clo
 import { extractInstruction } from "@atlaskit/pragmatic-drag-and-drop-hitbox/list-item"
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine"
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
-import { reorder } from "@atlaskit/pragmatic-drag-and-drop/reorder"
 import {
   Accordion,
   Box,
@@ -36,7 +35,11 @@ import type { NavbarItems } from "./types"
 import { getParentPath } from "../utils"
 import { EditNavbarItem } from "./EditNavbarItem"
 import { StackableNavbarItem } from "./StackableNavbarItem"
-import { handleMoveItem, isFirstLevelLinksOverLimit } from "./utils"
+import {
+  getNavbarItemPath,
+  handleMoveItem,
+  isFirstLevelLinksOverLimit,
+} from "./utils"
 
 export const jsonFormsNavbarControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.NavbarControl,
@@ -105,23 +108,8 @@ function JsonFormsNavbarControl({
     [arraySchema.maxItems, ctx, data, path],
   )
 
-  const handleMoveTo = useCallback(
-    (arrPath: string, fromIndex: number, toIndex: number) => {
-      if (fromIndex === toIndex) {
-        return
-      }
-
-      ctx.dispatch?.(
-        Actions.update(arrPath, (prevData) =>
-          reorder({
-            list: prevData as NavbarItems["items"],
-            startIndex: fromIndex,
-            finishIndex: toIndex,
-          }),
-        ),
-      )
-    },
-    [ctx],
+  const isTopLevelFull = !!(
+    arraySchema.maxItems && data >= arraySchema.maxItems
   )
 
   const allTopLevelItems = useMemo(
@@ -330,19 +318,39 @@ function JsonFormsNavbarControl({
                           handleRemove(path, index)
                         }
                       }}
-                      moveItem={(targetIndex, subItemIndex) => {
+                      moveItem={(destinationParentIndex, subItemIndex) => {
                         if (subItemIndex !== undefined) {
-                          handleMoveTo(
-                            [childPath, "items"].join("."),
+                          const originalPath = getNavbarItemPath(
                             subItemIndex,
-                            targetIndex,
+                            index,
                           )
-                        } else {
-                          handleMoveTo(path, index, targetIndex)
+
+                          if (destinationParentIndex === undefined) {
+                            // Move the subitem out to become a top-level item
+                            handleMove(
+                              originalPath,
+                              getNavbarItemPath(Math.max(data - 1, 0)),
+                            )
+                          } else {
+                            handleMove(
+                              originalPath,
+                              getNavbarItemPath(destinationParentIndex),
+                              "combine",
+                            )
+                          }
+                        } else if (destinationParentIndex !== undefined) {
+                          // Move this top-level item to become a subitem of
+                          // another top-level item
+                          handleMove(
+                            getNavbarItemPath(index),
+                            getNavbarItemPath(destinationParentIndex),
+                            "combine",
+                          )
                         }
                       }}
                       subItems={childItem.items}
                       allTopLevelItems={allTopLevelItems}
+                      isTopLevelFull={isTopLevelFull}
                     />
                   )
                 })}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/MoveNavbarItemModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/MoveNavbarItemModal.tsx
@@ -1,0 +1,117 @@
+import {
+  Box,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  Tooltip,
+  VStack,
+} from "@chakra-ui/react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+
+export interface MoveNavbarItemDestination {
+  key: string
+  label: string
+  isDisabled?: boolean
+}
+
+interface MoveNavbarItemModalProps {
+  isOpen: boolean
+  label: string
+  /** Top-level items (and "Top level" itself, where applicable) this item can be nested under */
+  destinations: MoveNavbarItemDestination[]
+  onClose: () => void
+  onMove: (destinationKey: string) => void
+}
+
+export const MoveNavbarItemModal = ({
+  isOpen,
+  label,
+  destinations,
+  onClose,
+  onMove,
+}: MoveNavbarItemModalProps): JSX.Element => {
+  const handleMove = (destinationKey: string) => {
+    onMove(destinationKey)
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader mr="3.5rem">Move “{label}” to…</ModalHeader>
+        <ModalCloseButton size="lg" />
+
+        <ModalBody>
+          {destinations.length === 0 ? (
+            <Text textStyle="body-2" textColor="base.content.medium">
+              There’s nowhere else to move “{label}” to.
+            </Text>
+          ) : (
+            <VStack align="stretch" spacing="0.5rem">
+              {destinations.map((destination) => (
+                <Tooltip
+                  key={destination.key}
+                  label={
+                    destination.isDisabled
+                      ? "You can only have up to 8 first-level links."
+                      : undefined
+                  }
+                  hasArrow
+                >
+                  <Box
+                    as="button"
+                    type="button"
+                    onClick={() => {
+                      if (!destination.isDisabled) {
+                        handleMove(destination.key)
+                      }
+                    }}
+                    disabled={destination.isDisabled}
+                    px="0.75rem"
+                    py="0.625rem"
+                    borderWidth="1px"
+                    borderStyle="solid"
+                    borderColor="base.divider.medium"
+                    borderRadius="0.375rem"
+                    bgColor="utility.ui"
+                    textAlign="start"
+                    w="full"
+                    opacity={destination.isDisabled ? 0.5 : 1}
+                    cursor={destination.isDisabled ? "not-allowed" : "pointer"}
+                    _hover={
+                      destination.isDisabled
+                        ? undefined
+                        : {
+                            borderColor: "interaction.main-subtle.hover",
+                            bg: "interaction.muted.main.hover",
+                          }
+                    }
+                  >
+                    <Text
+                      textStyle="body-2"
+                      textColor="base.content.default"
+                      noOfLines={1}
+                    >
+                      {destination.label}
+                    </Text>
+                  </Box>
+                </Tooltip>
+              ))}
+            </VStack>
+          )}
+        </ModalBody>
+
+        <ModalFooter>
+          <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/NavbarItemBox.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/NavbarItemBox.tsx
@@ -359,16 +359,18 @@ export const NavbarItemBox = ({
                   <Text textStyle="body-2">Edit link</Text>
                 </Flex>
               </MenuItem>
-              <MenuItem onClick={onMoveItem}>
-                <Flex
-                  alignItems="center"
-                  gap="0.5rem"
-                  color="base.content.strong"
-                >
-                  <Icon as={BiMove} />
-                  <Text textStyle="body-2">Move to</Text>
-                </Flex>
-              </MenuItem>
+              {(!subItems || subItems.length === 0) && (
+                <MenuItem onClick={onMoveItem}>
+                  <Flex
+                    alignItems="center"
+                    gap="0.5rem"
+                    color="base.content.strong"
+                  >
+                    <Icon as={BiMove} />
+                    <Text textStyle="body-2">Move to</Text>
+                  </Flex>
+                </MenuItem>
+              )}
               <MenuItem onClick={onDeleteItem}>
                 <Flex
                   alignItems="center"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/NavbarItemBox.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/NavbarItemBox.tsx
@@ -35,6 +35,7 @@ import {
   BiChevronDown,
   BiDotsHorizontalRounded,
   BiGridVertical,
+  BiMove,
   BiPencil,
   BiSolidErrorCircle,
   BiTrash,
@@ -50,6 +51,7 @@ interface NavbarItemBoxProps {
   index: number
   onEditItem: () => void
   onDeleteItem: () => void
+  onMoveItem: () => void
   name?: string
   description?: string
   subItems?: Pick<NavbarItemBoxProps, "name" | "description">[]
@@ -66,6 +68,7 @@ export const NavbarItemBox = ({
   index,
   onEditItem,
   onDeleteItem,
+  onMoveItem,
   name = DEFAULT_NAVBAR_ITEM_TITLE,
   description = DEFAULT_NAVBAR_ITEM_DESCRIPTION,
   subItems,
@@ -354,6 +357,16 @@ export const NavbarItemBox = ({
                 >
                   <Icon as={BiPencil} />
                   <Text textStyle="body-2">Edit link</Text>
+                </Flex>
+              </MenuItem>
+              <MenuItem onClick={onMoveItem}>
+                <Flex
+                  alignItems="center"
+                  gap="0.5rem"
+                  color="base.content.strong"
+                >
+                  <Icon as={BiMove} />
+                  <Text textStyle="body-2">Move to</Text>
                 </Flex>
               </MenuItem>
               <MenuItem onClick={onDeleteItem}>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/StackableNavbarItem.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/StackableNavbarItem.tsx
@@ -25,6 +25,7 @@ import {
 } from "@chakra-ui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 
+import { MovePositionModal } from "../../../components/MovePositionModal"
 import {
   DEFAULT_NAVBAR_ITEM_DESCRIPTION,
   DEFAULT_NAVBAR_ITEM_TITLE,
@@ -51,9 +52,12 @@ interface StackableNavbarItemProps {
   errors: ErrorObject<string, Record<string, any>, unknown>[]
   onEdit: (subItemIndex?: number) => void
   removeItem: (subItemIndex?: number) => void
+  moveItem: (targetIndex: number, subItemIndex?: number) => void
   name?: string
   description?: string
   subItems?: Pick<StackableNavbarItemProps, "name" | "description">[]
+  /** Every top-level navbar item, in order, used to build the "Move to" list for this item */
+  allTopLevelItems: Pick<StackableNavbarItemProps, "name">[]
 }
 
 export const StackableNavbarItem = ({
@@ -61,9 +65,11 @@ export const StackableNavbarItem = ({
   errors,
   onEdit,
   removeItem,
+  moveItem,
   name,
   description,
   subItems,
+  allTopLevelItems,
 }: StackableNavbarItemProps) => {
   const {
     isOpen: isDeleteGroupModalOpen,
@@ -76,6 +82,17 @@ export const StackableNavbarItem = ({
     onClose: onDeleteSubItemModalClose,
   } = useDisclosure()
   const [subItemToDelete, setSubItemToDelete] = useState<number>()
+  const {
+    isOpen: isMoveMainItemModalOpen,
+    onOpen: onMoveMainItemModalOpen,
+    onClose: onMoveMainItemModalClose,
+  } = useDisclosure()
+  const {
+    isOpen: isMoveSubItemModalOpen,
+    onOpen: onMoveSubItemModalOpen,
+    onClose: onMoveSubItemModalClose,
+  } = useDisclosure()
+  const [subItemToMove, setSubItemToMove] = useState<number>()
   const [isNavbarItemDragging, setIsNavbarItemDragging] = useState(false)
   const [isItemBeingDraggedOver, setIsItemBeingDraggedOver] = useState(false)
   const [navbarItemClosestEdge, setNavbarItemClosestEdge] =
@@ -239,6 +256,45 @@ export const StackableNavbarItem = ({
         />
       )}
 
+      <MovePositionModal
+        isOpen={isMoveMainItemModalOpen}
+        label={name || DEFAULT_NAVBAR_ITEM_TITLE}
+        siblings={allTopLevelItems
+          .map((item, i) => ({
+            key: `${i}`,
+            label: item.name || DEFAULT_NAVBAR_ITEM_TITLE,
+            itemIndex: i,
+          }))
+          .filter(({ itemIndex }) => itemIndex !== index)}
+        onClose={onMoveMainItemModalClose}
+        onMove={(targetIndex) => moveItem(targetIndex)}
+      />
+
+      {hasSubItems && (
+        <MovePositionModal
+          isOpen={isMoveSubItemModalOpen}
+          label={
+            subItems[subItemToMove ?? 0]?.name ?? DEFAULT_NAVBAR_ITEM_TITLE
+          }
+          siblings={subItems
+            .map((item, i) => ({
+              key: `${i}`,
+              label: item.name || DEFAULT_NAVBAR_ITEM_TITLE,
+              itemIndex: i,
+            }))
+            .filter(({ itemIndex }) => itemIndex !== subItemToMove)}
+          onClose={() => {
+            onMoveSubItemModalClose()
+            setSubItemToMove(undefined)
+          }}
+          onMove={(targetIndex) => {
+            if (subItemToMove !== undefined) {
+              moveItem(targetIndex, subItemToMove)
+            }
+          }}
+        />
+      )}
+
       {navbarItemClosestEdge === "top" && !isItemBeingDraggedOver && (
         <Divider borderColor="base.divider.brand" borderWidth="2px" />
       )}
@@ -259,6 +315,7 @@ export const StackableNavbarItem = ({
             isNavbarItemDragging={isNavbarItemDragging}
             onEditItem={onEdit}
             onDeleteItem={onDeleteGroupModalOpen}
+            onMoveItem={onMoveMainItemModalOpen}
             isItemBeingDraggedOver={isItemBeingDraggedOver}
             setIsItemBeingDraggedOver={setIsItemBeingDraggedOver}
             isInvalid={numberOfErrors > 0}
@@ -296,6 +353,10 @@ export const StackableNavbarItem = ({
                       onDeleteItem={() => {
                         setSubItemToDelete(idx)
                         onDeleteSubItemModalOpen()
+                      }}
+                      onMoveItem={() => {
+                        setSubItemToMove(idx)
+                        onMoveSubItemModalOpen()
                       }}
                       isInvalid={isInvalid}
                     />

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/StackableNavbarItem.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/StackableNavbarItem.tsx
@@ -25,7 +25,6 @@ import {
 } from "@chakra-ui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 
-import { MovePositionModal } from "../../../components/MovePositionModal"
 import {
   DEFAULT_NAVBAR_ITEM_DESCRIPTION,
   DEFAULT_NAVBAR_ITEM_TITLE,
@@ -33,6 +32,7 @@ import {
 } from "./constants"
 import { DeleteGroupModal } from "./DeleteGroupModal"
 import { DeleteSubItemModal } from "./DeleteSubItemModal"
+import { MoveNavbarItemModal } from "./MoveNavbarItemModal"
 import { NavbarItemBox } from "./NavbarItemBox"
 import { getInstancePathFromNavbarItemPath, getNavbarItemPath } from "./utils"
 
@@ -52,12 +52,21 @@ interface StackableNavbarItemProps {
   errors: ErrorObject<string, Record<string, any>, unknown>[]
   onEdit: (subItemIndex?: number) => void
   removeItem: (subItemIndex?: number) => void
-  moveItem: (targetIndex: number, subItemIndex?: number) => void
+  /**
+   * Moves an item to become a subitem of the top-level item at
+   * `destinationParentIndex`, or to the top level if undefined.
+   */
+  moveItem: (
+    destinationParentIndex: number | undefined,
+    subItemIndex?: number,
+  ) => void
   name?: string
   description?: string
   subItems?: Pick<StackableNavbarItemProps, "name" | "description">[]
-  /** Every top-level navbar item, in order, used to build the "Move to" list for this item */
+  /** Every top-level navbar item, in order, used to build the "Move to" destination list */
   allTopLevelItems: Pick<StackableNavbarItemProps, "name">[]
+  /** Whether the top-level items array is already at its maxItems limit */
+  isTopLevelFull: boolean
 }
 
 export const StackableNavbarItem = ({
@@ -70,6 +79,7 @@ export const StackableNavbarItem = ({
   description,
   subItems,
   allTopLevelItems,
+  isTopLevelFull,
 }: StackableNavbarItemProps) => {
   const {
     isOpen: isDeleteGroupModalOpen,
@@ -82,17 +92,8 @@ export const StackableNavbarItem = ({
     onClose: onDeleteSubItemModalClose,
   } = useDisclosure()
   const [subItemToDelete, setSubItemToDelete] = useState<number>()
-  const {
-    isOpen: isMoveMainItemModalOpen,
-    onOpen: onMoveMainItemModalOpen,
-    onClose: onMoveMainItemModalClose,
-  } = useDisclosure()
-  const {
-    isOpen: isMoveSubItemModalOpen,
-    onOpen: onMoveSubItemModalOpen,
-    onClose: onMoveSubItemModalClose,
-  } = useDisclosure()
-  const [subItemToMove, setSubItemToMove] = useState<number>()
+  // "main" moves this item itself; a number moves the subitem at that index
+  const [moveTarget, setMoveTarget] = useState<"main" | number>()
   const [isNavbarItemDragging, setIsNavbarItemDragging] = useState(false)
   const [isItemBeingDraggedOver, setIsItemBeingDraggedOver] = useState(false)
   const [navbarItemClosestEdge, setNavbarItemClosestEdge] =
@@ -103,6 +104,37 @@ export const StackableNavbarItem = ({
   const subItemsDroppableZoneRef = useRef<HTMLDivElement | null>(null)
 
   const hasSubItems = !!subItems && subItems.length > 0
+
+  const movingSubItemIndex =
+    typeof moveTarget === "number" ? moveTarget : undefined
+  const moveLabel =
+    moveTarget === "main"
+      ? name || DEFAULT_NAVBAR_ITEM_TITLE
+      : (subItems?.[movingSubItemIndex ?? 0]?.name ?? DEFAULT_NAVBAR_ITEM_TITLE)
+  const moveDestinations = useMemo(() => {
+    if (moveTarget === undefined) {
+      return []
+    }
+
+    // Every other top-level item can become the new parent, whether it
+    // already has subitems or not; the item's own current parent (or
+    // itself, when moving a top-level item) is excluded as a no-op.
+    const otherTopLevelItems = allTopLevelItems
+      .map((item, i) => ({
+        key: `${i}`,
+        label: item.name || DEFAULT_NAVBAR_ITEM_TITLE,
+      }))
+      .filter((_, i) => i !== index)
+
+    if (moveTarget === "main") {
+      return otherTopLevelItems
+    }
+
+    return [
+      { key: "top-level", label: "Top level", isDisabled: isTopLevelFull },
+      ...otherTopLevelItems,
+    ]
+  }, [moveTarget, allTopLevelItems, index, isTopLevelFull])
 
   const numberOfErrors = getNumberOfErrors(errors, getNavbarItemPath(index))
   const itemDescription = useMemo(() => {
@@ -256,44 +288,17 @@ export const StackableNavbarItem = ({
         />
       )}
 
-      <MovePositionModal
-        isOpen={isMoveMainItemModalOpen}
-        label={name || DEFAULT_NAVBAR_ITEM_TITLE}
-        siblings={allTopLevelItems
-          .map((item, i) => ({
-            key: `${i}`,
-            label: item.name || DEFAULT_NAVBAR_ITEM_TITLE,
-            itemIndex: i,
-          }))
-          .filter(({ itemIndex }) => itemIndex !== index)}
-        onClose={onMoveMainItemModalClose}
-        onMove={(targetIndex) => moveItem(targetIndex)}
+      <MoveNavbarItemModal
+        isOpen={moveTarget !== undefined}
+        label={moveLabel}
+        destinations={moveDestinations}
+        onClose={() => setMoveTarget(undefined)}
+        onMove={(destinationKey) => {
+          const destinationParentIndex =
+            destinationKey === "top-level" ? undefined : Number(destinationKey)
+          moveItem(destinationParentIndex, movingSubItemIndex)
+        }}
       />
-
-      {hasSubItems && (
-        <MovePositionModal
-          isOpen={isMoveSubItemModalOpen}
-          label={
-            subItems[subItemToMove ?? 0]?.name ?? DEFAULT_NAVBAR_ITEM_TITLE
-          }
-          siblings={subItems
-            .map((item, i) => ({
-              key: `${i}`,
-              label: item.name || DEFAULT_NAVBAR_ITEM_TITLE,
-              itemIndex: i,
-            }))
-            .filter(({ itemIndex }) => itemIndex !== subItemToMove)}
-          onClose={() => {
-            onMoveSubItemModalClose()
-            setSubItemToMove(undefined)
-          }}
-          onMove={(targetIndex) => {
-            if (subItemToMove !== undefined) {
-              moveItem(targetIndex, subItemToMove)
-            }
-          }}
-        />
-      )}
 
       {navbarItemClosestEdge === "top" && !isItemBeingDraggedOver && (
         <Divider borderColor="base.divider.brand" borderWidth="2px" />
@@ -315,7 +320,7 @@ export const StackableNavbarItem = ({
             isNavbarItemDragging={isNavbarItemDragging}
             onEditItem={onEdit}
             onDeleteItem={onDeleteGroupModalOpen}
-            onMoveItem={onMoveMainItemModalOpen}
+            onMoveItem={() => setMoveTarget("main")}
             isItemBeingDraggedOver={isItemBeingDraggedOver}
             setIsItemBeingDraggedOver={setIsItemBeingDraggedOver}
             isInvalid={numberOfErrors > 0}
@@ -354,10 +359,7 @@ export const StackableNavbarItem = ({
                         setSubItemToDelete(idx)
                         onDeleteSubItemModalOpen()
                       }}
-                      onMoveItem={() => {
-                        setSubItemToMove(idx)
-                        onMoveSubItemModalOpen()
-                      }}
+                      onMoveItem={() => setMoveTarget(idx)}
                       isInvalid={isInvalid}
                     />
                   )


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 7 | +415 | -3 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
Drag-and-drop reordering of navbar/footer items can be blocked by client-side browser security policies (see [ISOM-2544](https://linear.app/ogp/issue/ISOM-2544)), leaving no way to reorganize in those cases.

**Navbar** — reworked to match [ISOM-2545](https://linear.app/ogp/issue/ISOM-2545) / the prototype shared in [this thread](https://opengovproducts.slack.com/archives/C06R4DX966P/p1787808232005509?thread_ts=1787734861.723749&cid=C06R4DX966P):
- A **"Move to"** kebab-menu action appears only on navbar items **without nested items** (plain top-level links and sub-items — not groups).
- Clicking it opens a modal to pick a **destination parent**: "Top level", or any other top-level item to nest under.
- Validation: "Top level" is disabled once the top-level array is at its 8-item limit; nesting under an already-nested item is structurally impossible since only top-level items are offered as destinations.
- Reuses the exact reparenting operations (`moveSingleMainItemToBecomeSubitem`, `moveSubItemToBecomeSubItemOfAnother`, `moveSubItemToBecomeMainItem`) already exercised by drag-and-drop via the existing `handleMoveItem`/`handleMove` — no new data-manipulation logic, just a new (non-drag) way to trigger it.

**Footer** — simpler same-container reorder, unchanged from the original design (footer has no nesting concept, so a destination-parent picker doesn't apply):
- A **"Move to"** action on each link in `siteNavItems` / `customNavItems` opens a position-picker modal showing that column's other links with clickable insertion points, reusing the existing `moveUp`/`moveDown` JSONForms actions.
- No cross-column moves.

Both are purely additive — existing drag-and-drop reordering is untouched and still works exactly as before.

## Test plan
- [x] `tsc --noEmit` passes for `apps/studio`
- [x] `oxlint` passes on all changed files
- [ ] Manually verify in the Studio UI:
  - Navbar: a plain top-level link and a sub-item both show "Move to" and can be reparented (to "Top level" and to another top-level item); a group does **not** show "Move to"; "Top level" is disabled with a tooltip when the top-level array is full
  - Footer: both columns can reorder links via "Move to"; empty-state modal shows for single-item columns
  - Drag-and-drop still works for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)