### PR TITLE
fix(publisher): retry CloudFront origin-path update on ETag race

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -217,47 +217,51 @@ calculate_duration $start_time
 #
 # Two builds of the same site can run concurrently (see computeBuildChanges),
 # racing to write the same DistributionConfig; the second writer gets a 412
-# PreconditionFailed on a stale ETag. Retry with a fresh ETag rather than
-# failing the build. This keeps the pre-existing "last write wins" ordering
-# semantics (unchanged from before this fix) instead of trying to order by
-# CODEBUILD_BUILD_NUMBER: that's assigned at build start, not when a build
-# fetches its content, so a slower-starting build can still legitimately
-# fetch fresher content later - ordering by build number would wrongly and
-# permanently lock that fresher content out.
+# PreconditionFailed on a stale ETag. If we lose the race, only concede
+# silently when the live OriginPath proves a build >= ours already won -
+# that's the one state a normal race actually produces. Anything else
+# (an older build won, or the path is unrecognised - e.g. a manual or IaC
+# change) isn't explained by a normal race, so fail loudly instead of
+# guessing and silently overwriting.
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
 
-MAX_ATTEMPTS=5
-UPDATED=false
+aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
+ETag=$(jq -r '.ETag' distribution.json)
 
-for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
-  aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
-  ETag=$(jq -r '.ETag' distribution.json)
-  echo "Attempt $attempt/$MAX_ATTEMPTS: ETag=$ETag"
+jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
+jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
 
-  jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
-  jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
-
-  if aws cloudfront update-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" --distribution-config file://distribution-config.json --if-match "$ETag" 2>update-error.log; then
-    echo "Successfully updated CloudFront origin path to build $CODEBUILD_BUILD_NUMBER"
-    UPDATED=true
-    break
-  fi
-
+if aws cloudfront update-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" --distribution-config file://distribution-config.json --if-match "$ETag" 2>update-error.log; then
+  echo "Successfully updated CloudFront origin path to build $CODEBUILD_BUILD_NUMBER"
+else
   cat update-error.log
   if ! grep -q "PreconditionFailed" update-error.log; then
     echo "Error: CloudFront update-distribution failed for a reason other than an ETag conflict."
     exit 1
   fi
 
-  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-    sleep_time=$(((2 ** attempt) + (RANDOM % 3)))
-    echo "ETag conflict detected. Retrying in ${sleep_time}s..."
-    sleep "$sleep_time"
-  fi
-done
+  aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
+  CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
 
-if [ "$UPDATED" != true ]; then
-  echo "Error: exhausted $MAX_ATTEMPTS attempts due to repeated ETag conflicts."
-  exit 1
+  # SITE_NAME can contain digits (e.g. "mindef-sg101"), so strip the known
+  # prefix/suffix instead of grepping the whole path for digits. Fails
+  # closed to empty if the path isn't exactly /$SITE_NAME/<digits>/latest.
+  CURRENT_BUILD_NUMBER=""
+  EXPECTED_PREFIX="/$SITE_NAME/"
+  EXPECTED_SUFFIX="/latest"
+  if [[ "$CURRENT_ORIGIN_PATH" == "$EXPECTED_PREFIX"*"$EXPECTED_SUFFIX" ]]; then
+    MIDDLE="${CURRENT_ORIGIN_PATH#"$EXPECTED_PREFIX"}"
+    MIDDLE="${MIDDLE%"$EXPECTED_SUFFIX"}"
+    if [[ "$MIDDLE" =~ ^[0-9]+$ ]]; then
+      CURRENT_BUILD_NUMBER="$MIDDLE"
+    fi
+  fi
+
+  if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -ge "$CODEBUILD_BUILD_NUMBER" ]; then
+    echo "Warning: CloudFront already points to build $CURRENT_BUILD_NUMBER (>= ours: $CODEBUILD_BUILD_NUMBER). A concurrent build won the race, skipping our update."
+  else
+    echo "Error: PreconditionFailed but the live origin path ($CURRENT_ORIGIN_PATH) does not point to a build >= ours ($CODEBUILD_BUILD_NUMBER)."
+    exit 1
+  fi
 fi

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -214,13 +214,59 @@ echo "Uploading redirect files to S3..."
 calculate_duration $start_time
 
 # Update CloudFront origin path
