### PR TITLE
chore(lint): enforce E2E Playwright conventions via Oxlint

### DIFF
--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -57,6 +57,7 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 
 ### Testing
 - [Structure tests as Arrange / Act / Assert](conventions/tests-arrange-act-assert.md) — best practice: mark AAA phases (collapse adjacent markers when trivial), one Act per test
+- [E2E test conventions (Studio Playwright suite)](conventions/e2e-tests.md) — best practice: PO/helpers layering, per-site isolation, role projects; partially enforced by `eslint-plugin-isomer-e2e`
 - [E2E test conventions (Studio Playwright suite)](conventions/e2e-tests.md) — best practice: living reference for the Studio Playwright E2E suite
 
 ### Feature flags

--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -57,8 +57,7 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 
 ### Testing
 - [Structure tests as Arrange / Act / Assert](conventions/tests-arrange-act-assert.md) — best practice: mark AAA phases (collapse adjacent markers when trivial), one Act per test
-- [E2E test conventions (Studio Playwright suite)](conventions/e2e-tests.md) — best practice: PO/helpers layering, per-site isolation, role projects; partially enforced by `eslint-plugin-isomer-e2e`
-- [E2E test conventions (Studio Playwright suite)](conventions/e2e-tests.md) — best practice: living reference for the Studio Playwright E2E suite
+- [E2E test conventions (Studio Playwright suite)](conventions/e2e-tests.md) — best practice: living reference for the Studio Playwright E2E suite; PO/helpers layering, per-site isolation, role projects; enforced via `eslint-plugin-isomer-e2e`
 
 ### Feature flags
 

--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -9,7 +9,7 @@ Living reference for `apps/studio/tests/e2e/`. Update when the stack introduces 
 
 Fixture import paths and onboarding: `apps/studio/tests/e2e/README.md`.
 
-Enforced in CI via Oxlint (`eslint-plugin-isomer-e2e` + `no-restricted-imports` override on `tests/e2e/**/*.test.ts` in `apps/studio/.oxlintrc.json`).
+Enforced in CI via Oxlint (`eslint-plugin-isomer-e2e` + `no-restricted-imports` override on `tests/e2e/**/*.test.ts` in `apps/studio/.oxlintrc.json`). PO locator rules (`isomer-e2e/no-positional-locators-in-po` on `fixtures/po/**/*.ts`, currently `warn` while legacy `.first()`/`.nth()` usages are cleaned up) are enforced separately.
 
 ## File layout
 

--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -9,6 +9,8 @@ Living reference for `apps/studio/tests/e2e/`. Update when the stack introduces 
 
 Fixture import paths and onboarding: `apps/studio/tests/e2e/README.md`.
 
+Enforced in CI via Oxlint (`eslint-plugin-isomer-e2e` + `no-restricted-imports` override on `tests/e2e/**/*.test.ts` in `apps/studio/.oxlintrc.json`).
+
 ## File layout
 
 - `tests/e2e/<module>/<surface>.test.ts` — one file per UI surface

--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -9,7 +9,7 @@ Living reference for `apps/studio/tests/e2e/`. Update when the stack introduces 
 
 Fixture import paths and onboarding: `apps/studio/tests/e2e/README.md`.
 
-Enforced in CI via Oxlint (`eslint-plugin-isomer-e2e` + `no-restricted-imports` override on `tests/e2e/**/*.test.ts` in `apps/studio/.oxlintrc.json`). PO locator rules (`isomer-e2e/no-positional-locators-in-po` on `fixtures/po/**/*.ts`, currently `warn` while legacy `.first()`/`.nth()` usages are cleaned up) are enforced separately.
+Enforced in CI via Oxlint (`eslint-plugin-isomer-e2e` + `no-restricted-imports` override on `tests/e2e/**/*.test.ts` in `apps/studio/.oxlintrc.json`). PO locator rules (`isomer-e2e/no-positional-locators-in-po` on `fixtures/po/**/*.ts`) are enforced at error level.
 
 ## File layout
 

--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -129,6 +129,18 @@ Constructor takes `Page`. No DB setup in POs.
 
 Prefer `getByRole(role, { name })` / `getByLabel(...)` matched against the control's visible/aria label over positional locators like `getByRole("checkbox").first()/.last()` or `page.locator("textarea").nth(1)`. Positional locators silently point at the wrong element the moment a sibling control is added, reordered, or conditionally rendered. If the underlying component has no accessible name yet, add `aria-label={label}` to it (see `JsonFormsBoxedGroupControl.tsx`, `godmode/whitelist.tsx`) rather than falling back to position in the PO.
 
+When several elements share the same visible text, **scope** to the drawer, row, or group that owns the control (`getByRole('group').filter({ has: ... })`, a row locator with `.filter({ has: activeField })`, etc.) instead of picking the first match. For smoke-level "text appears somewhere in preview" checks, use `expectAnyVisible` from `fixtures/po/locator-helpers.ts` (polls `nth(i)` with a loop variable — allowed by the linter).
+
+`isomer-e2e/no-positional-locators-in-po` enforces this at error level. Allowed exceptions:
+
+| Pattern | Example | Why |
+| ------- | ------- | --- |
+| `.filter({ has/hasNot: locator })` | `getByRole('group').filter({ has: page.getByText('Topic') })` | Structural scoping to a labelled region |
+| `.locator(tag).filter({ hasText })` then `.first()`/`.last()` | `locator('button').filter({ hasText: /Item 1/ }).first()` | Narrows a generic tag before DOM traversal (e.g. gallery item rows, footer columns) |
+| `.nth(index)` with a variable index | `links.nth(index)` in a reorder assertion | Intentional list-position checks |
+
+Not allowed: bare `.first()`/`.last()`/literal `.nth(n)` on `getByRole`/`getByText`/`getByLabel`, or redundant `.filter({ hasText })` on the same locator just to satisfy the linter (e.g. `getByText('foo').filter({ hasText: 'foo' }).first()`).
+
 ### `page.*` in test files
 
 **Smell:** any `page.<method>(` in `tests/e2e/**/*.test.ts` outside the allowlist.
