### PR TITLE
📆 chore: rename user-facing Articles copy to Items for collection dates

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
@@ -32,7 +32,7 @@ import FormBuilder from "../form-builder/FormBuilder"
 import { DrawerHeader } from "./DrawerHeader"
 
 const HEADER_LABELS: Record<string, string> = {
-  article: "Edit article page header",
+  article: "Edit item page header",
   content: "Edit content page header",
   index: "Edit index page header",
   database: "Edit page header",

--- a/apps/studio/src/features/editing-experience/utils/__tests__/getCollectionSortOptions.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/getCollectionSortOptions.test.ts
@@ -49,7 +49,7 @@ describe("getCollectionSortOptions", () => {
     expect(options).toHaveLength(4)
     expect(options[0]).toEqual({
       value: COLLECTION_SORT_ORDER.DateDesc,
-      label: "By article date, newest → oldest",
+      label: "By item date, newest → oldest",
     })
   })
 

--- a/apps/studio/src/features/editing-experience/utils/getCollectionSortOptions.ts
+++ b/apps/studio/src/features/editing-experience/utils/getCollectionSortOptions.ts
@@ -8,11 +8,11 @@ import type { CollectionTags } from "../hooks/useCollectionTags"
 const BASE_COLLECTION_SORT_OPTIONS = [
   {
     value: COLLECTION_SORT_ORDER.DateDesc,
-    label: "By article date, newest → oldest",
+    label: "By item date, newest → oldest",
   },
   {
     value: COLLECTION_SORT_ORDER.DateAsc,
-    label: "By article date, oldest → newest",
+    label: "By item date, oldest → newest",
   },
   {
     value: COLLECTION_SORT_ORDER.TitleAsc,

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -268,7 +268,7 @@ const categorySchemaObject = Type.Object({
 const dateSchemaObject = Type.Object({
   date: Type.Optional(
     Type.String({
-      title: "Item date",
+      title: "Article date",
       format: "date",
     }),
   ),

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -268,7 +268,7 @@ const categorySchemaObject = Type.Object({
 const dateSchemaObject = Type.Object({
   date: Type.Optional(
     Type.String({
-      title: "Article date",
+      title: "Item date",
       format: "date",
     }),
   ),


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +3 | -3 |
| 🧪 Test | 1 | +1 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Collection admin and schema copy still refers to "article" in places where the product terminology is "item" (collection entries). That is inconsistent with how admins think about collection pages and with the rest of the date-filters stack.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Rename schema field title `Article date` → `Item date` on collection item date fields (`page.ts`).
- Rename base sort option labels `By article date, …` → `By item date, …` in `collectionSortOrder.ts`.
- Rename Studio drawer title `Edit article page header` → `Edit item page header` in `MetadataEditorStateDrawer.tsx`.

Test fixture tag values (e.g. `"Feature Articles"`) and filter option labels in tests are intentionally unchanged.

## Before & After Screenshots

**BEFORE**:

Admin sees "Article date", "By article date, newest → oldest", and "Edit article page header".

**AFTER**:

Admin sees "Item date", "By item date, newest → oldest", and "Edit item page header".

## Tests

`pnpm exec vitest run src/templates/next/layouts/Collection/utils/__tests__/` (from `packages/components`)

**Manual Verification Steps**:

- [ ] Open a collection page in Studio and confirm the item date field label reads **Item date**.
- [ ] Open collection page settings and confirm base sort options read **By item date, newest → oldest** and **By item date, oldest → newest**.
- [ ] Open an article-type collection item and confirm the metadata drawer header reads **Edit item page header**.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates collection terminology from “article” to “item” and incorporates date-filter UI, state, validation, stories, and tests. Two compile-time defects need correction before merge:
- Remove duplicate GrowthBook feature-key and fallback declarations.
- Update `getFilteredItems` to accept and use the newly supplied `today` argument.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not safe to merge until the duplicate GrowthBook declarations and the mismatched `getFilteredItems` call signature are corrected.

Studio has duplicate exported constants with conflicting fallback values, while the collection hook and new tests pass an unsupported fifth argument to `getFilteredItems`; both defects prevent successful type checking or compilation.

**Files Needing Attention:** apps/studio/src/lib/growthbook.ts; packages/components/src/templates/next/layouts/Collection/useCollection.ts; packages/components/src/templates/next/layouts/Collection/utils/getFilteredItems.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/lib/growthbook.ts | Adds date-filter flag declarations that duplicate existing constants and prevent Studio compilation. |
| packages/components/src/templates/next/layouts/Collection/useCollection.ts | Wires date-range updates and a shared current date, but passes that date to a function whose signature was not updated. |
| packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx | Moves available-filter derivation into the interactive collection client and consistently passes the current date. |
| packages/components/src/templates/next/types/Filter.ts | Strengthens URL date-range validation and extends the filter callback contract. |
| packages/components/src/templates/next/layouts/Collection/utils/getAvailableFilters.ts | Threads a deterministic current date into date-filter bucket generation. |
| packages/components/src/types/page.ts | Renames the collection item date field title and removes an unused private status schema. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Collection page data] --> B[Process collection items]
  B --> C[CollectionClient]
  C --> D[Derive available tag and date filters]
  C --> E[useCollection state]
  E --> F[Apply search, status, and date-range filters]
  F --> G[Paginated collection results]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233295%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3295&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Flib%2Fgrowthbook.ts%3A26-27%0A**Duplicate%20feature%20flag%20constants**%0A%0AThese%20date-filter%20constants%20are%20declared%20again%20immediately%20below%20with%20a%20conflicting%20fallback%20value.%20TypeScript%20rejects%20the%20duplicate%20block-scoped%20declarations%2C%20so%20Studio%20cannot%20compile.%20Keep%20only%20one%20declaration%20and%20fallback%20value.%20This%20also%20violates%20the%20repository%20directive%20to%20avoid%20competing%20sources%20of%20truth.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcomponents%2Fsrc%2Ftemplates%2Fnext%2Flayouts%2FCollection%2FuseCollection.ts%3A109%0A**Unsupported%20today%20argument**%0A%0AThis%20call%20passes%20%60today%60%20as%20a%20fifth%20argument%2C%20but%20%60getFilteredItems%60%20still%20accepts%20only%20four%20arguments%20and%20calculates%20the%20current%20date%20internally.%20TypeScript%20therefore%20reports%20an%20argument-count%20error%20here%20and%20in%20the%20new%20tests.%20Update%20%60getFilteredItems%60%20to%20accept%20and%20use%20the%20supplied%20date%20so%20the%20build%20succeeds%20and%20filtering%20remains%20deterministic.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Flib%2Fgrowthbook.ts%3A26-27%0A**Duplicate%20feature%20flag%20constants**%0A%0AThese%20date-filter%20constants%20are%20declared%20again%20immediately%20below%20with%20a%20conflicting%20fallback%20value.%20TypeScript%20rejects%20the%20duplicate%20block-scoped%20declarations%2C%20so%20Studio%20cannot%20compile.%20Keep%20only%20one%20declaration%20and%20fallback%20value.%20This%20also%20violates%20the%20repository%20directive%20to%20avoid%20competing%20sources%20of%20truth.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcomponents%2Fsrc%2Ftemplates%2Fnext%2Flayouts%2FCollection%2FuseCollection.ts%3A109%0A**Unsupported%20today%20argument**%0A%0AThis%20call%20passes%20%60today%60%20as%20a%20fifth%20argument%2C%20but%20%60getFilteredItems%60%20still%20accepts%20only%20four%20arguments%20and%20calculates%20the%20current%20date%20internally.%20TypeScript%20therefore%20reports%20an%20argument-count%20error%20here%20and%20in%20the%20new%20tests.%20Update%20%60getFilteredItems%60%20to%20accept%20and%20use%20the%20supplied%20date%20so%20the%20build%20succeeds%20and%20filtering%20remains%20deterministic.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22cursor%2Farticles-to-items-terminology-99d6%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Farticles-to-items-terminology-99d6%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Flib%2Fgrowthbook.ts%3A26-27%0A**Duplicate%20feature%20flag%20constants**%0A%0AThese%20date-filter%20constants%20are%20declared%20again%20immediately%20below%20with%20a%20conflicting%20fallback%20value.%20TypeScript%20rejects%20the%20duplicate%20block-scoped%20declarations%2C%20so%20Studio%20cannot%20compile.%20Keep%20only%20one%20declaration%20and%20fallback%20value.%20This%20also%20violates%20the%20repository%20directive%20to%20avoid%20competing%20sources%20of%20truth.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcomponents%2Fsrc%2Ftemplates%2Fnext%2Flayouts%2FCollection%2FuseCollection.ts%3A109%0A**Unsupported%20today%20argument**%0A%0AThis%20call%20passes%20%60today%60%20as%20a%20fifth%20argument%2C%20but%20%60getFilteredItems%60%20still%20accepts%20only%20four%20arguments%20and%20calculates%20the%20current%20date%20internally.%20TypeScript%20therefore%20reports%20an%20argument-count%20error%20here%20and%20in%20the%20new%20tests.%20Update%20%60getFilteredItems%60%20to%20accept%20and%20use%20the%20supplied%20date%20so%20the%20build%20succeeds%20and%20filtering%20remains%20deterministic.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/studio/src/lib/growthbook.ts:26-27
**Duplicate feature flag constants**

These date-filter constants are declared again immediately below with a conflicting fallback value. TypeScript rejects the duplicate block-scoped declarations, so Studio cannot compile. Keep only one declaration and fallback value. This also violates the repository directive to avoid competing sources of truth.

### Issue 2
packages/components/src/templates/next/layouts/Collection/useCollection.ts:109
**Unsupported today argument**

This call passes `today` as a fifth argument, but `getFilteredItems` still accepts only four arguments and calculates the current date internally. TypeScript therefore reports an argument-count error here and in the new tests. Update `getFilteredItems` to accept and use the supplied date so the build succeeds and filtering remains deterministic.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: rename user-facing Articles copy ..."](https://github.com/opengovsg/isomer/commit/4601bee19bb9206aaf6471831c95bf32abdc4c20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62267306)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - # Isomer review rules    Apply the same standards ... ([source](https://app.greptile.com/opengovsg/-/custom-context?memory=fd2ee0a5-1a6a-4898-86da-1b53c321a5ad))
- Knowledge Base — [Component rendering engine](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/component-rendering-engine.md)
- Knowledge Base — [Site rendering components](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/site-rendering-components.md)
- Knowledge Base — [Page authoring experience](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/page-authoring.md)
</details>


<!-- /greptile_comment -->

## /show-me to help explain what this PR does

This PR's net diff (base `cursor/collection-date-sort-options-d230` → head) touches 3 files, 4 lines each way — a straight `article` → `item` copy rename in two admin-facing strings, plus the test that pins them.

**Before → after (net diff only)**

| File | Before | After |
|---|---|---|
| `apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx` | `"Edit article page header"` | `"Edit item page header"` |
| `apps/studio/src/features/editing-experience/utils/getCollectionSortOptions.ts` | `"By article date, newest → oldest"` | `"By item date, newest → oldest"` |
| `apps/studio/src/features/editing-experience/utils/getCollectionSortOptions.ts` | `"By article date, oldest → newest"` | `"By item date, oldest → newest"` |
| `apps/studio/src/features/editing-experience/utils/__tests__/getCollectionSortOptions.test.ts` | expects `"By article date, ..."` | expects `"By item date, ..."` |

**Two commits, one of them a self-correction:**

```
e485dfc30  chore: rename user-facing Articles copy to Items for collection dates
             touches 4 files, incl. packages/components/src/types/page.ts
             "Article date" -> "Item date"   (schema field title)

b3f6196a1  fix(types): update title in date schema from "Item date" to "Article date"
             packages/components/src/types/page.ts
             "Item date" -> "Article date"   (reverts the schema title only)
```

Net effect on `packages/components/src/types/page.ts`: **unchanged** - the schema field title stays `"Article date"`. Only the two Studio admin-UI strings (drawer header + sort labels) end up renamed to "item"; the PR scopes the terminology switch to that UI copy and deliberately leaves the `page.ts` schema title alone.