+#
+# This can race with a concurrent build of the SAME site (Studio allows a second
+# build to start alongside a stale in-progress one - see computeBuildChanges).
+# Both builds read-modify-write the same DistributionConfig, so the second one to
+# write hits a 412 PreconditionFailed on a stale ETag. On conflict we re-fetch and
+# retry, but only if we are actually the more recent build: CODEBUILD_BUILD_NUMBER
+# is an AWS-assigned, per-project, monotonically increasing counter, so comparing
+# it against the build number already live tells us, independent of the ETag,
+# whether our content is newer. This guarantees the highest build number always
+# ends up live, regardless of which build's write happens to land last.
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
-aws cloudfront get-distribution --id $CLOUDFRONT_DISTRIBUTION_ID >distribution.json
 
-ETag=$(cat distribution.json | jq -r '.ETag')
-echo "ETag: $ETag"
+MAX_ATTEMPTS=5
+UPDATED=false
 
-jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
-jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
-aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
+
+  ETag=$(jq -r '.ETag' distribution.json)
+  CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
+  CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | grep -oE '[0-9]+' | head -n1)
+  echo "Attempt $attempt/$MAX_ATTEMPTS: ETag=$ETag, live build=$CURRENT_BUILD_NUMBER, this build=$CODEBUILD_BUILD_NUMBER"
+
+  if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -gt "$CODEBUILD_BUILD_NUMBER" ]; then
+    echo "Live origin path is already on a newer build ($CURRENT_BUILD_NUMBER > $CODEBUILD_BUILD_NUMBER). Skipping CloudFront update."
+    UPDATED=true
+    break
+  fi
+
+  jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
+  jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
+
+  if aws cloudfront update-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" --distribution-config file://distribution-config.json --if-match "$ETag" 2>update-error.log; then
+    echo "Successfully updated CloudFront origin path to build $CODEBUILD_BUILD_NUMBER"
+    UPDATED=true
+    break
+  fi
+
+  cat update-error.log
+  if ! grep -q "PreconditionFailed" update-error.log; then
+    echo "Error: CloudFront update-distribution failed for a reason other than an ETag conflict."
+    exit 1
+  fi
+
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    sleep_time=$(((2 ** attempt) + (RANDOM % 3)))
+    echo "ETag conflict detected. Retrying in ${sleep_time}s..."
+    sleep "$sleep_time"
+  fi
+done
+
+if [ "$UPDATED" != true ]; then
+  echo "Error: exhausted $MAX_ATTEMPTS attempts due to repeated ETag conflicts."
+  exit 1
+fi

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -217,28 +217,40 @@ calculate_duration $start_time
 #
 # Two builds of the same site can run concurrently (see computeBuildChanges),
 # racing to write the same DistributionConfig; the second writer gets a 412
-# PreconditionFailed on a stale ETag. If we lose the race, only concede
-# silently when the live OriginPath proves a build >= ours already won -
-# that's the one state a normal race actually produces. Anything else
-# (an older build won, or the path is unrecognised - e.g. a manual or IaC
-# change) isn't explained by a normal race, so fail loudly instead of
-# guessing and silently overwriting.
+# PreconditionFailed on a stale ETag. On a lost race, check who actually
+# should be live:
+#   - live build >= ours: a concurrent build legitimately won. Concede.
+#   - live build < ours: we're the newer build and only lost because the
+#     other write landed first. Retry with a fresh ETag - failing here
+#     would leave the site on older content and page on-call for a race
+#     that a retry resolves on its own.
+#   - anything else (path doesn't parse): not explained by a normal race
+#     (e.g. a manual or IaC change). Fail loudly rather than guess.
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
 
-aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
-ETag=$(jq -r '.ETag' distribution.json)
+MAX_ATTEMPTS=5
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
+  ETag=$(jq -r '.ETag' distribution.json)
 
-jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
-jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
+  jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
+  jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
 
