### PR TITLE
📆 feat(components): show date filter status on collection cards and article headers

### DIFF
--- a/packages/components/src/templates/next/components/complex/DynamicDataBanner/utils.ts
+++ b/packages/components/src/templates/next/components/complex/DynamicDataBanner/utils.ts
@@ -1,19 +1,4 @@
-export const getSingaporeDateYYYYMMDD = (): string => {
-  const singaporeDateFormatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  })
-  return singaporeDateFormatter.format(new Date()) // Outputs YYYY-MM-DD
-}
-
-export const getSingaporeDateLong = (): string => {
-  const singaporeDateFormatter = new Intl.DateTimeFormat("en-SG", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  })
-  return singaporeDateFormatter.format(new Date()) // Outputs DD Month YYYY
-}
+export {
+  getSingaporeDateLong,
+  getSingaporeDateYYYYMMDD,
+} from "~/utils/getSingaporeDate"

--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -2,9 +2,7 @@ import type { ArticlePageHeaderProps } from "~/interfaces"
 import { getFormattedDate } from "~/utils/getFormattedDate"
 
 import { Breadcrumb } from "../Breadcrumb"
-import { EventDateFilterDates } from "../CollectionCard/EventDateFilterDates"
-import { EventStatusPill } from "../CollectionCard/EventStatusPill"
-import { useDateFilterCards } from "../CollectionCard/useDateFilterCards"
+import { EventDateFilterDisplay } from "../CollectionCard/EventDateFilterDisplay"
 import { PillTags, PlaintextTags } from "../Tags"
 
 export const ArticlePageHeader = ({
@@ -16,10 +14,6 @@ export const ArticlePageHeader = ({
   pillTags,
   dateFilterDisplayEntries,
 }: ArticlePageHeaderProps) => {
-  const dateFilterCards = useDateFilterCards(dateFilterDisplayEntries)
-  const statusBadges =
-    dateFilterCards?.filter(({ statusLabel }) => statusLabel.trim()) ?? []
-
   return (
     <div className="mx-auto w-full">
       <div className="my-16">
@@ -28,37 +22,31 @@ export const ArticlePageHeader = ({
 
       <div className="flex flex-col gap-5">
         <div className="flex flex-col gap-4">
-          {statusBadges.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2">
-              {statusBadges.map(({ id, status, statusLabel }) => (
-                <EventStatusPill key={id} status={status} label={statusLabel} />
-              ))}
-            </div>
-          )}
+          <EventDateFilterDisplay
+            entries={dateFilterDisplayEntries}
+            beforeTitle={
+              <PlaintextTags
+                tags={plaintextTags}
+                className="prose-body-base text-base-content"
+              />
+            }
+            afterDates={
+              <PillTags
+                tags={pillTags}
+                className="flex flex-wrap items-center gap-2"
+              />
+            }
+          >
+            <h1 className="prose-display-md break-words text-base-content-strong">
+              {title}
+            </h1>
 
-          <PlaintextTags
-            tags={plaintextTags}
-            className="prose-body-base text-base-content"
-          />
-
-          <h1 className="prose-display-md break-words text-base-content-strong">
-            {title}
-          </h1>
-
-          {date && (
-            <p className="prose-label-sm-medium text-base-content">
-              {getFormattedDate(date)}
-            </p>
-          )}
-
-          {dateFilterCards && (
-            <EventDateFilterDates entries={dateFilterCards} />
-          )}
-
-          <PillTags
-            tags={pillTags}
-            className="flex flex-wrap items-center gap-2"
-          />
+            {date && (
+              <p className="prose-label-sm-medium text-base-content">
+                {getFormattedDate(date)}
+              </p>
+            )}
+          </EventDateFilterDisplay>
         </div>
 
         {summary && (

--- a/packages/components/src/templates/next/components/internal/CollectionCard/EventDateFilterDisplay.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/EventDateFilterDisplay.tsx
@@ -11,18 +11,27 @@ interface EventDateFilterDisplayProps {
   entries?: DateFilterDisplayEntry[]
   beforeTitle?: ReactNode
   afterTitle?: ReactNode
+  afterDates?: ReactNode
 }
 
 export const EventDateFilterDisplay = ({
   entries,
   beforeTitle,
   afterTitle,
+  afterDates,
   children,
 }: PropsWithChildren<EventDateFilterDisplayProps>) => {
   const dateFilterCards = useDateFilterCards(entries)
 
   if (!dateFilterCards || dateFilterCards.length === 0) {
-    return children ?? null
+    return (
+      <>
+        {beforeTitle}
+        {children}
+        {afterTitle}
+        {afterDates}
+      </>
+    )
   }
 
   const statusBadges = dateFilterCards.filter(({ statusLabel }) =>
@@ -42,6 +51,7 @@ export const EventDateFilterDisplay = ({
       {children}
       {afterTitle}
       <EventDateFilterDates entries={dateFilterCards} />
+      {afterDates}
     </>
   )
 }

--- a/packages/components/src/templates/next/components/internal/CollectionCard/EventStatusPill.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/EventStatusPill.tsx
@@ -1,6 +1,7 @@
 import type { DateFilterStatusId } from "~/types/constants"
 import { DATE_FILTER_STATUS_ID } from "~/types/constants"
 
+// Deliberate one-off design colours — not theme tokens.
 const STATUS_STYLES: Record<DateFilterStatusId, string> = {
   [DATE_FILTER_STATUS_ID.Upcoming]: "bg-[#358257] text-white",
   [DATE_FILTER_STATUS_ID.Ongoing]: "bg-[#A88651] text-white",

--- a/packages/components/src/templates/next/components/internal/CollectionCard/useDateFilterCards.ts
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/useDateFilterCards.ts
@@ -11,4 +11,6 @@ export const useDateFilterCards = (entries?: DateFilterDisplayEntry[]) =>
     }
 
     return getDateFilterCardsFromEntries(entries, getTodayInSingapore())
+    // NOTE: `today` is only recomputed when `entries` changes. Status can stay
+    // stale if the page stays mounted across Singapore midnight — accepted.
   }, [entries])

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/dateFilter.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/dateFilter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
+import { getDateFilterCardsFromEntries } from "~/templates/next/components/internal/CollectionCard/utils/getDateFilterCardsFromEntries"
+import { DEFAULT_DATE_FILTER_STATUS_LABELS } from "~/types/constants"
 
-import { getDateFilterCardsFromEntries } from "../dateFilterCards"
 import { resolveItemDateFields } from "../dateFilterStatic"
 
 const EVENT_DATE_FILTER_ID = "11111111-1111-1111-1111-111111111111"
@@ -10,11 +11,7 @@ const tagCategories = [
     id: EVENT_DATE_FILTER_ID,
     label: "Event Date",
     type: "date" as const,
-    statusLabels: [
-      { id: "ENDED" as const, label: "Event ended" },
-      { id: "ONGOING" as const, label: "Ongoing" },
-      { id: "UPCOMING" as const, label: "Upcoming" },
-    ],
+    statusLabels: DEFAULT_DATE_FILTER_STATUS_LABELS,
   },
 ]
 
@@ -109,7 +106,7 @@ describe("getDateFilterCardsFromEntries", () => {
       tagCategories,
     ).dateFilterDisplayEntries!
 
-    expect(getDateFilterCardsFromEntries(entries, "2026-06-15")).toEqual([
+    expect(getDateFilterCardsFromEntries(entries)).toEqual([
       {
         id: EVENT_DATE_FILTER_ID,
         label: "Event Date",

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getDateFilterStatus.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getDateFilterStatus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { DATE_FILTER_STATUS_ID } from "~/types/constants"
+import { getSingaporeDateYYYYMMDD } from "~/utils/getSingaporeDate"
 
 import { getDateFilterStatus } from "../getDateFilterStatus"
 
@@ -55,9 +56,7 @@ describe("getDateFilterStatus", () => {
   })
 
   it("defaults `today` to the current date in Asia/Singapore when omitted", () => {
-    const todayInSg = new Intl.DateTimeFormat("en-CA", {
-      timeZone: "Asia/Singapore",
-    }).format(new Date())
+    const todayInSg = getSingaporeDateYYYYMMDD()
 
     expect(getDateFilterStatus({ date: todayInSg })).toEqual(
       DATE_FILTER_STATUS_ID.Ongoing,

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/processCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/processCollectionItems.test.ts
@@ -39,11 +39,11 @@ describe("processCollectionItems", () => {
         label: "Event Date",
         dateText: "27 Sep 2026",
         date: "2026-09-27",
-        statusLabels: [
-          { id: "ENDED" as const, label: "Ended" },
-          { id: "ONGOING" as const, label: "Ongoing" },
-          { id: "UPCOMING" as const, label: "Upcoming" },
-        ],
+        statusLabels: {
+          ENDED: "Ended",
+          ONGOING: "Ongoing",
+          UPCOMING: "Upcoming",
+        },
       },
     ]
 

--- a/packages/components/src/templates/next/layouts/Collection/utils/dateFilterStatic.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/dateFilterStatic.ts
@@ -5,6 +5,7 @@ import type {
   DateTaggedItem,
 } from "~/types"
 import { format, isSameDay, parseISO } from "date-fns"
+import { DEFAULT_DATE_FILTER_STATUS_LABELS } from "~/types/constants"
 import { isDateFilter } from "~/types/page"
 
 export interface ResolvedItemDateFields {
@@ -64,7 +65,10 @@ export const resolveItemDateFields = (
       dateText: formatDateFilterDateText(value.date, value.endDate),
       date: value.date,
       endDate: value.endDate,
-      statusLabels: category.statusLabels,
+      statusLabels: {
+        ...DEFAULT_DATE_FILTER_STATUS_LABELS,
+        ...category.statusLabels,
+      },
     })
   })
 

--- a/packages/components/src/templates/next/layouts/Collection/utils/getDateFilterStatus.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getDateFilterStatus.ts
@@ -2,6 +2,7 @@ import {
   DATE_FILTER_STATUS_ID,
   type DateFilterStatusId,
 } from "~/types/constants"
+import { getSingaporeDateYYYYMMDD } from "~/utils/getSingaporeDate"
 
 export interface DateFilterValue {
   date: string
@@ -14,13 +15,7 @@ export interface DateFilterValue {
 // and `endDate` are already plain "yyyy-MM-dd" strings (schema format
 // "date", no time component), so lexicographic string comparison against
 // this is equivalent to calendar-date comparison — no Date parsing needed.
-export const getTodayInSingapore = (): string =>
-  new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(new Date())
+export const getTodayInSingapore = (): string => getSingaporeDateYYYYMMDD()
 
 // Inclusive on both ends: `today < date` → upcoming, `date <= today <= end`
 // → ongoing, `today > end` → ended. A single date (no `endDate`) is treated

--- a/packages/components/src/utils/__tests__/getSingaporeDate.test.ts
+++ b/packages/components/src/utils/__tests__/getSingaporeDate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+
+import { getSingaporeDateYYYYMMDD } from "../getSingaporeDate"
+
+describe("getSingaporeDateYYYYMMDD", () => {
+  it("formats a known UTC instant as the Singapore calendar date", () => {
+    // 2026-06-15 20:00 UTC = 2026-06-16 04:00 SGT
+    const date = new Date("2026-06-15T20:00:00.000Z")
+
+    expect(getSingaporeDateYYYYMMDD(date)).toEqual("2026-06-16")
+  })
+
+  it("returns a yyyy-MM-dd string", () => {
+    expect(getSingaporeDateYYYYMMDD()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})

--- a/packages/components/src/utils/getSingaporeDate.ts
+++ b/packages/components/src/utils/getSingaporeDate.ts
@@ -1,0 +1,26 @@
+import { format } from "date-fns"
+
+export const SINGAPORE_TIME_ZONE = "Asia/Singapore"
+
+// Singapore is fixed UTC+8 with no DST — safe to shift without date-fns-tz.
+const SINGAPORE_UTC_OFFSET_MS = 8 * 60 * 60 * 1000
+
+const toSingaporeLocalDate = (date: Date): Date => {
+  const utcMs = date.getTime() + date.getTimezoneOffset() * 60_000
+  return new Date(utcMs + SINGAPORE_UTC_OFFSET_MS)
+}
+
+// Canonical "yyyy-MM-dd" in Asia/Singapore for comparison/sorting — not for display.
+// Uses date-fns with a fixed offset instead of an Intl locale trick (en-CA) so output
+// stays deterministic on minimal-ICU runtimes.
+export const getSingaporeDateYYYYMMDD = (date = new Date()): string =>
+  format(toSingaporeLocalDate(date), "yyyy-MM-dd")
+
+// Human-readable date for display — locale formatting is appropriate here.
+export const getSingaporeDateLong = (date = new Date()): string =>
+  new Intl.DateTimeFormat("en-SG", {
+    timeZone: SINGAPORE_TIME_ZONE,
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date)


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 39 | +1564 | -239 |
| 🧪 Test | 22 | +1807 | -5 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 1 | +50 | -5 |
<!-- pr-diff-breakdown:end -->

## Summary
- Add card/header display components and status pills for date filters
- Include minimal collection utils needed for client-side date status derivation on cards

Stacks on #3155 (`feat/date-filters-schema`). Replaces the UI portion of #3156.

> [!NOTE]
> Was from https://github.com/opengovsg/isomer/pull/3156 but i split into 3 PRs for ease of review

## Test plan
- [ ] Review Storybook stories for `CollectionCard`, `BlogCard`, and `ArticlePageHeader` date filter variants
- [ ] `pnpm typecheck` in `packages/components`
- [ ] Unit tests for `getDateFilterStatus`, `getPillAndPlaintextTags`, `getTagFilters`, `getTagsFromTagged`













<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds Singapore-date-aware status and date displays to collection cards, blog cards, and article headers.
- Introduces shared date-filter display types, status derivation utilities, and status-pill components.
- Passes preprocessed date-filter data from collection and article layouts into client-facing components.
- Updates text-tag utilities to distinguish date filters from option-based filters.
- Adds unit tests and Storybook variants covering date statuses and mixed filter categories.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/components/internal/CollectionCard/DateFilterStatusClient.tsx | Derives and renders non-empty status labels from preprocessed date-filter entries. |
| packages/components/src/templates/next/components/internal/CollectionCard/utils/getDateFilterStatus.ts | Classifies single dates and inclusive date ranges against the current Singapore calendar date. |
| packages/components/src/templates/next/layouts/Collection/utils/getPillAndPlaintextTags.ts | Excludes date-filter categories from option-based pill and plaintext tag derivation. |
| packages/components/src/types/page.ts | Adds reusable type guards and generates date-filter status-label schema fields from shared constants. |
| packages/components/src/utils/getSingaporeDate.ts | Centralizes Singapore calendar-date and long-date formatting for status and dynamic-data consumers. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Collection date-filter data] --> B[Server-side display entries]
  B --> C[Collection and blog cards]
  B --> D[Article page header]
  C --> E[Client status derivation]
  D --> E
  E --> F[Status pills]
  B --> G[Date labels and ranges]
```
</details>

<sub>Reviews (8): Last reviewed commit: ["test(components): expect doubled dates i..."](https://github.com/opengovsg/isomer/commit/02730fe71070f5b8344f872f193d80d645682863) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59441575)</sub>

<!-- /greptile_comment -->