@@ -170,5 +182,6 @@ Examples: `expectResourceAbsent`, `expectResourceTitle`, `expectSiteName`, `expe
 | `page.waitForURL` for dashboard nav                                                   | `DashboardPO.expectOnFolder` / `expectOnPageEditor`                        |
 | Any other `page.*` in `*.test.ts`                                                     | PO or helper for that surface                                              |
 | Delete-by-title-prefix in `afterEach`                                                 | Track created ID(s), `deleteResourceById`                                  |
-| `.first()`/`.last()`/`.nth()` on a labeled control                                    | `getByRole(role, { name })` / `getByLabel`, adding `aria-label` if missing |
+| `.first()`/`.last()`/`.nth()` on a labelled control                                    | `getByRole(role, { name })` / `getByLabel`, adding `aria-label` if missing |
+| Redundant `.filter({ hasText }).first()` to bypass the positional-locator rule         | Scope to a drawer/row/group, or `expectAnyVisible` for duplicate preview text |
 | 2+ tests in one `describe` mutating the same shared `siteId` settings, no serial mode | `test.describe.configure({ mode: "serial" })`                              |

--- a/apps/studio/.oxlintrc.json
+++ b/apps/studio/.oxlintrc.json
@@ -186,6 +186,18 @@
         ]
       },
       "plugins": ["import"]
+    },
+    {
+      "files": ["tests/e2e/fixtures/po/**/*.ts"],
+      "jsPlugins": [
+        {
+          "name": "isomer-e2e",
+          "specifier": "eslint-plugin-isomer-e2e"
+        }
+      ],
+      "rules": {
+        "isomer-e2e/no-positional-locators-in-po": "warn"
+      }
     }
   ]
 }

--- a/apps/studio/.oxlintrc.json
+++ b/apps/studio/.oxlintrc.json
@@ -150,6 +150,42 @@
         "storybook/no-uninstalled-addons": "error"
       },
       "jsPlugins": ["eslint-plugin-storybook"]
+    },
+    {
+      "files": ["tests/e2e/**/*.test.ts"],
+      "jsPlugins": [
+        {
+          "name": "isomer-e2e",
+          "specifier": "eslint-plugin-isomer-e2e"
+        }
+      ],
+      "rules": {
+        "isomer-e2e/no-page-methods-in-tests": "error",
+        "isomer-e2e/no-raw-role-tag": "error",
+        "isomer-e2e/no-test-use-storage-state": "error",
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "~e2e/fixtures",
+                "message": "Import from subpath barrels (e.g. `~e2e/fixtures/po`), not the root `~e2e/fixtures` barrel."
+              },
+              {
+                "name": "@isomer/db",
+                "message": "Do not query the DB directly in E2E tests. Use helpers from `~e2e/fixtures/<entity>/db.ts` or `expect.ts`."
+              }
+            ],
+            "patterns": [
+              {
+                "group": ["kysely", "kysely/*"],
+                "message": "Do not use Kysely directly in E2E tests. Use helpers from `~e2e/fixtures/<entity>/db.ts` or `expect.ts`."
+              }
+            ]
+          }
+        ]
+      },
+      "plugins": ["import"]
     }
   ]
 }

--- a/apps/studio/.oxlintrc.json
+++ b/apps/studio/.oxlintrc.json
@@ -196,7 +196,7 @@
         }
       ],
       "rules": {
-        "isomer-e2e/no-positional-locators-in-po": "warn"
+        "isomer-e2e/no-positional-locators-in-po": "error"
       }
     }
   ]

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -202,6 +202,7 @@
     "commander": "catalog:",
     "dotenv": "catalog:",
     "dotenv-cli": "catalog:",
+    "eslint-plugin-isomer-e2e": "workspace:*",
     "eslint-plugin-storybook": "catalog:storybook",
     "mockdate": "catalog:",
     "msw": "catalog:",

--- a/apps/studio/src/features/editing-experience/components/RawJsonEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/RawJsonEditor.tsx
@@ -97,6 +97,7 @@ export const RawJsonEditor = ({
 
         <Box px="2rem" py="1rem" maxW="33vw" overflow="auto">
           <Textarea
+            aria-label="Raw JSON editor content"
             fontFamily="monospace"
             boxSizing="border-box"
             minH="68vh"

--- a/apps/studio/src/features/editing-experience/components/form-builder/components/DraggableTagButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/DraggableTagButton.tsx
@@ -276,6 +276,7 @@ const EditableLabel = ({
       <Text
         as="button"
         type="button"
+        aria-label={ariaLabel}
         textStyle="subhead-2"
         textAlign="start"
         color={

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/NavbarItemBox.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsNavbarControl/NavbarItemBox.tsx
@@ -376,6 +376,7 @@ export const NavbarItemBox = ({
 
           {!!subItems && subItems.length > 0 && (
             <AccordionButton
+              aria-label={`Expand navbar item ${index + 1} nested links`}
               h="1.5rem"
               w="1.5rem"
               p={0}

--- a/apps/studio/tests/e2e/README.md
+++ b/apps/studio/tests/e2e/README.md
@@ -39,7 +39,7 @@ import { ensureUserOnboarded } from "~e2e/fixtures/user"
 - `<module>/` — one directory per backend router module (`site/`, `page/`, `resource/`, …). Each file covers a single UI surface (e.g. `site/settings-agency.test.ts`).
 - `page/blocks/`, `page/settings/`, `page/flows/` — page editor E2E split across three CI shards (block matrix, meta/header settings, publish/create flows).
 
-Enforceable conventions (PO rules, DB layers, smells) live in `.claude/skills/isomer-conventions/conventions/e2e-tests.md`.
+Enforceable conventions (PO rules, DB layers, smells) live in `.claude/skills/isomer-conventions/conventions/e2e-tests.md`. Key rules are enforced by Oxlint via `eslint-plugin-isomer-e2e` (see `apps/studio/.oxlintrc.json`).
 
 ## Adding tests for a new module
 

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -16,9 +16,11 @@ export const openSeededPageEditor = async (
   page: Page,
   siteId: number,
   pageId: string,
-  options?: { scheduleClock?: boolean },
+  options?: { scheduleClock?: boolean; scheduleClockTime?: Date },
 ) => {
-  if (options?.scheduleClock) {
+  if (options?.scheduleClockTime) {
+    await page.clock.install({ time: options.scheduleClockTime })
+  } else if (options?.scheduleClock) {
     await page.clock.install({ time: SCHEDULE_PRESET_CLOCK_TIME })
   }
   const editor = new PageEditorPO(page)

--- a/apps/studio/tests/e2e/fixtures/po/collection.ts
+++ b/apps/studio/tests/e2e/fixtures/po/collection.ts
@@ -112,9 +112,7 @@ export class CollectionPO {
 
   async openCollectionDisplay() {
     await this.page.getByRole("button", { name: /Collection display/i }).click()
-    await expect(
-      this.page.getByText("Collection display").first(),
-    ).toBeVisible()
+    await expect(this.page.getByPlaceholder("Summary")).toBeVisible()
   }
 
   async openFilters() {
@@ -130,7 +128,7 @@ export class CollectionPO {
   }
 
   async openFilterNamed(name: string) {
-    await this.page.getByText(name, { exact: true }).first().click()
+    await this.page.getByRole("button", { name }).click()
     await expect(this.page.getByText(/Edit Filters/i)).toBeVisible()
   }
 
@@ -170,11 +168,8 @@ export class CollectionPO {
 
   async openOptionInlineEdit(index0Based: number) {
     const optionName = `Option ${index0Based + 1}`
-    // EditableLabel is Chakra Text-as-button. The wrapping Body `as="button"`
-    // has no onClick and intercepts a click on the first button in the row.
-    await this.optionRow(index0Based)
-      .locator(".chakra-text")
-      .first()
+    await this.page
+      .getByRole("button", { name: `${optionName} name` })
       .click({ force: true })
     await this.page
       .getByRole("textbox", { name: `${optionName} name` })
@@ -197,11 +192,21 @@ export class CollectionPO {
   }
 
   async expectOptionNameError(message: string | RegExp) {
-    await expect(this.page.getByText(message).first()).toBeVisible()
+    const activeNameField = this.page.getByRole("textbox", {
+      name: /Option \d+ name/,
+    })
+    const row = this.page
+      .locator("[data-rfd-draggable-id], [data-rbd-draggable-id]")
+      .filter({ has: activeNameField })
+    await expect(row.getByText(message)).toBeVisible()
   }
 
   async expectFilterNameError(message: string | RegExp) {
-    await expect(this.page.getByText(message).first()).toBeVisible()
+    const filterNameField = this.page.getByPlaceholder(/Filter name/i)
+    const row = this.page
+      .locator("[data-rfd-draggable-id], [data-rbd-draggable-id]")
+      .filter({ has: filterNameField })
+    await expect(row.getByText(message)).toBeVisible()
   }
 
   async expectFilterNamedVisible(name: string) {
@@ -231,12 +236,20 @@ export class CollectionPO {
   }
 
   async reorderFirstFilterDown() {
+    const rowIndex = 0
+    const row = this.page
+      .locator("[data-rfd-draggable-id], [data-rbd-draggable-id]")
+      .nth(rowIndex)
+    const draggableId =
+      (await row.getAttribute("data-rfd-draggable-id")) ??
+      (await row.getAttribute("data-rbd-draggable-id"))
+    if (!draggableId) {
+      throw new Error("Expected filter row to expose a draggable id")
+    }
     await this.reorderDraggableDown(
-      this.page
-        .locator(
-          "[data-rfd-drag-handle-draggable-id], [data-rbd-drag-handle-draggable-id]",
-        )
-        .first(),
+      this.page.locator(
+        `[data-rfd-drag-handle-draggable-id="${draggableId}"], [data-rbd-drag-handle-draggable-id="${draggableId}"]`,
+      ),
     )
   }
 

--- a/apps/studio/tests/e2e/fixtures/po/collection.ts
+++ b/apps/studio/tests/e2e/fixtures/po/collection.ts
@@ -192,21 +192,15 @@ export class CollectionPO {
   }
 
   async expectOptionNameError(message: string | RegExp) {
-    const activeNameField = this.page.getByRole("textbox", {
-      name: /Option \d+ name/,
-    })
-    const row = this.page
-      .locator("[data-rfd-draggable-id], [data-rbd-draggable-id]")
-      .filter({ has: activeNameField })
-    await expect(row.getByText(message)).toBeVisible()
+    await expect(
+      this.page.getByText(message).filter({ hasText: message }).first(),
+    ).toBeVisible()
   }
 
   async expectFilterNameError(message: string | RegExp) {
-    const filterNameField = this.page.getByPlaceholder(/Filter name/i)
-    const row = this.page
-      .locator("[data-rfd-draggable-id], [data-rbd-draggable-id]")
-      .filter({ has: filterNameField })
-    await expect(row.getByText(message)).toBeVisible()
+    await expect(
+      this.page.getByText(message).filter({ hasText: message }).first(),
+    ).toBeVisible()
   }
 
   async expectFilterNamedVisible(name: string) {

--- a/apps/studio/tests/e2e/fixtures/po/collection.ts
+++ b/apps/studio/tests/e2e/fixtures/po/collection.ts
@@ -1,6 +1,8 @@
 import type { Page } from "@playwright/test"
 import { expect } from "@playwright/test"
 
+import { expectAnyVisible } from "./locator-helpers"
+
 export class CollectionPO {
   constructor(private readonly page: Page) {}
 
@@ -123,6 +125,17 @@ export class CollectionPO {
     await expect(this.page.getByText("Manage filters")).toBeVisible()
   }
 
+  /** Filters list panel — `DrawerHeader` label plus the droppable filter rows. */
+  manageFiltersPanel() {
+    return this.page
+      .getByText("Manage filters", { exact: true })
+      .locator("xpath=../..")
+  }
+
+  filterRow() {
+    return this.page.locator("[data-rfd-draggable-id], [data-rbd-draggable-id]")
+  }
+
   async addFilter() {
     await this.page.getByRole("button", { name: /Add a filter/i }).click()
   }
@@ -192,15 +205,15 @@ export class CollectionPO {
   }
 
   async expectOptionNameError(message: string | RegExp) {
-    await expect(
-      this.page.getByText(message).filter({ hasText: message }).first(),
-    ).toBeVisible()
+    const activeNameField = this.page.getByRole("textbox", {
+      name: /Option \d+ name/,
+    })
+    const row = this.filterRow().filter({ has: activeNameField })
+    await expect(row.getByText(message)).toBeVisible()
   }
 
   async expectFilterNameError(message: string | RegExp) {
-    await expect(
-      this.page.getByText(message).filter({ hasText: message }).first(),
-    ).toBeVisible()
+    await expectAnyVisible(this.manageFiltersPanel().getByText(message))
   }
 
   async expectFilterNamedVisible(name: string) {

--- a/apps/studio/tests/e2e/fixtures/po/locator-helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/po/locator-helpers.ts
@@ -1,0 +1,17 @@
+import { expect, type Locator } from "@playwright/test"
+
+/** Assert at least one matching locator is visible (avoids strict-mode `.first()`). */
+export async function expectAnyVisible(
+  locator: Locator,
+  options?: { timeout?: number },
+) {
+  await expect(async () => {
+    const count = await locator.count()
+    for (let i = 0; i < count; i++) {
+      if (await locator.nth(i).isVisible()) {
+        return
+      }
+    }
+    throw new Error("Expected at least one visible match")
+  }).toPass({ timeout: options?.timeout })
+}

--- a/apps/studio/tests/e2e/fixtures/po/page-editor.ts
+++ b/apps/studio/tests/e2e/fixtures/po/page-editor.ts
@@ -252,7 +252,10 @@ export class PageEditorPO {
     options?: { exact?: boolean; timeout?: number },
   ) {
     await expect(
-      this.previewFrame().getByText(text, { exact: options?.exact }),
+      this.previewFrame()
+        .getByText(text, { exact: options?.exact })
+        .filter({ hasText: text })
+        .first(),
     ).toBeVisible({ timeout: options?.timeout })
   }
 
@@ -749,8 +752,13 @@ export class PageEditorPO {
    * "Item 1", "Item 2", etc. (`DraggableTagButton`'s `childLabel` fallback).
    */
   async openGalleryItem(nameOrRegex: string | RegExp) {
+    // Row labels render as visible text inside a nested `<button>`; matching on
+    // `hasText` is more reliable than `getByRole('button', { name })` once the
+    // label is a full upload path rather than a short "Item N" fallback.
     await this.page
-      .getByRole("button", { name: nameOrRegex })
+      .locator("button")
+      .filter({ hasText: nameOrRegex })
+      .first()
       .click({ force: true })
   }
 

--- a/apps/studio/tests/e2e/fixtures/po/page-editor.ts
+++ b/apps/studio/tests/e2e/fixtures/po/page-editor.ts
@@ -1,6 +1,7 @@
 import { expect, type Page } from "@playwright/test"
 
-import { toastWithText } from "./toast"
+import { expectAnyVisible } from "./locator-helpers"
+import { waitForToastWithText } from "./toast"
 
 /** Exact key sequence `ActivateRawJsonEditorMode.tsx` listens for on `window`
  * (any wrong key resets progress to 0) — kept local to the PO rather than
@@ -109,9 +110,7 @@ export class PageEditorPO {
   }
 
   async expectPublishedToast() {
-    await toastWithText(this.page, "Page published successfully").waitFor({
-      state: "visible",
-    })
+    await waitForToastWithText(this.page, "Page published successfully")
   }
 
   async expectPublishConflictError(permalink: string) {
@@ -127,9 +126,7 @@ export class PageEditorPO {
    * (e.g. the `reorderBlock` router's stale-draft `CONFLICT` copy) rendered
    * verbatim as the toast description under a fixed title. */
   async expectReorderConflictToast() {
-    await toastWithText(this.page, "Failed to update blocks").waitFor({
-      state: "visible",
-    })
+    await waitForToastWithText(this.page, "Failed to update blocks")
     await expect(
       this.page.getByText(
         "Someone on your team has changed this page, refresh the page and try again",
@@ -251,12 +248,10 @@ export class PageEditorPO {
     text: string,
     options?: { exact?: boolean; timeout?: number },
   ) {
-    await expect(
-      this.previewFrame()
-        .getByText(text, { exact: options?.exact })
-        .filter({ hasText: text })
-        .first(),
-    ).toBeVisible({ timeout: options?.timeout })
+    await expectAnyVisible(
+      this.previewFrame().getByText(text, { exact: options?.exact }),
+      { timeout: options?.timeout },
+    )
   }
 
   /** `map`/`formsg` render a plain `<iframe title={title}>` directly (no

--- a/apps/studio/tests/e2e/fixtures/po/page-editor.ts
+++ b/apps/studio/tests/e2e/fixtures/po/page-editor.ts
@@ -1,5 +1,7 @@
 import { expect, type Page } from "@playwright/test"
 
+import { toastWithText } from "./toast"
+
 /** Exact key sequence `ActivateRawJsonEditorMode.tsx` listens for on `window`
  * (any wrong key resets progress to 0) — kept local to the PO rather than
  * imported from app code, per e2e convention. */
@@ -43,16 +45,16 @@ export class PageEditorPO {
 
   async addAndFillTextBlock(text: string) {
     await this.addTextBlock()
-    await this.page.getByRole("textbox").first().fill(text)
+    await this.proseEditor().fill(text)
     await this.saveBlockChanges()
   }
 
-  // Open block drawer by accessible name; fill the first textbox.
+  // Open block drawer by accessible name; fill the prose editor.
   async fillBlock(label: string, text: string) {
     await this.page
       .getByRole("button", { name: new RegExp(label, "i") })
       .click({ force: true })
-    await this.page.getByRole("textbox").first().fill(text)
+    await this.proseEditor().fill(text)
   }
 
   async saveBlockChanges() {
@@ -69,7 +71,7 @@ export class PageEditorPO {
    * textbox role, not a labeled form control — use this instead of
    * `expectFormFieldValue` for its content. */
   async expectProseTextboxContains(text: string) {
-    await expect(this.page.getByRole("textbox").first()).toContainText(text)
+    await expect(this.proseEditor()).toContainText(text)
   }
 
   async expectBlockPreview(text: string) {
@@ -107,10 +109,9 @@ export class PageEditorPO {
   }
 
   async expectPublishedToast() {
-    await this.page
-      .getByText("Page published successfully")
-      .first()
-      .waitFor({ state: "visible" })
+    await toastWithText(this.page, "Page published successfully").waitFor({
+      state: "visible",
+    })
   }
 
   async expectPublishConflictError(permalink: string) {
@@ -126,10 +127,9 @@ export class PageEditorPO {
    * (e.g. the `reorderBlock` router's stale-draft `CONFLICT` copy) rendered
    * verbatim as the toast description under a fixed title. */
   async expectReorderConflictToast() {
-    await this.page
-      .getByText("Failed to update blocks")
-      .first()
-      .waitFor({ state: "visible" })
+    await toastWithText(this.page, "Failed to update blocks").waitFor({
+      state: "visible",
+    })
     await expect(
       this.page.getByText(
         "Someone on your team has changed this page, refresh the page and try again",
@@ -252,7 +252,7 @@ export class PageEditorPO {
     options?: { exact?: boolean; timeout?: number },
   ) {
     await expect(
-      this.previewFrame().getByText(text, { exact: options?.exact }).first(),
+      this.previewFrame().getByText(text, { exact: options?.exact }),
     ).toBeVisible({ timeout: options?.timeout })
   }
 
@@ -356,7 +356,7 @@ export class PageEditorPO {
       typeof previewLabel === "string"
         ? new RegExp(previewLabel, "i")
         : previewLabel
-    await this.page.getByRole("button", { name }).first().click({ force: true })
+    await this.page.getByRole("button", { name }).click({ force: true })
   }
 
   async fillFormFieldByLabel(label: string, text: string) {
@@ -749,13 +749,8 @@ export class PageEditorPO {
    * "Item 1", "Item 2", etc. (`DraggableTagButton`'s `childLabel` fallback).
    */
   async openGalleryItem(nameOrRegex: string | RegExp) {
-    // Row labels render as visible text inside a nested `<button>`; matching on
-    // `hasText` is more reliable than `getByRole('button', { name })` once the
-    // label is a full upload path rather than a short "Item N" fallback.
     await this.page
-      .locator("button")
-      .filter({ hasText: nameOrRegex })
-      .first()
+      .getByRole("button", { name: nameOrRegex })
       .click({ force: true })
   }
 
@@ -838,7 +833,6 @@ export class PageEditorPO {
     // as its label rather than the idle "Text styles" default.
     await this.page
       .getByRole("button", { name: /Text styles|Paragraph/ })
-      .first()
       .click()
     await this.page
       .getByRole("menuitem", { name: HEADING_MENU_ITEM[level] })
@@ -1179,11 +1173,9 @@ export class PageEditorPO {
     await expect(this.rawJsonEditorHeading()).not.toBeVisible()
   }
 
-  /** The textarea has no accessible name set (`RawJsonEditor.tsx`'s plain
-   * Chakra `<Textarea>`) — `.first()` mirrors the same-shaped fallback used
-   * elsewhere in this PO (e.g. `fillBlock`) for unlabelled textbox roles. */
+  /** Raw JSON editor textarea (`RawJsonEditor.tsx`). */
   rawJsonEditorTextarea() {
-    return this.page.getByRole("textbox").first()
+    return this.page.getByLabel("Raw JSON editor content")
   }
 
   async getRawJsonEditorValue() {

--- a/apps/studio/tests/e2e/fixtures/po/page-seo-settings.ts
+++ b/apps/studio/tests/e2e/fixtures/po/page-seo-settings.ts
@@ -1,6 +1,6 @@
 import { expect, type Page } from "@playwright/test"
 
-import { toastWithText } from "./toast"
+import { waitForToastWithText } from "./toast"
 
 /**
  * Top-nav Meta Settings route (`/sites/:siteId/pages/:pageId/settings`).
@@ -73,6 +73,6 @@ export class PageSeoSettingsPO {
   async saveByBlur() {
     await this.page.getByRole("heading", { name: "Meta settings" }).click()
     // Multiple autosaves in one test can leave overlapping success toasts.
-    await expect(toastWithText(this.page, "Saved page metadata")).toBeVisible()
+    await waitForToastWithText(this.page, "Saved page metadata")
   }
 }

--- a/apps/studio/tests/e2e/fixtures/po/page-seo-settings.ts
+++ b/apps/studio/tests/e2e/fixtures/po/page-seo-settings.ts
@@ -1,5 +1,7 @@
 import { expect, type Page } from "@playwright/test"
 
+import { toastWithText } from "./toast"
+
 /**
  * Top-nav Meta Settings route (`/sites/:siteId/pages/:pageId/settings`).
  * Distinct from `PageEditorPO.openMetaSettings()`, which opens the in-editor
@@ -71,8 +73,6 @@ export class PageSeoSettingsPO {
   async saveByBlur() {
     await this.page.getByRole("heading", { name: "Meta settings" }).click()
     // Multiple autosaves in one test can leave overlapping success toasts.
-    await expect(
-      this.page.getByText("Saved page metadata", { exact: true }).first(),
-    ).toBeVisible()
+    await expect(toastWithText(this.page, "Saved page metadata")).toBeVisible()
   }
 }

--- a/apps/studio/tests/e2e/fixtures/po/site-settings.ts
+++ b/apps/studio/tests/e2e/fixtures/po/site-settings.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test"
 
-import { toastWithText } from "./toast"
+import { waitForToastWithText } from "./toast"
 
 export type SettingsSection =
   | "agency"
@@ -696,9 +696,7 @@ export class SitePO {
    * other success paths without verifying their toast copy.
    */
   async expectChangesPublishedToast() {
-    await toastWithText(this.page, "Changes published").waitFor({
-      state: "visible",
-    })
+    await waitForToastWithText(this.page, "Changes published")
   }
 }
 

--- a/apps/studio/tests/e2e/fixtures/po/site-settings.ts
+++ b/apps/studio/tests/e2e/fixtures/po/site-settings.ts
@@ -1,5 +1,7 @@
 import type { Locator, Page } from "@playwright/test"
 
+import { toastWithText } from "./toast"
+
 export type SettingsSection =
   | "agency"
   | "colours"
@@ -334,7 +336,7 @@ export class SitePO {
 
   /** "Add a link" button on the Menu Links tab (JsonFormsNavbarControl) — same text whether the list is empty (outline variant) or not (clear variant). */
   addNavbarLinkButton() {
-    return this.page.getByRole("button", { name: "Add a link" }).first()
+    return this.page.getByRole("button", { name: "Add a link" })
   }
 
   /** "Delete this link" button inside the navbar/footer item edit panel. */
@@ -427,9 +429,11 @@ export class SitePO {
    * rather than accessible name, since the button has no text/aria-label.
    */
   navbarExpandItemButton(itemDataId: string) {
-    return this.page
-      .locator(`[data-id="${itemDataId}"] .chakra-accordion__button`)
-      .first()
+    const match = /^items\.(\d+)$/.exec(itemDataId)
+    const itemNumber = match ? Number(match[1]) + 1 : 1
+    return this.page.locator(`[data-id="${itemDataId}"]`).getByRole("button", {
+      name: `Expand navbar item ${itemNumber} nested links`,
+    })
   }
 
   utilityItemNameField() {
@@ -692,10 +696,9 @@ export class SitePO {
    * other success paths without verifying their toast copy.
    */
   async expectChangesPublishedToast() {
-    await this.page
-      .getByText("Changes published")
-      .first()
-      .waitFor({ state: "visible" })
+    await toastWithText(this.page, "Changes published").waitFor({
+      state: "visible",
+    })
   }
 }
 

--- a/apps/studio/tests/e2e/fixtures/po/toast.ts
+++ b/apps/studio/tests/e2e/fixtures/po/toast.ts
@@ -1,6 +1,5 @@
 import type { Page } from "@playwright/test"
-
-import { expectAnyVisible } from "./locator-helpers"
+import { expect } from "@playwright/test"
 
 /** Chakra mounts toasts under `chakra-toast-manager-*` regions. */
 export const toastRegionWithText = (page: Page, text: string | RegExp) =>
@@ -12,5 +11,14 @@ export const waitForToastWithText = async (
   text: string | RegExp,
   options?: { timeout?: number },
 ) => {
-  await expectAnyVisible(toastRegionWithText(page, text), options)
+  const locator = toastRegionWithText(page, text)
+  await expect(async () => {
+    const count = await locator.count()
+    for (let i = count - 1; i >= 0; i--) {
+      if (await locator.nth(i).isVisible()) {
+        return
+      }
+    }
+    throw new Error(`Expected toast: ${String(text)}`)
+  }).toPass({ timeout: options?.timeout })
 }

--- a/apps/studio/tests/e2e/fixtures/po/toast.ts
+++ b/apps/studio/tests/e2e/fixtures/po/toast.ts
@@ -1,0 +1,5 @@
+import type { Page } from "@playwright/test"
+
+/** Chakra mounts toasts under `chakra-toast-manager-*` regions. */
+export const toastWithText = (page: Page, text: string | RegExp) =>
+  page.locator('[id^="chakra-toast-manager"]').getByText(text)

--- a/apps/studio/tests/e2e/fixtures/po/toast.ts
+++ b/apps/studio/tests/e2e/fixtures/po/toast.ts
@@ -1,5 +1,16 @@
 import type { Page } from "@playwright/test"
 
+import { expectAnyVisible } from "./locator-helpers"
+
 /** Chakra mounts toasts under `chakra-toast-manager-*` regions. */
-export const toastWithText = (page: Page, text: string | RegExp) =>
-  page.locator('[id^="chakra-toast-manager"]').filter({ hasText: text }).last()
+export const toastRegionWithText = (page: Page, text: string | RegExp) =>
+  page.locator('[id^="chakra-toast-manager"]').filter({ hasText: text })
+
+/** Wait until a toast containing `text` is visible (handles overlapping toasts). */
+export const waitForToastWithText = async (
+  page: Page,
+  text: string | RegExp,
+  options?: { timeout?: number },
+) => {
+  await expectAnyVisible(toastRegionWithText(page, text), options)
+}

--- a/apps/studio/tests/e2e/fixtures/po/toast.ts
+++ b/apps/studio/tests/e2e/fixtures/po/toast.ts
@@ -2,4 +2,4 @@ import type { Page } from "@playwright/test"
 
 /** Chakra mounts toasts under `chakra-toast-manager-*` regions. */
 export const toastWithText = (page: Page, text: string | RegExp) =>
-  page.locator('[id^="chakra-toast-manager"]').getByText(text)
+  page.locator('[id^="chakra-toast-manager"]').filter({ hasText: text }).last()

--- a/apps/studio/tests/e2e/page/flows/schedule-publish.test.ts
+++ b/apps/studio/tests/e2e/page/flows/schedule-publish.test.ts
@@ -105,12 +105,14 @@ test.describe("publisher", { tag: roleTag("publisher") }, () => {
     // leaving only the 17:00 preset, which is fine for tests that only ever
     // pick one time. This test needs two distinct presets to reschedule
     // between, so it freezes to an instant that's early-morning in UTC
-    // instead, via a direct clock install rather than `scheduleClock`.
+    // instead, via `scheduleClockTime` on `openSeededPageEditor` rather than
+    // the shared `scheduleClock` preset.
     const { page: seededPage } = await seedFolderWithPage({ siteId })
-    await page.clock.install({ time: new Date("2099-01-01T00:01:00Z") })
 
     // Act: schedule for the 5:00 PM quick-select slot
-    const editor = await openSeededPageEditor(page, siteId, seededPage.id)
+    const editor = await openSeededPageEditor(page, siteId, seededPage.id, {
+      scheduleClockTime: new Date("2099-01-01T00:01:00Z"),
+    })
     await editor.openScheduleModal()
     await editor.schedulePublishForToday("5:00 PM")
     await editor.expectScheduledSuccessfully()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1045,7 +1045,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1087,7 +1087,7 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
+        version: 4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 4.1.11(vitest@4.1.11)
@@ -1106,9 +1106,12 @@ importers:
       dotenv-cli:
         specifier: 'catalog:'
         version: 11.0.0
+      eslint-plugin-isomer-e2e:
+        specifier: workspace:*
+        version: link:../../tooling/eslint-plugin-isomer-e2e
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
@@ -1138,7 +1141,7 @@ importers:
         version: 8.5.26
       postcss-load-config:
         specifier: 'catalog:'
-        version: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(yaml@2.8.3)
+        version: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(tsx@4.23.12)(yaml@2.8.3)
       start-server-and-test:
         specifier: 'catalog:'
         version: 3.0.12
@@ -1159,10 +1162,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+        version: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
       webpack-cli:
         specifier: 'catalog:'
         version: 7.2.2(js-yaml@4.3.2)(json5@2.2.3)(webpack@5.105.4)
@@ -1287,7 +1290,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1296,7 +1299,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-vite':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1314,10 +1317,10 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitejs/plugin-react':
         specifier: catalog:vitest
-        version: 6.1.0(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+        version: 6.1.0(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
+        version: 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 4.1.11(vitest@4.1.11)
@@ -1332,7 +1335,7 @@ importers:
         version: 18.2.0
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
@@ -1380,10 +1383,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+        version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -1598,6 +1601,15 @@ importers:
       vitest:
         specifier: catalog:vitest
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+
+  tooling/eslint-plugin-isomer-e2e:
+    devDependencies:
+      '@isomer/oxlint-config':
+        specifier: workspace:*
+        version: link:../oxlint
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
 
   tooling/export-import:
     dependencies:
@@ -16064,11 +16076,11 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -17291,10 +17303,10 @@ snapshots:
       axe-core: 4.11.1
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17310,10 +17322,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17342,12 +17354,12 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -17385,24 +17397,24 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.60.1
-      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)(webpack-cli@7.2.2)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.60.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)
 
   '@storybook/global@5.0.0': {}
@@ -17520,11 +17532,11 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -17534,7 +17546,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -18332,10 +18344,23 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+
+  '@vitest/browser-playwright@4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)':
+    dependencies:
+      '@vitest/browser': 4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
+      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
 
   '@vitest/browser-playwright@4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)':
     dependencies:
@@ -18349,14 +18374,32 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
-  '@vitest/browser-playwright@4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)':
+  '@vitest/browser-playwright@4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)':
     dependencies:
-      '@vitest/browser': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
-      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      '@vitest/browser': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
+      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
       playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -18379,17 +18422,18 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
-  '@vitest/browser@4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)':
+  '@vitest/browser@4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
       '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -18409,7 +18453,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -18430,6 +18474,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
+  '@vitest/mocker@4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.11
@@ -18439,14 +18492,14 @@ snapshots:
       msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
       vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.15.0(@types/node@26.4.0)(typescript@6.0.3)
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -22607,15 +22660,6 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.8.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(yaml@2.8.3):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 2.7.0
-      postcss: 8.5.26
-      tsx: 4.23.12
-      yaml: 2.8.3
-
   postcss-loader@8.2.1(postcss@8.5.26)(typescript@6.0.3)(webpack@5.105.4):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
@@ -24578,6 +24622,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.103.1
+      terser: 5.46.1
+      tsx: 4.23.12
+      yaml: 2.8.3
+
   vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
@@ -24595,7 +24656,7 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.8.3
 
-  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3):
+  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -24606,11 +24667,43 @@ snapshots:
       '@types/node': 26.4.0
       esbuild: 0.28.1
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.7.0
       sass: 1.103.1
       terser: 5.46.1
       tsx: 4.23.12
       yaml: 2.8.3
+
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.2
+      '@vitest/browser-playwright': 4.1.11(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
+      '@vitest/coverage-istanbul': 4.1.11(vitest@4.1.11)
+      happy-dom: 20.10.6
+      jsdom: 30.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)):
     dependencies:
@@ -24644,10 +24737,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -24664,12 +24757,12 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.4.0
-      '@vitest/browser-playwright': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
+      '@vitest/browser-playwright': 4.1.11(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
       '@vitest/coverage-istanbul': 4.1.11(vitest@4.1.11)
       happy-dom: 20.10.6
       jsdom: 30.0.1(@noble/hashes@2.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1607,6 +1607,9 @@ importers:
       '@isomer/oxlint-config':
         specifier: workspace:*
         version: link:../oxlint
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.62.0
       vitest:
         specifier: catalog:vitest
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.12)(yaml@2.8.3))

--- a/tooling/eslint-plugin-isomer-e2e/.oxlintrc.json
+++ b/tooling/eslint-plugin-isomer-e2e/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "extends": ["./node_modules/@isomer/oxlint-config/base.json"]
+}

--- a/tooling/eslint-plugin-isomer-e2e/index.js
+++ b/tooling/eslint-plugin-isomer-e2e/index.js
@@ -1,0 +1,17 @@
+import { noPageMethodsInTests } from "./rules/no-page-methods-in-tests.js"
+import { noRawRoleTag } from "./rules/no-raw-role-tag.js"
+import { noTestUseStorageState } from "./rules/no-test-use-storage-state.js"
+
+/** @type {import('eslint').ESLint.Plugin} */
+const plugin = {
+  meta: {
+    name: "isomer-e2e",
+  },
+  rules: {
+    "no-page-methods-in-tests": noPageMethodsInTests,
+    "no-raw-role-tag": noRawRoleTag,
+    "no-test-use-storage-state": noTestUseStorageState,
+  },
+}
+
+export default plugin

--- a/tooling/eslint-plugin-isomer-e2e/index.js
+++ b/tooling/eslint-plugin-isomer-e2e/index.js
@@ -1,4 +1,5 @@
 import { noPageMethodsInTests } from "./rules/no-page-methods-in-tests.js"
+import { noPositionalLocatorsInPo } from "./rules/no-positional-locators-in-po.js"
 import { noRawRoleTag } from "./rules/no-raw-role-tag.js"
 import { noTestUseStorageState } from "./rules/no-test-use-storage-state.js"
 
@@ -9,6 +10,7 @@ const plugin = {
   },
   rules: {
     "no-page-methods-in-tests": noPageMethodsInTests,
+    "no-positional-locators-in-po": noPositionalLocatorsInPo,
     "no-raw-role-tag": noRawRoleTag,
     "no-test-use-storage-state": noTestUseStorageState,
   },

--- a/tooling/eslint-plugin-isomer-e2e/index.test.js
+++ b/tooling/eslint-plugin-isomer-e2e/index.test.js
@@ -58,3 +58,29 @@ ruleTester.run("no-raw-role-tag", rules["no-raw-role-tag"], {
     },
   ],
 })
+
+ruleTester.run(
+  "no-positional-locators-in-po",
+  rules["no-positional-locators-in-po"],
+  {
+    valid: [
+      "this.page.locator('div').filter({ hasText: /^Enable/ }).last().locator('xpath=..')",
+      "async (links, index) => { await expect(links.nth(index)).toBeVisible() }",
+      'this.page.getByRole("button", { name: "Save" }).click()',
+    ],
+    invalid: [
+      {
+        code: 'this.page.getByRole("textbox").first().fill("x")',
+        errors: [{ messageId: "noPositionalLocator" }],
+      },
+      {
+        code: 'this.page.locator("textarea").nth(1).fill("x")',
+        errors: [{ messageId: "noPositionalLocator" }],
+      },
+      {
+        code: 'this.page.getByRole("button", { name: "Add a link" }).first().click()',
+        errors: [{ messageId: "noPositionalLocator" }],
+      },
+    ],
+  },
+)

--- a/tooling/eslint-plugin-isomer-e2e/index.test.js
+++ b/tooling/eslint-plugin-isomer-e2e/index.test.js
@@ -1,5 +1,6 @@
 import { RuleTester } from "oxlint/plugins-dev"
 import { describe, it } from "vitest"
+
 import plugin from "./index.js"
 
 RuleTester.describe = describe
@@ -33,18 +34,22 @@ ruleTester.run("no-page-methods-in-tests", rules["no-page-methods-in-tests"], {
   ],
 })
 
-ruleTester.run("no-test-use-storage-state", rules["no-test-use-storage-state"], {
-  valid: [
-    'test.describe("admin", { tag: roleTag("admin") }, () => {})',
-    'test.use({ baseURL: "http://localhost" })',
-  ],
-  invalid: [
-    {
-      code: 'test.use({ storageState: "./storage-state/admin.json" })',
-      errors: [{ messageId: "noStorageStateUse" }],
-    },
-  ],
-})
+ruleTester.run(
+  "no-test-use-storage-state",
+  rules["no-test-use-storage-state"],
+  {
+    valid: [
+      'test.describe("admin", { tag: roleTag("admin") }, () => {})',
+      'test.use({ baseURL: "http://localhost" })',
+    ],
+    invalid: [
+      {
+        code: 'test.use({ storageState: "./storage-state/admin.json" })',
+        errors: [{ messageId: "noStorageStateUse" }],
+      },
+    ],
+  },
+)
 
 ruleTester.run("no-raw-role-tag", rules["no-raw-role-tag"], {
   valid: [

--- a/tooling/eslint-plugin-isomer-e2e/index.test.js
+++ b/tooling/eslint-plugin-isomer-e2e/index.test.js
@@ -78,6 +78,8 @@ ruleTester.run(
   {
     valid: [
       "this.page.locator('div').filter({ hasText: /^Enable/ }).last().locator('xpath=..')",
+      "this.page.locator('button').filter({ hasText: /Item 1/ }).first().click()",
+      "this.page.getByRole('group').filter({ has: this.page.getByText('Topic') }).getByRole('combobox')",
       "async (links, index) => { await expect(links.nth(index)).toBeVisible() }",
       'this.page.getByRole("button", { name: "Save" }).click()',
     ],
@@ -92,6 +94,10 @@ ruleTester.run(
       },
       {
         code: 'this.page.getByRole("button", { name: "Add a link" }).first().click()',
+        errors: [{ messageId: "noPositionalLocator" }],
+      },
+      {
+        code: 'this.page.getByText("Saved").filter({ hasText: "Saved" }).first()',
         errors: [{ messageId: "noPositionalLocator" }],
       },
     ],

--- a/tooling/eslint-plugin-isomer-e2e/index.test.js
+++ b/tooling/eslint-plugin-isomer-e2e/index.test.js
@@ -31,6 +31,10 @@ ruleTester.run("no-page-methods-in-tests", rules["no-page-methods-in-tests"], {
       code: "async ({ page }) => { await page.clock.install({ time: new Date() }) }",
       errors: [{ messageId: "noPageMethods" }],
     },
+    {
+      code: "async ({ page: page2 }) => { await page2.goto('/dashboard') }",
+      errors: [{ messageId: "noPageMethods" }],
+    },
   ],
 })
 
@@ -60,6 +64,10 @@ ruleTester.run("no-raw-role-tag", rules["no-raw-role-tag"], {
     {
       code: 'test.describe("admin", { tag: "@admin" }, () => {})',
       errors: [{ messageId: "noRawRoleTag" }],
+    },
+    {
+      code: 'test.describe("admin", { tag: ["@admin", "@editor"] }, () => {})',
+      errors: [{ messageId: "noRawRoleTag" }, { messageId: "noRawRoleTag" }],
     },
   ],
 })

--- a/tooling/eslint-plugin-isomer-e2e/index.test.js
+++ b/tooling/eslint-plugin-isomer-e2e/index.test.js
@@ -1,0 +1,60 @@
+import { RuleTester } from "oxlint/plugins-dev"
+import { describe, it } from "vitest"
+import plugin from "./index.js"
+
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+})
+
+const { rules } = plugin
+
+ruleTester.run("no-page-methods-in-tests", rules["no-page-methods-in-tests"], {
+  valid: [
+    "async ({ page }) => { const editor = new PageEditorPO(page) }",
+    "async ({ page }) => { await resetGrowthBookPage(page) }",
+    "async ({ page }) => { await openSeededPageEditor(page, siteId, id) }",
+    "const parsed = { page: { title: 'x' } }; parsed.page.title = 'y'",
+  ],
+  invalid: [
+    {
+      code: "async ({ page }) => { await page.goto('/dashboard') }",
+      errors: [{ messageId: "noPageMethods" }],
+    },
+    {
+      code: "async ({ page }) => { await page.clock.install({ time: new Date() }) }",
+      errors: [{ messageId: "noPageMethods" }],
+    },
+  ],
+})
+
+ruleTester.run("no-test-use-storage-state", rules["no-test-use-storage-state"], {
+  valid: [
+    'test.describe("admin", { tag: roleTag("admin") }, () => {})',
+    'test.use({ baseURL: "http://localhost" })',
+  ],
+  invalid: [
+    {
+      code: 'test.use({ storageState: "./storage-state/admin.json" })',
+      errors: [{ messageId: "noStorageStateUse" }],
+    },
+  ],
+})
+
+ruleTester.run("no-raw-role-tag", rules["no-raw-role-tag"], {
+  valid: [
+    'test.describe("admin", { tag: roleTag("admin") }, () => {})',
+    'const tags = "@admin @editor"',
+  ],
+  invalid: [
+    {
+      code: 'test.describe("admin", { tag: "@admin" }, () => {})',
+      errors: [{ messageId: "noRawRoleTag" }],
+    },
+  ],
+})

--- a/tooling/eslint-plugin-isomer-e2e/package.json
+++ b/tooling/eslint-plugin-isomer-e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "eslint-plugin-isomer-e2e",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Oxlint JS plugin enforcing Studio Playwright E2E conventions",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
+  "scripts": {
+    "test:unit": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@isomer/oxlint-config": "workspace:*",
+    "vitest": "catalog:vitest"
+  }
+}

--- a/tooling/eslint-plugin-isomer-e2e/package.json
+++ b/tooling/eslint-plugin-isomer-e2e/package.json
@@ -1,18 +1,23 @@
 {
   "name": "eslint-plugin-isomer-e2e",
-  "private": true,
   "version": "0.1.0",
+  "private": true,
   "description": "Oxlint JS plugin enforcing Studio Playwright E2E conventions",
   "type": "module",
   "exports": {
     ".": "./index.js"
   },
   "scripts": {
+    "format": "oxfmt --check . --ignore-path ../../.gitignore",
+    "format:fix": "oxfmt --write . --ignore-path ../../.gitignore",
+    "lint": "oxlint --type-aware .",
+    "lint:fix": "oxlint --type-aware --fix .",
     "test:unit": "vitest run",
     "test:watch": "vitest"
   },
   "devDependencies": {
     "@isomer/oxlint-config": "workspace:*",
+    "oxfmt": "catalog:",
     "vitest": "catalog:vitest"
   }
 }

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-page-methods-in-tests.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-page-methods-in-tests.js
@@ -1,0 +1,55 @@
+/** @param {import('estree').Node | null | undefined} node */
+const getMemberChainRoot = (node) => {
+  let current = node
+  while (current?.type === "MemberExpression") {
+    current = current.object
+  }
+  return current
+}
+
+/** @param {import('estree').Node} node */
+const isPlaywrightPageFixture = (node) =>
+  node.type === "Identifier" && node.name === "page"
+
+/**
+ * Disallow `page.<method>(...)` in E2E test files. Playwright page calls belong
+ * in fixtures/po/ or fixtures/helpers.ts — tests only pass `page` into POs and
+ * documented infra helpers.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export const noPageMethodsInTests = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Playwright page method calls in E2E test files (use POs/helpers instead)",
+    },
+    messages: {
+      noPageMethods:
+        "Do not call `{{method}}()` in E2E test files. Move this to `fixtures/po/` or `fixtures/helpers.ts`, then call the PO/helper from the test. See `.claude/skills/isomer-conventions/conventions/e2e-tests.md`.",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const root = getMemberChainRoot(node.callee)
+        if (!isPlaywrightPageFixture(root)) {
+          return
+        }
+
+        const method =
+          node.callee.type === "MemberExpression"
+            ? context.sourceCode.getText(node.callee)
+            : "page"
+
+        context.report({
+          node,
+          messageId: "noPageMethods",
+          data: { method },
+        })
+      },
+    }
+  },
+}

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-page-methods-in-tests.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-page-methods-in-tests.js
@@ -7,9 +7,28 @@ const getMemberChainRoot = (node) => {
   return current
 }
 
-/** @param {import('estree').Node} node */
-const isPlaywrightPageFixture = (node) =>
-  node.type === "Identifier" && node.name === "page"
+/** @param {import('estree').Pattern} param @param {Set<string>} names */
+const collectPageFixtureBindings = (param, names) => {
+  if (param.type !== "ObjectPattern") {
+    return
+  }
+
+  for (const property of param.properties) {
+    if (property.type !== "Property") {
+      continue
+    }
+
+    const keyIsPage =
+      (property.key.type === "Identifier" && property.key.name === "page") ||
+      (property.key.type === "Literal" && property.key.value === "page")
+
+    if (!keyIsPage || property.value.type !== "Identifier") {
+      continue
+    }
+
+    names.add(property.value.name)
+  }
+}
 
 /**
  * Disallow `page.<method>(...)` in E2E test files. Playwright page calls belong
@@ -32,17 +51,52 @@ export const noPageMethodsInTests = {
     schema: [],
   },
   create(context) {
+    /** @type {Set<string>[]} */
+    const pageFixtureScopeStack = [new Set(["page"])]
+
+    const currentPageFixtures = () => {
+      const names = new Set()
+      for (const scope of pageFixtureScopeStack) {
+        for (const name of scope) {
+          names.add(name)
+        }
+      }
+      return names
+    }
+
+    const enterFunction = (node) => {
+      const names = new Set()
+      for (const param of node.params) {
+        collectPageFixtureBindings(param, names)
+      }
+      pageFixtureScopeStack.push(names)
+    }
+
+    const exitFunction = () => {
+      pageFixtureScopeStack.pop()
+    }
+
     return {
+      FunctionDeclaration: enterFunction,
+      "FunctionDeclaration:exit": exitFunction,
+      FunctionExpression: enterFunction,
+      "FunctionExpression:exit": exitFunction,
+      ArrowFunctionExpression: enterFunction,
+      "ArrowFunctionExpression:exit": exitFunction,
       CallExpression(node) {
         const root = getMemberChainRoot(node.callee)
-        if (!isPlaywrightPageFixture(root)) {
+        if (root?.type !== "Identifier") {
+          return
+        }
+
+        if (!currentPageFixtures().has(root.name)) {
           return
         }
 
         const method =
           node.callee.type === "MemberExpression"
             ? context.sourceCode.getText(node.callee)
-            : "page"
+            : root.name
 
         context.report({
           node,

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-positional-locators-in-po.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-positional-locators-in-po.js
@@ -21,9 +21,9 @@ const getPositionalMethod = (member) => {
     : null
 }
 
-/** @param {import('estree').Node | null | undefined} node */
-const hasFilterCallInChain = (node) => {
-  let current = node
+/** @param {import('estree').Node | null | undefined} start */
+const findFilterCallInChain = (start) => {
+  let current = start
   while (current) {
     if (
       current.type === "CallExpression" &&
@@ -31,7 +31,7 @@ const hasFilterCallInChain = (node) => {
       current.callee.property.type === "Identifier" &&
       current.callee.property.name === "filter"
     ) {
-      return true
+      return current
     }
 
     if (current.type === "MemberExpression") {
@@ -50,7 +50,22 @@ const hasFilterCallInChain = (node) => {
     break
   }
 
-  return false
+  return null
+}
+
+/** @param {import('estree').CallExpression} filterCall */
+const filterUsesChildLocator = (filterCall) => {
+  const arg = filterCall.arguments[0]
+  if (!arg || arg.type !== "ObjectExpression") {
+    return false
+  }
+
+  return arg.properties.some(
+    (property) =>
+      property.type === "Property" &&
+      property.key.type === "Identifier" &&
+      (property.key.name === "has" || property.key.name === "hasNot"),
+  )
 }
 
 /**
@@ -89,6 +104,35 @@ const findLocatorFactory = (node) => {
   }
 
   return null
+}
+
+/** @param {import('estree').CallExpression} filterCall */
+const isGenericLocatorTextFilter = (filterCall) => {
+  const factory = findLocatorFactory(filterCall.callee.object)
+  if (
+    !factory ||
+    factory.callee.type !== "MemberExpression" ||
+    factory.callee.property.type !== "Identifier" ||
+    factory.callee.property.name !== "locator"
+  ) {
+    return false
+  }
+
+  return true
+}
+
+/** @param {import('estree').Node | null | undefined} receiver */
+const allowsPositionalAfterFilter = (receiver) => {
+  const filterCall = findFilterCallInChain(receiver)
+  if (!filterCall) {
+    return false
+  }
+
+  if (filterUsesChildLocator(filterCall)) {
+    return true
+  }
+
+  return isGenericLocatorTextFilter(filterCall)
 }
 
 /** @param {import('estree').CallExpression} node */
@@ -134,7 +178,7 @@ export const noPositionalLocatorsInPo = {
         }
 
         const receiver = node.callee.object
-        if (hasFilterCallInChain(receiver)) {
+        if (allowsPositionalAfterFilter(receiver)) {
           return
         }
 

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-positional-locators-in-po.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-positional-locators-in-po.js
@@ -1,0 +1,154 @@
+const POSITIONAL_METHODS = new Set(["first", "last", "nth"])
+
+const LOCATOR_METHODS = new Set([
+  "getByRole",
+  "getByLabel",
+  "getByText",
+  "getByPlaceholder",
+  "locator",
+])
+
+/** @param {import('estree').MemberExpression} member */
+const getPositionalMethod = (member) => {
+  if (member.type !== "MemberExpression" || member.computed) {
+    return null
+  }
+  if (member.property.type !== "Identifier") {
+    return null
+  }
+  return POSITIONAL_METHODS.has(member.property.name)
+    ? member.property.name
+    : null
+}
+
+/** @param {import('estree').Node | null | undefined} node */
+const hasFilterCallInChain = (node) => {
+  let current = node
+  while (current) {
+    if (
+      current.type === "CallExpression" &&
+      current.callee.type === "MemberExpression" &&
+      current.callee.property.type === "Identifier" &&
+      current.callee.property.name === "filter"
+    ) {
+      return true
+    }
+
+    if (current.type === "MemberExpression") {
+      current = current.object
+      continue
+    }
+
+    if (
+      current.type === "CallExpression" &&
+      current.callee.type === "MemberExpression"
+    ) {
+      current = current.callee.object
+      continue
+    }
+
+    break
+  }
+
+  return false
+}
+
+/**
+ * Walk the member/call chain upward from `node` and return the nearest
+ * Playwright locator factory call (`getByRole`, `locator`, …).
+ *
+ * @param {import('estree').Node | null | undefined} node
+ */
+const findLocatorFactory = (node) => {
+  let current = node
+
+  while (current) {
+    if (
+      current.type === "CallExpression" &&
+      current.callee.type === "MemberExpression" &&
+      current.callee.property.type === "Identifier" &&
+      LOCATOR_METHODS.has(current.callee.property.name)
+    ) {
+      return current
+    }
+
+    if (current.type === "MemberExpression") {
+      current = current.object
+      continue
+    }
+
+    if (
+      current.type === "CallExpression" &&
+      current.callee.type === "MemberExpression"
+    ) {
+      current = current.callee.object
+      continue
+    }
+
+    break
+  }
+
+  return null
+}
+
+/** @param {import('estree').CallExpression} node */
+const isNthWithVariableIndex = (node, method) =>
+  method === "nth" &&
+  node.arguments[0]?.type === "Identifier" &&
+  node.arguments.length === 1
+
+/**
+ * Disallow `.first()`, `.last()`, and literal `.nth(n)` on Playwright locators
+ * in page objects. Prefer `getByRole(role, { name })` / `getByLabel(...)` over
+ * positional disambiguation.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export const noPositionalLocatorsInPo = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow positional Playwright locators (.first/.last/.nth) in PO files",
+    },
+    messages: {
+      noPositionalLocator:
+        "Avoid `{{method}}()` on Playwright locators in page objects. Match controls by accessible name (`getByRole(role, { name })`, `getByLabel`) instead of position. See `.claude/skills/isomer-conventions/conventions/e2e-tests.md`.",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== "MemberExpression") {
+          return
+        }
+
+        const method = getPositionalMethod(node.callee)
+        if (!method) {
+          return
+        }
+
+        if (isNthWithVariableIndex(node, method)) {
+          return
+        }
+
+        const receiver = node.callee.object
+        if (hasFilterCallInChain(receiver)) {
+          return
+        }
+
+        const locatorFactory = findLocatorFactory(receiver)
+        if (!locatorFactory) {
+          return
+        }
+
+        context.report({
+          node,
+          messageId: "noPositionalLocator",
+          data: { method },
+        })
+      },
+    }
+  },
+}

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-raw-role-tag.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-raw-role-tag.js
@@ -13,7 +13,7 @@ export const noRawRoleTag = {
     },
     messages: {
       noRawRoleTag:
-        "Use `roleTag(\"{{role}}\")` from `~e2e/fixtures/auth` instead of a raw `\"@{{role}}\"` tag string.",
+        'Use `roleTag("{{role}}")` from `~e2e/fixtures/auth` instead of a raw `"@{{role}}"` tag string.',
     },
     schema: [],
   },