-if aws cloudfront update-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" --distribution-config file://distribution-config.json --if-match "$ETag" 2>update-error.log; then
-  echo "Successfully updated CloudFront origin path to build $CODEBUILD_BUILD_NUMBER"
-else
+  set +e
+  aws cloudfront update-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" --distribution-config file://distribution-config.json --if-match "$ETag" 2>update-error.log
+  UPDATE_EXIT_CODE=$?
+  set -e
+
+  if [ "$UPDATE_EXIT_CODE" -eq 0 ]; then
+    echo "Successfully updated CloudFront origin path to build $CODEBUILD_BUILD_NUMBER"
+    exit 0
+  fi
+
   cat update-error.log
   if ! grep -q "PreconditionFailed" update-error.log; then
     echo "Error: CloudFront update-distribution failed for a reason other than an ETag conflict."
-    exit 1
+    exit "$UPDATE_EXIT_CODE"
   fi
 
   aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
@@ -258,10 +270,23 @@ else
     fi
   fi
 
-  if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -ge "$CODEBUILD_BUILD_NUMBER" ]; then
-    echo "Warning: CloudFront already points to build $CURRENT_BUILD_NUMBER (>= ours: $CODEBUILD_BUILD_NUMBER). A concurrent build won the race, skipping our update."
-  else
-    echo "Error: PreconditionFailed but the live origin path ($CURRENT_ORIGIN_PATH) does not point to a build >= ours ($CODEBUILD_BUILD_NUMBER)."
+  if [ -z "$CURRENT_BUILD_NUMBER" ]; then
+    echo "Error: PreconditionFailed but the live origin path ($CURRENT_ORIGIN_PATH) doesn't match /$SITE_NAME/<digits>/latest."
     exit 1
   fi
-fi
+
+  if [ "$CURRENT_BUILD_NUMBER" -ge "$CODEBUILD_BUILD_NUMBER" ]; then
+    echo "CloudFront already points to build $CURRENT_BUILD_NUMBER (>= ours: $CODEBUILD_BUILD_NUMBER). A concurrent build won the race fairly, skipping our update."
+    exit 0
+  fi
+
+  echo "Lost the write to an older build ($CURRENT_BUILD_NUMBER < ours: $CODEBUILD_BUILD_NUMBER)."
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    sleep_time=$(((2 ** attempt) + (RANDOM % 3)))
+    echo "Retrying with a fresh ETag in ${sleep_time}s..."
+    sleep "$sleep_time"
+  fi
+done
+
+echo "Error: exhausted $MAX_ATTEMPTS attempts trying to publish a build that should have won."
+exit 1

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -213,23 +213,20 @@ echo "Uploading redirect files to S3..."
 
 calculate_duration $start_time
 
-# Update CloudFront origin path
+# Update CloudFront origin path.
 #
-# This can race with a concurrent build of the SAME site (Studio allows a second
-# build to start alongside a stale in-progress one - see computeBuildChanges).
-# Both builds read-modify-write the same DistributionConfig, so the second one to
-# write hits a 412 PreconditionFailed on a stale ETag.
+# Two builds of the same site can run concurrently (see computeBuildChanges),
+# racing to write the same DistributionConfig; the second writer gets a 412
+# PreconditionFailed on a stale ETag. Retry with a fresh ETag, and on every
+# attempt skip the write if the live OriginPath already has a higher
+# CODEBUILD_BUILD_NUMBER than ours, so the highest build number always wins
+# regardless of write order - not just on collision, since two builds can
+# also finish minutes apart with no literal overlap.
 #
-# We only compare build numbers to decide whether to concede AFTER a real
-# collision, never on the first attempt. A live collision means another build
-# is racing us right now, which is only possible if it belongs to the same
-# CodeBuild project instance we do - so its build number is guaranteed to be on
-# the same counter scale as ours. Comparing unconditionally (even with no
-# collision) would also match against whatever number happens to be sitting in
-# the live OriginPath, which could be a stale leftover from a previous,
-# unrelated CodeBuild project instance (e.g. if the project was ever destroyed
-# and recreated, resetting CODEBUILD_BUILD_NUMBER back to 1) - wrongly and
-# silently suppressing every future build forever.
+# Known limitation: build numbers reset if a site's CodeBuild project is ever
+# destroyed and recreated, which would wrongly suppress new builds until the
+# new counter catches up. Not currently possible for a live site, so accepted
+# as a rare edge case rather than fixed here.
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
 
