### PR TITLE
chore(components): hide site entity settings schema

### DIFF
--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -116,6 +116,7 @@ export const SiteEntitySettingsSchema = Type.Object(
     title: "Organisation structured data",
     description:
       "Help search engines understand the organisation that owns this site.",
+    format: "hidden",
   },
 )
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +1 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Site entity structured-data settings are exposed in Studio even though they are not intended to be user-editable.

No linked issue.

## Solution

Mark `SiteEntitySettingsSchema` with `format: "hidden"` so the JSON Forms renderer does not display it.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Hide organisation structured-data settings from the Studio form UI.

**Bug Fixes**:

- None

## Before & After Screenshots

**BEFORE**:

Not applicable for this schema-only change.

**AFTER**:

Not applicable for this schema-only change.

## Tests

- `pnpm test:unit -- src/types/__tests__/site.test.ts`
- `pnpm exec oxfmt --check src/types/site.ts`

**Manual Verification Steps**:

- [ ] Open the relevant Studio settings form.
- [ ] Confirm organisation structured-data settings are hidden.
- [ ] Confirm existing site entity metadata remains unchanged.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR marks the site-level entity settings schema as hidden so Studio no longer exposes organisation structured-data fields for editing while retaining their existing values.
- Adds the established `format: "hidden"` annotation to `SiteEntitySettingsSchema`.
- Leaves schema validation, submission data, and structured-data rendering unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the hidden renderer preserves existing site entity data and validation and metadata generation remain unaffected.

The changed annotation selects the established hidden form renderer, while the shared validator accepts it and existing values continue through form submission into structured-data rendering.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/components/src/types/site.ts | Adds a UI-only hidden-format annotation to the site entity object schema; no correctness or compatibility issues were identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(components): hide site entity sett..."](https://github.com/opengovsg/isomer/commit/6a5e9a895659985651f9fdd91b018d7f04b4df4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58570500)</sub>

<!-- /greptile_comment -->