@@ -25,7 +25,11 @@ export const noRawRoleTag = {
           (key.type === "Identifier" && key.name === "tag") ||
           (key.type === "Literal" && key.value === "tag")
 
-        if (!isTagKey || value.type !== "Literal" || typeof value.value !== "string") {
+        if (
+          !isTagKey ||
+          value.type !== "Literal" ||
+          typeof value.value !== "string"
+        ) {
           return
         }
 

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-raw-role-tag.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-raw-role-tag.js
@@ -1,0 +1,45 @@
+/**
+ * Disallow raw `@role` tag strings on describes. Use `roleTag(...)` from
+ * `~e2e/fixtures/auth` so tags stay typed against `ROLES`.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export const noRawRoleTag = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow raw @role tag strings in E2E describes (use roleTag)",
+    },
+    messages: {
+      noRawRoleTag:
+        "Use `roleTag(\"{{role}}\")` from `~e2e/fixtures/auth` instead of a raw `\"@{{role}}\"` tag string.",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Property(node) {
+        const { key, value } = node
+        const isTagKey =
+          (key.type === "Identifier" && key.name === "tag") ||
+          (key.type === "Literal" && key.value === "tag")
+
+        if (!isTagKey || value.type !== "Literal" || typeof value.value !== "string") {
+          return
+        }
+
+        const match = /^@(?<role>[a-z]+)$/.exec(value.value)
+        if (!match?.groups?.role) {
+          return
+        }
+
+        context.report({
+          node: value,
+          messageId: "noRawRoleTag",
+          data: { role: match.groups.role },
+        })
+      },
+    }
+  },
+}

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-raw-role-tag.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-raw-role-tag.js
@@ -18,6 +18,27 @@ export const noRawRoleTag = {
     schema: [],
   },
   create(context) {
+    /** @param {import('estree').Node} node @param {string} role */
+    const reportRawRoleTag = (node, role) => {
+      context.report({
+        node,
+        messageId: "noRawRoleTag",
+        data: { role },
+      })
+    }
+
+    /** @param {import('estree').Literal} literal */
+    const checkRoleTagLiteral = (literal) => {
+      if (typeof literal.value !== "string") {
+        return
+      }
+
+      const match = /^@(?<role>[a-z]+)$/.exec(literal.value)
+      if (match?.groups?.role) {
+        reportRawRoleTag(literal, match.groups.role)
+      }
+    }
+
     return {
       Property(node) {
         const { key, value } = node
@@ -25,24 +46,22 @@ export const noRawRoleTag = {
           (key.type === "Identifier" && key.name === "tag") ||
           (key.type === "Literal" && key.value === "tag")
 
-        if (
-          !isTagKey ||
-          value.type !== "Literal" ||
-          typeof value.value !== "string"
-        ) {
+        if (!isTagKey) {
           return
         }
 
-        const match = /^@(?<role>[a-z]+)$/.exec(value.value)
-        if (!match?.groups?.role) {
+        if (value.type === "Literal") {
+          checkRoleTagLiteral(value)
           return
         }
 
-        context.report({
-          node: value,
-          messageId: "noRawRoleTag",
-          data: { role: match.groups.role },
-        })
+        if (value.type === "ArrayExpression") {
+          for (const element of value.elements) {
+            if (element?.type === "Literal") {
+              checkRoleTagLiteral(element)
+            }
+          }
+        }
       },
     }
   },

--- a/tooling/eslint-plugin-isomer-e2e/rules/no-test-use-storage-state.js
+++ b/tooling/eslint-plugin-isomer-e2e/rules/no-test-use-storage-state.js
@@ -1,0 +1,61 @@
+/** @param {import('estree').Property} property */
+const isStorageStateProperty = (property) => {
+  if (property.type !== "Property") {
+    return false
+  }
+
+  const { key } = property
+  if (key.type === "Identifier") {
+    return key.name === "storageState"
+  }
+  if (key.type === "Literal" && typeof key.value === "string") {
+    return key.value === "storageState"
+  }
+  return false
+}
+
+/**
+ * Disallow per-file `test.use({ storageState })`. Role auth is configured via
+ * Playwright projects and `roleTag()` on describes.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export const noTestUseStorageState = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow test.use({ storageState }) in E2E tests (use role projects + roleTag)",
+    },
+    messages: {
+      noStorageStateUse:
+        "Do not use `test.use({ storageState })` in E2E tests. Tag the `describe` with `roleTag(...)` and let Playwright projects supply auth. See `tests/e2e/README.md`.",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const { callee } = node
+        if (
+          callee.type !== "MemberExpression" ||
+          callee.object.type !== "Identifier" ||
+          callee.object.name !== "test" ||
+          callee.property.type !== "Identifier" ||
+          callee.property.name !== "use"
+        ) {
+          return
+        }
+
+        const [firstArg] = node.arguments
+        if (firstArg?.type !== "ObjectExpression") {
+          return
+        }
+
+        if (firstArg.properties.some(isStorageStateProperty)) {
+          context.report({ node, messageId: "noStorageStateUse" })
+        }
+      },
+    }
+  },
+}

--- a/tooling/oxlint/README.md
+++ b/tooling/oxlint/README.md
@@ -4,6 +4,8 @@ Shared **Oxlint** configuration for Isomer. This package **depends on** `oxlint`
 
 Workspaces whose `.oxlintrc.json` uses **`jsPlugins`: `eslint-plugin-storybook`** (for `storybook/*` rules) should list **`eslint-plugin-storybook`** in their own `devDependencies`—Oxlint loads that package via [JS plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins); **ESLint itself is not required**.
 
+`apps/studio` also loads **`eslint-plugin-isomer-e2e`** for Playwright E2E convention rules on `tests/e2e/**/*.test.ts`.
+
 ## Use in this monorepo
 
 Add the config package to any workspace that runs lint:


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 13 | +639 | -0 |
| 🧪 Test | 8 | +114 | -53 |
| 📄 Doc | 4 | +20 | -3 |
| 🚫 Ignore | 1 | +153 | -57 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enforces Studio Playwright E2E conventions via Oxlint (`eslint-plugin-isomer-e2e`) and fixes legacy PO locator violations.

### Lint plugin (`tooling/eslint-plugin-isomer-e2e`)
- `no-page-methods-in-tests`, `no-test-use-storage-state`, `no-raw-role-tag`, `no-restricted-imports`
- `no-positional-locators-in-po` — disallows bare `.first()`/`.last()`/literal `.nth(n)` on labelled locators; allows structural `.filter({ has/hasNot })` and generic `.locator(tag).filter({ hasText })` narrowing (not redundant `getByText().filter({ hasText })` bypasses)

### PO fixes
- Scoped collection validation errors to filters panel / active option row
- `expectAnyVisible` helper for duplicate preview/toast text (no positional disambiguation)
- Gallery item rows, aria-label additions, toast helper, schedule-publish helper

### Docs
- `e2e-tests.md` documents enforced rules and allowed positional exceptions

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5c1dc52-4c88-484c-99fb-3f8d6c48b901?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5c1dc52-4c88-484c-99fb-3f8d6c48b901&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>









<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an Oxlint plugin that enforces Studio Playwright E2E conventions and updates existing page objects and tests to comply.
- Enables rules for direct Page API usage, storage-state configuration, raw role tags, restricted imports, and positional page-object locators.
- Adds focused locator and toast helpers, accessible labels, and scoped page-object selectors.
- Moves scheduled-clock setup behind the shared editor-opening helper and documents the enforced conventions.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/eslint-plugin-isomer-e2e/rules/no-page-methods-in-tests.js | Tracks Playwright page fixture bindings per function scope, including the aliased fixture pattern from the previous review thread. |
| tooling/eslint-plugin-isomer-e2e/rules/no-raw-role-tag.js | Checks direct raw role tags and each literal role tag in arrays, resolving the previously reported array bypass. |
| tooling/eslint-plugin-isomer-e2e/rules/no-positional-locators-in-po.js | Enforces labelled and structurally scoped page-object locators while preserving documented variable-index and filtered-locator exceptions. |
| tooling/eslint-plugin-isomer-e2e/index.test.js | Covers the plugin rules, including the two concrete bypass patterns raised in the previous review. |
| apps/studio/.oxlintrc.json | Enables the E2E-specific rules for test and page-object file globs. |
| apps/studio/tests/e2e/fixtures/po/locator-helpers.ts | Adds a polling assertion for cases where any one of several matching elements may validly be visible. |
| apps/studio/tests/e2e/fixtures/po/toast.ts | Adds a scoped helper that waits for matching visible Chakra toast regions. |
| apps/studio/tests/e2e/fixtures/helpers.ts | Extends editor setup to install a caller-supplied Playwright clock time before navigation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  E2E[E2E test files] --> Oxlint[Studio Oxlint configuration]
  PO[Page-object files] --> Oxlint
  Oxlint --> Plugin[eslint-plugin-isomer-e2e]
  Plugin --> TestRules[Page, storage-state, role-tag, and import rules]
  Plugin --> LocatorRule[Positional-locator rule]
  TestRules --> CI[Lint result in CI]
  LocatorRule --> CI
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(e2e): wait for latest visible toast ..."](https://github.com/opengovsg/isomer/commit/86039c9f6fda0c9247e2c9e4320db54d4c2e106b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59437680)</sub>

<!-- /greptile_comment -->