@@ -239,32 +236,27 @@ UPDATED=false
 for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
   ETag=$(jq -r '.ETag' distribution.json)
+  CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
 
-  if [ "$attempt" -gt 1 ]; then
-    CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
-
-    # Extract the build-number segment precisely (SITE_NAME can itself contain
-    # digits, e.g. "mindef-sg101", so a bare digit grep over the whole path
-    # would pick up digits from the site name instead of the build number).
-    # Fail closed to an empty value if the path doesn't exactly match
-    # /$SITE_NAME/<digits>/latest.
-    CURRENT_BUILD_NUMBER=""
-    EXPECTED_PREFIX="/$SITE_NAME/"
-    EXPECTED_SUFFIX="/latest"
-    if [[ "$CURRENT_ORIGIN_PATH" == "$EXPECTED_PREFIX"*"$EXPECTED_SUFFIX" ]]; then
-      MIDDLE="${CURRENT_ORIGIN_PATH#"$EXPECTED_PREFIX"}"
-      MIDDLE="${MIDDLE%"$EXPECTED_SUFFIX"}"
-      if [[ "$MIDDLE" =~ ^[0-9]+$ ]]; then
-        CURRENT_BUILD_NUMBER="$MIDDLE"
-      fi
+  # SITE_NAME can contain digits (e.g. "mindef-sg101"), so strip the known
+  # prefix/suffix instead of grepping the whole path for digits. Fails
+  # closed to empty if the path isn't exactly /$SITE_NAME/<digits>/latest.
+  CURRENT_BUILD_NUMBER=""
+  EXPECTED_PREFIX="/$SITE_NAME/"
+  EXPECTED_SUFFIX="/latest"
+  if [[ "$CURRENT_ORIGIN_PATH" == "$EXPECTED_PREFIX"*"$EXPECTED_SUFFIX" ]]; then
+    MIDDLE="${CURRENT_ORIGIN_PATH#"$EXPECTED_PREFIX"}"
+    MIDDLE="${MIDDLE%"$EXPECTED_SUFFIX"}"
+    if [[ "$MIDDLE" =~ ^[0-9]+$ ]]; then
+      CURRENT_BUILD_NUMBER="$MIDDLE"
     fi
-    echo "Retry $attempt/$MAX_ATTEMPTS after ETag conflict: live build=$CURRENT_BUILD_NUMBER, this build=$CODEBUILD_BUILD_NUMBER"
+  fi
+  echo "Attempt $attempt/$MAX_ATTEMPTS: live build=$CURRENT_BUILD_NUMBER, this build=$CODEBUILD_BUILD_NUMBER"
 
-    if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -gt "$CODEBUILD_BUILD_NUMBER" ]; then
-      echo "Live origin path is already on a newer build ($CURRENT_BUILD_NUMBER > $CODEBUILD_BUILD_NUMBER). Conceding - skipping CloudFront update."
-      UPDATED=true
-      break
-    fi
+  if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -gt "$CODEBUILD_BUILD_NUMBER" ]; then
+    echo "Live origin path is already on a newer build ($CURRENT_BUILD_NUMBER > $CODEBUILD_BUILD_NUMBER). Skipping CloudFront update."
+    UPDATED=true
+    break
   fi
 
   jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -218,12 +218,18 @@ calculate_duration $start_time
 # This can race with a concurrent build of the SAME site (Studio allows a second
 # build to start alongside a stale in-progress one - see computeBuildChanges).
 # Both builds read-modify-write the same DistributionConfig, so the second one to
