### PR TITLE
docs(conventions): add tv/twMerge style-combining rule for packages/components

### DIFF
--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -43,6 +43,10 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 
 ## Catalog
 
+### Components
+
+- [Combine component styles with tv or twMerge in packages/components](conventions/components-tv-twmerge-combine-styles.md) — best practice: use tv/twMerge for variant/merge logic; plain className when there is no variance
+
 ### React
 
 - [Prefer a new component over overloading props](conventions/react-new-component-over-prop-overload.md) — smell: flag soup / single-caller props bending one component into two jobs

--- a/.claude/skills/isomer-conventions/conventions/components-tv-twmerge-combine-styles.md
+++ b/.claude/skills/isomer-conventions/conventions/components-tv-twmerge-combine-styles.md
@@ -12,13 +12,16 @@ variants or with a `className` prop — use `tv` (from `~/lib/tv`) or `twMerge`
 no variance to model and no classes to merge, a plain `className` string is
 fine.
 
+A single boolean variant is a normal `tv` use case. Prefer `tv` over inline
+ternaries whenever variant logic appears in `className`.
+
 ## Why
 
 Inline ternaries and template literals in `className` are hard to scan, easy to
 get wrong when adding a third state, and bypass the repo's Tailwind merge
 config. `tv` and `twMerge` keep variant logic in one place and resolve class
-conflicts predictably. Overusing them for static or single-class cases adds
-noise without benefit.
+conflicts predictably. Overusing them for fully static classes adds noise without
+benefit.
 
 ## Bad
 
@@ -33,13 +36,13 @@ noise without benefit.
   className={`absolute left-0 h-full w-full rounded ${isContainNeeded ? "object-contain" : "object-cover"}`}
 />
 
-// tv with a single variant and no real branching — smell: ceremony without payoff
+// Redundant true/false pair — smell: one branch is just the default, declare it in base
 const imageStyles = tv({
   base: "absolute left-0 h-full w-full rounded",
   variants: {
     contain: {
       true: "object-contain",
-      false: "object-cover",
+      false: "object-cover", // default belongs in base, not a false branch
     },
   },
 })
@@ -50,7 +53,19 @@ Real examples: `packages/components/src/templates/next/components/complex/Video/
 ## Good
 
 ```tsx
