### PR TITLE
fix(studio): show thumbnails in collection link preview

### DIFF
--- a/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
@@ -43,14 +43,9 @@ export const EditCollectionLinkPreview = ({
     siteId,
   })
 
-  const [indexPage] = trpc.folder.getIndexpage.useSuspenseQuery({
-    resourceId: parent?.id ?? "",
-    siteId,
-  })
-
   const [{ content: collectionIndexContent }] =
     trpc.page.readPageAndBlob.useSuspenseQuery({
-      pageId: Number(indexPage.id),
+      pageId: Number(parent?.id ?? 0),
       siteId,
     })
 

--- a/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
@@ -1,3 +1,4 @@
+import type { CollectionPagePageProps } from "@opengovsg/isomer-components"
 import type { CollectionLinkProps } from "~/schemas/collection"
 import { useMemo } from "react"
 import { useSuspenseCollectionTags } from "~/features/editing-experience/hooks/useCollectionTags"
@@ -42,6 +43,20 @@ export const EditCollectionLinkPreview = ({
     siteId,
   })
 
+  const [indexPage] = trpc.folder.getIndexpage.useSuspenseQuery({
+    resourceId: parent.id,
+    siteId,
+  })
+
+  const [{ content: collectionIndexContent }] =
+    trpc.page.readPageAndBlob.useSuspenseQuery({
+      pageId: Number(indexPage.id),
+      siteId,
+    })
+
+  const { showThumbnail, showDate } =
+    collectionIndexContent.page as CollectionPagePageProps
+
   // Ends at the parent collection, so drop it — the collection node is built below.
   const [ancestry] = trpc.resource.getAncestryStack.useSuspenseQuery({
     resourceId: String(linkId),
@@ -80,7 +95,7 @@ export const EditCollectionLinkPreview = ({
     <ViewportContainer siteId={siteId}>
       <PreviewWithCustomSitemap
         content={[]}
-        page={{ title: parentTitle, tagCategories }}
+        page={{ title: parentTitle, tagCategories, showThumbnail, showDate }}
         layout={"collection"}
         siteId={siteId}
         siteMap={siteMap}

--- a/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
@@ -44,7 +44,7 @@ export const EditCollectionLinkPreview = ({
   })
 
   const [indexPage] = trpc.folder.getIndexpage.useSuspenseQuery({
-    resourceId: parent.id,
+    resourceId: parent?.id ?? "",
     siteId,
   })
 

--- a/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
@@ -43,9 +43,14 @@ export const EditCollectionLinkPreview = ({
     siteId,
   })
 
+  const [indexPage] = trpc.folder.getIndexpage.useSuspenseQuery({
+    resourceId: String(parent?.id ?? ""),
+    siteId,
+  })
+
   const [{ content: collectionIndexContent }] =
     trpc.page.readPageAndBlob.useSuspenseQuery({
-      pageId: Number(parent?.id ?? 0),
+      pageId: Number(indexPage.id),
       siteId,
     })
 

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
 import { userEvent, within } from "storybook/test"
 import { collectionHandlers } from "tests/msw/handlers/collection"
+import { folderHandlers } from "tests/msw/handlers/folder"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
@@ -26,10 +27,11 @@ const COMMON_HANDLERS = [
   resourceHandlers.getBatchAncestryWithSelf.default(),
   resourceHandlers.getChildrenOf.default(),
   resourceHandlers.getMetadataById.article(),
-  resourceHandlers.getParentOf.collection(),
+  resourceHandlers.getParentOf.collectionLink(),
   collectionHandlers.getMetadata.default(),
   collectionHandlers.readCollectionLink.default(),
-  pageHandlers.readPageAndBlob.article(),
+  folderHandlers.getIndexpage.default(),
+  pageHandlers.readPageAndBlob.collection(),
   pageHandlers.readPage.article(),
   pageHandlers.getFullPermalink.article(),
   pageHandlers.getCollectionTags.default(),

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -87,6 +87,22 @@ export const resourceHandlers = {
         }
       })
     },
+    collectionLink: () => {
+      return trpcMsw.resource.getParentOf.query(() => {
+        return {
+          type: "CollectionLink",
+          id: "1",
+          parentId: "1",
+          title: "yet another link",
+          parent: {
+            type: "Collection",
+            id: "1",
+            parentId: null,
+            title: "a collection",
+          },
+        }
+      })
+    },
   },
   getAncestryStack: {
     default: () => {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +16 | -1 |
| 🧪 Test | 2 | +20 | -2 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When editing a collection link in Studio, the right-hand preview did not show the link's thumbnail even when one was set and the parent collection had "Display thumbnail on all items" enabled. The main collection index page preview showed thumbnails correctly.

## Solution

The collection link preview renders the parent collection listing, but only passed `title` and `tagCategories` to the preview renderer. The collection layout requires `showThumbnail` (and `showDate`) on the `page` prop to render item images — the link's `image` was already on the synthetic sitemap node.

This fix loads the parent collection index page settings using existing endpoints (`folder.getIndexpage` + `page.readPageAndBlob`), matching how the collection index page editor already sources its preview state, and passes `showThumbnail` and `showDate` into the preview `page` prop.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Collection link editor preview now respects the parent collection index page's thumbnail and date display settings.

## Before & After Screenshots

**BEFORE**:

<!-- Thumbnail missing on collection link card in Studio preview despite being set on the link and enabled on the collection -->

**AFTER**:

<!-- Thumbnail visible on collection link card in Studio preview when collection display settings allow it -->

## Tests

**Manual Verification Steps**:

- [ ] Open a collection that has "Display thumbnail on all items" enabled on its index page settings.
- [ ] Open a collection link under that collection that has a thumbnail set.
- [ ] Confirm the link editor preview on the right shows the thumbnail on the collection card.
- [ ] Toggle thumbnail display off on the parent collection index page settings and confirm the link preview hides thumbnails accordingly.
- [ ] Confirm the live published collection index page still shows link thumbnails as before (no regression).

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cea1756b-470f-4c79-b941-f3405d4a0911?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cea1756b-470f-4c79-b941-f3405d4a0911&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the Studio collection-link editor preview respect the parent collection index page’s thumbnail and date display settings.
- Loads the parent collection’s index-page content through the existing page API.
- Passes `showThumbnail` and `showDate` to the synthetic collection preview page.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The collection parent resolves through the existing page API to its index-page content, and the newly forwarded display flags match the collection renderer’s page contract.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx | Correctly sources the parent collection’s display settings and forwards them to the collection preview renderer; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(studio): load collection index ..."](https://github.com/opengovsg/isomer/commit/34c377dcf255f943455113bd6b5aa5ad9057f5eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59450547)</sub>

<!-- /greptile_comment -->