-# write hits a 412 PreconditionFailed on a stale ETag. On conflict we re-fetch and
-# retry, but only if we are actually the more recent build: CODEBUILD_BUILD_NUMBER
-# is an AWS-assigned, per-project, monotonically increasing counter, so comparing
-# it against the build number already live tells us, independent of the ETag,
-# whether our content is newer. This guarantees the highest build number always
-# ends up live, regardless of which build's write happens to land last.
+# write hits a 412 PreconditionFailed on a stale ETag.
+#
+# We only compare build numbers to decide whether to concede AFTER a real
+# collision, never on the first attempt. A live collision means another build
+# is racing us right now, which is only possible if it belongs to the same
+# CodeBuild project instance we do - so its build number is guaranteed to be on
+# the same counter scale as ours. Comparing unconditionally (even with no
+# collision) would also match against whatever number happens to be sitting in
+# the live OriginPath, which could be a stale leftover from a previous,
+# unrelated CodeBuild project instance (e.g. if the project was ever destroyed
+# and recreated, resetting CODEBUILD_BUILD_NUMBER back to 1) - wrongly and
+# silently suppressing every future build forever.
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
 
@@ -232,31 +238,33 @@ UPDATED=false
 
 for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
-
   ETag=$(jq -r '.ETag' distribution.json)
-  CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
 
-  # Extract the build-number segment precisely (SITE_NAME can itself contain
-  # digits, e.g. "mindef-sg101", so a bare digit grep over the whole path
-  # would pick up digits from the site name instead of the build number).
-  # Fail closed to an empty value if the path doesn't exactly match
-  # /$SITE_NAME/<digits>/latest.
-  CURRENT_BUILD_NUMBER=""
-  EXPECTED_PREFIX="/$SITE_NAME/"
-  EXPECTED_SUFFIX="/latest"
-  if [[ "$CURRENT_ORIGIN_PATH" == "$EXPECTED_PREFIX"*"$EXPECTED_SUFFIX" ]]; then
-    MIDDLE="${CURRENT_ORIGIN_PATH#"$EXPECTED_PREFIX"}"
-    MIDDLE="${MIDDLE%"$EXPECTED_SUFFIX"}"
-    if [[ "$MIDDLE" =~ ^[0-9]+$ ]]; then
-      CURRENT_BUILD_NUMBER="$MIDDLE"
+  if [ "$attempt" -gt 1 ]; then
+    CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
+
+    # Extract the build-number segment precisely (SITE_NAME can itself contain
+    # digits, e.g. "mindef-sg101", so a bare digit grep over the whole path
+    # would pick up digits from the site name instead of the build number).
+    # Fail closed to an empty value if the path doesn't exactly match
+    # /$SITE_NAME/<digits>/latest.
+    CURRENT_BUILD_NUMBER=""
+    EXPECTED_PREFIX="/$SITE_NAME/"
+    EXPECTED_SUFFIX="/latest"
+    if [[ "$CURRENT_ORIGIN_PATH" == "$EXPECTED_PREFIX"*"$EXPECTED_SUFFIX" ]]; then
+      MIDDLE="${CURRENT_ORIGIN_PATH#"$EXPECTED_PREFIX"}"
+      MIDDLE="${MIDDLE%"$EXPECTED_SUFFIX"}"
+      if [[ "$MIDDLE" =~ ^[0-9]+$ ]]; then
+        CURRENT_BUILD_NUMBER="$MIDDLE"
+      fi
     fi
-  fi
-  echo "Attempt $attempt/$MAX_ATTEMPTS: ETag=$ETag, live build=$CURRENT_BUILD_NUMBER, this build=$CODEBUILD_BUILD_NUMBER"
+    echo "Retry $attempt/$MAX_ATTEMPTS after ETag conflict: live build=$CURRENT_BUILD_NUMBER, this build=$CODEBUILD_BUILD_NUMBER"
 
-  if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -gt "$CODEBUILD_BUILD_NUMBER" ]; then
-    echo "Live origin path is already on a newer build ($CURRENT_BUILD_NUMBER > $CODEBUILD_BUILD_NUMBER). Skipping CloudFront update."
-    UPDATED=true
-    break
+    if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -gt "$CODEBUILD_BUILD_NUMBER" ]; then
+      echo "Live origin path is already on a newer build ($CURRENT_BUILD_NUMBER > $CODEBUILD_BUILD_NUMBER). Conceding - skipping CloudFront update."
+      UPDATED=true
+      break
+    fi
   fi
 
   jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -235,7 +235,22 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
 
   ETag=$(jq -r '.ETag' distribution.json)
   CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