-// tv when modelling real variants
+// tv with one boolean variant — fine; put the default in base, override in variants
+const imageStyles = tv({
+  base: "absolute left-0 h-full w-full rounded object-cover",
+  variants: {
+    contain: {
+      true: "object-contain",
+    },
+  },
+})
+
+<img className={imageStyles({ contain: isContainNeeded })} />
+
+// tv with multiple variant axes
 const tableCellStyles = tv({
   base: "max-w-40 break-words border border-base-divider-medium px-4 py-3 align-top",
   variants: {
@@ -82,8 +97,7 @@ Real examples: `packages/components/src/templates/next/components/native/Table/T
 ## How to detect
 
 In `packages/components`, grep for `className=\{.*\?` or `className=\{\`` with
-embedded `${... ? ... : ...}`. When you see variant logic, check whether `tv` or
-`twMerge` is the better fit. When you see `tv({` with only one boolean variant
-and no extension/reuse, ask whether a plain ternary-free `tv` call or static
-classes would be simpler — but still prefer `tv` over inline JSX conditionals
-when there are two or more variant axes.
+embedded `${... ? ... : ...}` — replace with `tv` or `twMerge`. When reviewing
+`tv({`, check that defaults live in `base` (or `defaultVariants`) rather than
+as a redundant `false` branch. Reserve plain `className` strings for fully static
+markup with nothing to merge.

--- a/.claude/skills/isomer-conventions/conventions/components-tv-twmerge-combine-styles.md
+++ b/.claude/skills/isomer-conventions/conventions/components-tv-twmerge-combine-styles.md
@@ -1,0 +1,89 @@
+---
+title: Combine component styles with tv or twMerge in packages/components
+category: Components
+type: best-practice
+---
+
+## Pattern
+
+In `packages/components`, when combining Tailwind classes — especially across
+variants or with a `className` prop — use `tv` (from `~/lib/tv`) or `twMerge`
+(from `~/lib/twMerge`) instead of inline conditional class strings. When there is
+no variance to model and no classes to merge, a plain `className` string is
+fine.
+
+## Why
+
+Inline ternaries and template literals in `className` are hard to scan, easy to
+get wrong when adding a third state, and bypass the repo's Tailwind merge
+config. `tv` and `twMerge` keep variant logic in one place and resolve class
+conflicts predictably. Overusing them for static or single-class cases adds
+noise without benefit.
+
+## Bad
+
+```tsx
+// Inline conditional — smell: variant logic buried in JSX
+<div
+  className={isPortrait ? "mx-auto w-full max-w-[20.3125rem]" : "w-full"}
+/>
+
+// Template-literal ternary — smell: same problem, harder to merge with className
+<img
+  className={`absolute left-0 h-full w-full rounded ${isContainNeeded ? "object-contain" : "object-cover"}`}
+/>
+
+// tv with a single variant and no real branching — smell: ceremony without payoff
+const imageStyles = tv({
+  base: "absolute left-0 h-full w-full rounded",
+  variants: {
+    contain: {
+      true: "object-contain",
+      false: "object-cover",
+    },
+  },
+})
+```
+
+Real examples: `packages/components/src/templates/next/components/complex/Video/Video.tsx:106`, `packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx:45`.
+
+## Good
+
+```tsx
+// tv when modelling real variants
+const tableCellStyles = tv({
+  base: "max-w-40 break-words border border-base-divider-medium px-4 py-3 align-top",
+  variants: {
+    isHeader: {
+      true: "bg-base-canvas-backdrop [&_p]:prose-label-md-medium",
+      false: "bg-base-canvas-alt [&_p]:prose-body-sm",
+    },
+  },
+})
+
+<td className={tableCellStyles({ isHeader: cell.type === "header" })} />
+
+// twMerge when merging a fixed base with an optional className prop
+<div className={twMerge("flex flex-wrap items-center gap-2", className)} />
+
+// Plain string when there is no variance and nothing to merge
+<nav className="flex flex-col gap-3 rounded-lg bg-base-canvas-alt p-6" />
+```
+
+Real examples: `packages/components/src/templates/next/components/native/Table/Table.tsx:22-29`, `packages/components/src/templates/next/components/internal/Tags/PlaintextTags.tsx:16`.
+
+## Not required
+
+- A single static `className` with no conditionals and no `className` prop to
+  merge.
+- A one-off class with no variant logic — don't reach for `tv` just to wrap one
+  string.
+
+## How to detect
+
+In `packages/components`, grep for `className=\{.*\?` or `className=\{\`` with
+embedded `${... ? ... : ...}`. When you see variant logic, check whether `tv` or
+`twMerge` is the better fit. When you see `tv({` with only one boolean variant
+and no extension/reuse, ask whether a plain ternary-free `tv` call or static
+classes would be simpler — but still prefer `tv` over inline JSX conditionals
+when there are two or more variant axes.


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 0 | +0 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 2 | +107 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The isomer-conventions catalog had no guidance on how `packages/components` should combine Tailwind classes when variants or `className` merging are involved.

## Solution

Added a new convention entry documenting that `packages/components` should use `tv` or `twMerge` for variant/merge logic instead of inline conditional class strings, with examples of code smells (inline ternaries, redundant `true`/`false` variant pairs) and when plain `className` strings are fine.

Clarified that single-variant `tv` is normal and preferred over inline ternaries; the smell is redundant `false` branches when the default belongs in `base`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- New convention: `components-tv-twmerge-combine-styles.md`
- Catalog entry under a new **Components** section in `isomer-conventions/SKILL.md`

## Tests

Documentation-only change; no runtime code affected.

**Manual Verification Steps**:

- [x] Convention entry follows the existing TEMPLATE format
- [x] Catalog in SKILL.md links to the new entry
- [x] Single-variant `tv` guidance is unambiguous
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-274d8a09-63b4-41ee-b82d-890fa4599cfb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-274d8a09-63b4-41ee-b82d-890fa4599cfb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds repository guidance for combining Tailwind styles in `packages/components`.
- Introduces a convention favoring `tv` for variant logic and `twMerge` when merging classes.
- Documents acceptable static `className` usage and discourages redundant boolean variant branches.
- Adds the convention to the Components section of the conventions catalog.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only pull request appears safe to merge.

The new catalog entry and styling convention introduce no runtime behavior, and the documented imports and cited patterns are consistent with the component package’s styling utilities.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .claude/skills/isomer-conventions/SKILL.md | Adds a valid catalog entry for the new component styling convention; no actionable issue identified. |
| .claude/skills/isomer-conventions/conventions/components-tv-twmerge-combine-styles.md | Documents `tv` and `twMerge` usage with consistent examples and detection guidance; no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(conventions): clarify single-varian..."](https://github.com/opengovsg/isomer/commit/462ca7b44f9749852e70f036beebbb445489ef3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59868091)</sub>

<!-- /greptile_comment -->