### PR TITLE
fix: scope PostHog cookies to the Studio subdomain

### DIFF
--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -10,6 +10,7 @@ if (posthogProjectToken && posthogHost) {
   posthog.init(posthogProjectToken, {
     api_host: posthogHost,
     asset_host: env.NEXT_PUBLIC_POSTHOG_ASSETS_HOST,
+    cross_subdomain_cookie: false,
     defaults: "2026-01-30",
     capture_exceptions: true,
     ...(env.NEXT_PUBLIC_APP_URL


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +1 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

PostHog cookies are shared across sibling subdomains, allowing analytics identity state to spill into other sites on the parent domain.

Closes N/A

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Scope PostHog persistence cookies to the Studio hostname.

**Bug Fixes**:

- Set `cross_subdomain_cookie: false` during PostHog initialization.

## Before & After Screenshots

**BEFORE**:

N/A - configuration-only change.

**AFTER**:

N/A - configuration-only change.

## Tests

- `pnpm exec oxfmt --check instrumentation-client.ts`
- `pnpm exec oxlint --type-aware instrumentation-client.ts`
- `pnpm --filter isomer-studio typecheck` *(blocked by existing missing workspace package and generated Prisma types)*

**Manual Verification Steps**:

- [ ] Clear existing `ph_*_posthog` cookies for the Studio and parent domains.
- [ ] Load Studio and perform a navigation that emits a PostHog event, then confirm the new PostHog cookie is host-only for the Studio hostname.
- [ ] Open a sibling subdomain and confirm that the PostHog cookie is not available there.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR scopes newly persisted PostHog cookies to the Studio hostname to prevent analytics identity from being shared across sibling subdomains.
- Adds `cross_subdomain_cookie: false` to the Studio PostHog initialization.
- Leaves the existing analytics initialization and event-capture configuration unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue established.

The configuration change narrows PostHog cookie scope to the current Studio hostname without altering initialization control flow or analytics event behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/instrumentation-client.ts | Configures PostHog persistence cookies as host-only; no concrete changed-code defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: scope PostHog cookies to current su..."](https://github.com/opengovsg/isomer/commit/914625649a28024fdad1040b398b25f4308911d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59416181)</sub>

<!-- /greptile_comment -->