-  CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | grep -oE '[0-9]+' | head -n1)
+
+  # Extract the build-number segment precisely (SITE_NAME can itself contain
+  # digits, e.g. "mindef-sg101", so a bare digit grep over the whole path
+  # would pick up digits from the site name instead of the build number).
+  # Fail closed to an empty value if the path doesn't exactly match
+  # /$SITE_NAME/<digits>/latest.
+  CURRENT_BUILD_NUMBER=""
+  EXPECTED_PREFIX="/$SITE_NAME/"
+  EXPECTED_SUFFIX="/latest"
+  if [[ "$CURRENT_ORIGIN_PATH" == "$EXPECTED_PREFIX"*"$EXPECTED_SUFFIX" ]]; then
+    MIDDLE="${CURRENT_ORIGIN_PATH#"$EXPECTED_PREFIX"}"
+    MIDDLE="${MIDDLE%"$EXPECTED_SUFFIX"}"
+    if [[ "$MIDDLE" =~ ^[0-9]+$ ]]; then
+      CURRENT_BUILD_NUMBER="$MIDDLE"
+    fi
+  fi
   echo "Attempt $attempt/$MAX_ATTEMPTS: ETag=$ETag, live build=$CURRENT_BUILD_NUMBER, this build=$CODEBUILD_BUILD_NUMBER"
 
   if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -gt "$CODEBUILD_BUILD_NUMBER" ]; then

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -217,16 +217,13 @@ calculate_duration $start_time
 #
 # Two builds of the same site can run concurrently (see computeBuildChanges),
 # racing to write the same DistributionConfig; the second writer gets a 412
-# PreconditionFailed on a stale ETag. Retry with a fresh ETag, and on every
-# attempt skip the write if the live OriginPath already has a higher
-# CODEBUILD_BUILD_NUMBER than ours, so the highest build number always wins
-# regardless of write order - not just on collision, since two builds can
-# also finish minutes apart with no literal overlap.
-#
-# Known limitation: build numbers reset if a site's CodeBuild project is ever
-# destroyed and recreated, which would wrongly suppress new builds until the
-# new counter catches up. Not currently possible for a live site, so accepted
-# as a rare edge case rather than fixed here.
+# PreconditionFailed on a stale ETag. Retry with a fresh ETag rather than
+# failing the build. This keeps the pre-existing "last write wins" ordering
+# semantics (unchanged from before this fix) instead of trying to order by
+# CODEBUILD_BUILD_NUMBER: that's assigned at build start, not when a build
+# fetches its content, so a slower-starting build can still legitimately
+# fetch fresher content later - ordering by build number would wrongly and
+# permanently lock that fresher content out.
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
 
@@ -236,28 +233,7 @@ UPDATED=false
 for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
   ETag=$(jq -r '.ETag' distribution.json)
-  CURRENT_ORIGIN_PATH=$(jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath' distribution.json)
-
-  # SITE_NAME can contain digits (e.g. "mindef-sg101"), so strip the known
-  # prefix/suffix instead of grepping the whole path for digits. Fails
-  # closed to empty if the path isn't exactly /$SITE_NAME/<digits>/latest.
-  CURRENT_BUILD_NUMBER=""
-  EXPECTED_PREFIX="/$SITE_NAME/"
-  EXPECTED_SUFFIX="/latest"
-  if [[ "$CURRENT_ORIGIN_PATH" == "$EXPECTED_PREFIX"*"$EXPECTED_SUFFIX" ]]; then
-    MIDDLE="${CURRENT_ORIGIN_PATH#"$EXPECTED_PREFIX"}"
-    MIDDLE="${MIDDLE%"$EXPECTED_SUFFIX"}"
-    if [[ "$MIDDLE" =~ ^[0-9]+$ ]]; then
-      CURRENT_BUILD_NUMBER="$MIDDLE"
-    fi
-  fi
-  echo "Attempt $attempt/$MAX_ATTEMPTS: live build=$CURRENT_BUILD_NUMBER, this build=$CODEBUILD_BUILD_NUMBER"
-
-  if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -gt "$CODEBUILD_BUILD_NUMBER" ]; then
-    echo "Live origin path is already on a newer build ($CURRENT_BUILD_NUMBER > $CODEBUILD_BUILD_NUMBER). Skipping CloudFront update."
-    UPDATED=true
-    break
-  fi
+  echo "Attempt $attempt/$MAX_ATTEMPTS: ETag=$ETag"
 
   jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
   jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +74 | -8 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

📄 [Read the full explainer](https://app.notion.com/p/3d077dbba78881588b70f4c14047d4ce) (background, intuition, code walkthrough, quiz)

## Summary
- CodeBuild's `computeBuildChanges` deliberately allows a second build of the same site to start alongside a stale in-progress one, so two builds can concurrently read-modify-write the same CloudFront `DistributionConfig`. Whichever writes second hits a `412 PreconditionFailed` on a stale ETag and the whole build fails, even though the publish content itself built and uploaded fine — a false-positive failure that pages on-call for nothing.
- Fix: on `PreconditionFailed`, re-fetch the distribution and compare the live build number to our own:
  - **Live build >= ours** → a concurrent build legitimately won. Concede, exit 0.
  - **Live build < ours** → we're the one that should be live, just lost the write race. Retry with a fresh ETag (bounded to 5 attempts, exponential backoff + jitter).
  - **Path doesn't parse** (`/$SITE_NAME/<digits>/latest`) → not explained by a normal race (e.g. a manual/IaC change). Fail loudly.
- Credit: the core idea of comparing the live build number to decide whether to concede comes from [PR #2256](https://github.com/opengovsg/isomer/pull/2256), an independent, already-approved fix for the same bug. This PR borrows that comparison and adds retrying specifically when we're the build that should legitimately win — failing there instead would reintroduce the same on-call-paging problem this fix exists to remove.

## Known limitation (not fixed by this PR)
Ordering by `CODEBUILD_BUILD_NUMBER` is not a true content-freshness guarantee: the number is assigned when a build *starts*, not when it fetches its content from the database, so a slower-starting build can legitimately end up with fresher content than a faster one with a higher number. A fully correct fix would need an authoritative content-revision signal threaded from the DB fetch through to the CloudFront promotion step — a structural change spanning `tooling/build/scripts/publishing` and the promotion step, out of scope here. Recommend a follow-up ticket if stronger freshness guarantees are needed. (Both PR #2256 and this PR share this limitation.)

## Test plan
- [ ] `bash -n tooling/build/scripts/publisher.sh` (syntax-checked locally, passes)
- [ ] Trigger two overlapping publishes for the same staging site and confirm the collision is retried (not a hard failure) and the newer build's content ends up live
- [ ] Confirm a genuine (non-ETag) `update-distribution` failure still fails the build immediately with the original AWS exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The change handles a CloudFront ETag conflict by re-fetching the live distribution and inspecting its origin path rather than immediately failing. It now:
- Parses the build number only from the exact `/$SITE_NAME/<digits>/latest` format, including site names containing digits.
- Skips the update when the live origin points to an equal or higher-numbered build.
- Fails closed for older or unrecognized live origin paths and fails fast for non-ETag errors.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both previously reported origin-path handling failures are resolved and no blocking failure remains within this follow-up review’s scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publisher.sh | Adds fail-closed handling for CloudFront ETag conflicts and correctly addresses the two previously reported origin-path parsing and validation defects. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Build as Publisher build
  participant CF as CloudFront
  Build->>CF: Get distribution config and ETag
  Build->>CF: Update origin path with ETag
  alt Update succeeds
    CF-->>Build: Success
  else PreconditionFailed
    CF-->>Build: 412 ETag conflict
    Build->>CF: Re-fetch live distribution
    CF-->>Build: Current origin path
    alt "Exact path and live build >= current build"
      Build->>Build: Concede update
    else Older or unrecognized path
      Build->>Build: Exit with failure
    end
  else Other update error
    CF-->>Build: Error
    Build->>Build: Exit immediately
  end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(publisher): re-add build-number chec..."](https://github.com/opengovsg/isomer/commit/d3695b425274f87b60a523554c3a2e72ce7cd795) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59860174)</sub>

**Context used:**

- Knowledge Base — [Site lifecycle tooling](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/site-lifecycle-tooling.md)

<!-- /greptile_comment -->
