### PR TITLE
feat: enable local publishing to the template dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ packages/db/prisma/generated/
 
 # Generated Tailwind CSS for the editor preview iframe (built by `build:preview-tw`)
 apps/studio/public/assets/css/preview-tw.css
+
+# JSON generated when publishing from the local Studio to the local template
+tooling/template/.local-publish*/

--- a/apps/studio/src/server/modules/aws/codebuild.service.ts
+++ b/apps/studio/src/server/modules/aws/codebuild.service.ts
@@ -1,4 +1,7 @@
 import { pick } from "lodash-es"
+import { spawn } from "node:child_process"
+import { copyFile, mkdtemp, rename, rm } from "node:fs/promises"
+import path from "node:path"
 import { env } from "~/env.mjs"
 
 import type { Logger } from "@isomer/logging"
@@ -19,10 +22,70 @@ interface PublishSiteArgs {
   }
 }
 
+const REPO_ROOT = path.resolve(process.cwd(), "../..")
+const PUBLISHING_DIR = path.join(REPO_ROOT, "tooling/build/scripts/publishing")
+const LOCAL_PUBLISH_DIR = path.join(
+  REPO_ROOT,
+  "tooling/template/.local-publish",
+)
+let localPublishQueue = Promise.resolve()
+
+const publishLocalSite = async (logger: Logger<string>, siteId: number) => {
+  const outputDir = await mkdtemp(`${LOCAL_PUBLISH_DIR}-`)
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn("pnpm", ["start"], {
+        cwd: PUBLISHING_DIR,
+        env: {
+          // oxlint-disable-next-line node/no-process-env
+          ...process.env,
+          SITE_ID: String(siteId),
+          OUTPUT_DIR: outputDir,
+        },
+        stdio: "inherit",
+      })
+
+      child.once("error", reject)
+      child.once("exit", (code) => {
+        if (code === 0) resolve()
+        else reject(new Error(`Local publisher exited with code ${code}`))
+      })
+    })
+
+    await copyFile(
+      path.join(outputDir, "schema/_index.json"),
+      path.join(outputDir, "schema/not-found.json"),
+    )
+    await rm(LOCAL_PUBLISH_DIR, { recursive: true, force: true })
+    await rename(outputDir, LOCAL_PUBLISH_DIR)
+    logger.info(
+      { siteId },
+      "Published site to the local template at http://localhost:3001",
+    )
+  } catch (error) {
+    await rm(outputDir, { recursive: true, force: true })
+    throw error
+  }
+}
+
 export const publishSite = async (
   logger: Logger<string>,
   { siteId, codebuildJob }: PublishSiteArgs,
 ) => {
+  if (env.NEXT_PUBLIC_APP_ENV === "development") {
+    // Publishing can be called from inside a transaction. Defer the export until
+    // that transaction has committed so the exporter sees the just-published data.
+    setTimeout(() => {
+      localPublishQueue = localPublishQueue
+        .then(() => publishLocalSite(logger, siteId))
+        .catch((error) =>
+          logger.error({ error, siteId }, "Local publish failed"),
+        )
+    })
+    return
+  }
+
   if (env.NEXT_PUBLIC_APP_ENV === "preview") {
     logger.info({ siteId }, "Preview env: skipping CodeBuild publish")
     return

--- a/apps/studio/src/server/modules/aws/codebuild.service.ts
+++ b/apps/studio/src/server/modules/aws/codebuild.service.ts
@@ -1,5 +1,6 @@
 import { pick } from "lodash-es"
 import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
 import { copyFile, mkdtemp, rename, rm } from "node:fs/promises"
 import path from "node:path"
 import { env } from "~/env.mjs"
@@ -28,6 +29,7 @@ const LOCAL_PUBLISH_DIR = path.join(
   REPO_ROOT,
   "tooling/template/.local-publish",
 )
+const LOCAL_PUBLISH_BACKUP_DIR = `${LOCAL_PUBLISH_DIR}-backup`
 let localPublishQueue = Promise.resolve()
 
 const publishLocalSite = async (logger: Logger<string>, siteId: number) => {
@@ -57,8 +59,20 @@ const publishLocalSite = async (logger: Logger<string>, siteId: number) => {
       path.join(outputDir, "schema/_index.json"),
       path.join(outputDir, "schema/not-found.json"),
     )
-    await rm(LOCAL_PUBLISH_DIR, { recursive: true, force: true })
-    await rename(outputDir, LOCAL_PUBLISH_DIR)
+    await rm(LOCAL_PUBLISH_BACKUP_DIR, { recursive: true, force: true })
+    const hadPreviousPublish = existsSync(LOCAL_PUBLISH_DIR)
+    if (hadPreviousPublish) {
+      await rename(LOCAL_PUBLISH_DIR, LOCAL_PUBLISH_BACKUP_DIR)
+    }
+    try {
+      await rename(outputDir, LOCAL_PUBLISH_DIR)
+    } catch (error) {
+      if (hadPreviousPublish) {
+        await rename(LOCAL_PUBLISH_BACKUP_DIR, LOCAL_PUBLISH_DIR)
+      }
+      throw error
+    }
+    await rm(LOCAL_PUBLISH_BACKUP_DIR, { recursive: true, force: true })
     logger.info(
       { siteId },
       "Published site to the local template at http://localhost:3001",
@@ -74,15 +88,9 @@ export const publishSite = async (
   { siteId, codebuildJob }: PublishSiteArgs,
 ) => {
   if (env.NEXT_PUBLIC_APP_ENV === "development") {
-    // Publishing can be called from inside a transaction. Defer the export until
-    // that transaction has committed so the exporter sees the just-published data.
-    setTimeout(() => {
-      localPublishQueue = localPublishQueue
-        .then(() => publishLocalSite(logger, siteId))
-        .catch((error) =>
-          logger.error({ error, siteId }, "Local publish failed"),
-        )
-    })
+    localPublishQueue = localPublishQueue
+      .then(() => publishLocalSite(logger, siteId))
+      .catch((error) => logger.error({ error, siteId }, "Local publish failed"))
     return
   }
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -795,7 +795,7 @@ export const pageRouter = router({
               }),
           )
 
-        return db.transaction().execute(async (tx) => {
+        const updatedResource = await db.transaction().execute(async (tx) => {
           const fullPage = await getFullPageById(tx, {
             resourceId: pageId,
             siteId,
@@ -892,21 +892,7 @@ export const pageRouter = router({
               })
             }
 
-            // We do an implicit publish so that we can make the changes to the
-            // page settings immediately visible on the end site. A page that
-            // has never been published has no live presence, so skip the site
-            // rebuild and Publish audit entry for it.
-            if (updatedResource.publishedVersionId !== null) {
-              await publishResource(ctx.user.id, updatedResource, ctx.logger)
-            }
-
-            return pick(updatedResource, [
-              "id",
-              "type",
-              "title",
-              "permalink",
-              "draftBlobId",
-            ])
+            return updatedResource
           } catch (err) {
             if (err instanceof TRPCError) {
               throw err
@@ -919,6 +905,22 @@ export const pageRouter = router({
             })
           }
         })
+
+        // We do an implicit publish so that we can make the changes to the
+        // page settings immediately visible on the end site. A page that
+        // has never been published has no live presence, so skip the site
+        // rebuild and Publish audit entry for it.
+        if (updatedResource.publishedVersionId !== null) {
+          await publishResource(ctx.user.id, updatedResource, ctx.logger)
+        }
+
+        return pick(updatedResource, [
+          "id",
+          "type",
+          "title",
+          "permalink",
+          "draftBlobId",
+        ])
       },
     ),
   getFullPermalink: protectedProcedure

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1403,7 +1403,7 @@ export const publishResource = async (
         }),
     )
 
-  return db.transaction().execute(async (tx) => {
+  await db.transaction().execute(async (tx) => {
     await logPublishEvent(tx, {
       siteId: resource.siteId,
       by: byUser,
@@ -1411,9 +1411,9 @@ export const publishResource = async (
       eventType: AuditLogEvent.Publish,
       metadata: resource,
     })
-
-    await publishSite(logger, { siteId: resource.siteId })
   })
+
+  await publishSite(logger, { siteId: resource.siteId })
 }
 
 export const publishSiteConfig = async (
@@ -1436,7 +1436,7 @@ export const publishSiteConfig = async (
         }),
     )
 
-  return db.transaction().execute(async (tx) => {
+  await db.transaction().execute(async (tx) => {
     await logPublishEvent(tx, {
       siteId: site.id,
       by: byUser,
@@ -1444,9 +1444,9 @@ export const publishSiteConfig = async (
       eventType: AuditLogEvent.Publish,
       metadata: { site, ...rest },
     })
-
-    await publishSite(logger, { siteId: site.id })
   })
+
+  await publishSite(logger, { siteId: site.id })
 }
 
 export const getBatchAncestryWithSelfQuery = async ({

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -204,7 +204,7 @@ export const siteRouter = router({
         .executeTakeFirstOrThrow()
       const normalizedData = normalizeAskgovConfig(data)
 
-      return await db.transaction().execute(async (tx) => {
+      const result = await db.transaction().execute(async (tx) => {
         const site = await tx
           .selectFrom("Site")
           .where("id", "=", siteId)
@@ -246,10 +246,11 @@ export const siteRouter = router({
           siteId,
         })
 
-        await publishSiteConfig(ctx.user.id, { site }, ctx.logger)
-
-        return updatedSite
+        return { site, updatedSite }
       })
+
+      await publishSiteConfig(ctx.user.id, { site: result.site }, ctx.logger)
+      return result.updatedSite
     }),
   getTheme: protectedProcedure
     .input(getConfigSchema)
@@ -328,9 +329,10 @@ export const siteRouter = router({
           by: user,
         })
 
-        await publishSiteConfig(ctx.user.id, { site }, ctx.logger)
         return newSite
       })
+
+      await publishSiteConfig(ctx.user.id, { site }, ctx.logger)
 
       // NOTE: if the users update their `canvas.inverse`
       // we also need to update their searchsg theme settings
@@ -370,7 +372,7 @@ export const siteRouter = router({
         action: "update",
       })
 
-      await db.transaction().execute(async (tx) => {
+      const result = await db.transaction().execute(async (tx) => {
         const user = await tx
           .selectFrom("User")
           .where("id", "=", ctx.user.id)
@@ -438,12 +440,14 @@ export const siteRouter = router({
           by: user,
         })
 
-        await publishSiteConfig(
-          ctx.user.id,
-          { site, footer: newFooter },
-          ctx.logger,
-        )
+        return { site, newFooter }
       })
+
+      await publishSiteConfig(
+        ctx.user.id,
+        { site: result.site, footer: result.newFooter },
+        ctx.logger,
+      )
     }),
   getNavbar: protectedProcedure
     .input(getConfigSchema)
@@ -464,7 +468,7 @@ export const siteRouter = router({
         action: "update",
       })
 
-      await db.transaction().execute(async (tx) => {
+      const result = await db.transaction().execute(async (tx) => {
         const user = await tx
           .selectFrom("User")
           .where("id", "=", ctx.user.id)
@@ -531,12 +535,14 @@ export const siteRouter = router({
           by: user,
         })
 
-        await publishSiteConfig(
-          ctx.user.id,
-          { site, navbar: newNavbar },
-          ctx.logger,
-        )
+        return { site, newNavbar }
       })
+
+      await publishSiteConfig(
+        ctx.user.id,
+        { site: result.site, navbar: result.newNavbar },
+        ctx.logger,
+      )
     }),
   getLocalisedSitemap: protectedProcedure
     .input(getLocalisedSitemapSchema)
@@ -596,7 +602,7 @@ export const siteRouter = router({
           roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
         })
 
-        await db.transaction().execute(async (tx) => {
+        const result = await db.transaction().execute(async (tx) => {
           const user = await tx
             .selectFrom("User")
             .where("id", "=", ctx.user.id)
@@ -731,12 +737,18 @@ export const siteRouter = router({
             by: user,
           })
 
-          await publishSiteConfig(
-            ctx.user.id,
-            { site: newSite, navbar: newNavbar, footer: newFooter },
-            ctx.logger,
-          )
+          return { newSite, newNavbar, newFooter }
         })
+
+        await publishSiteConfig(
+          ctx.user.id,
+          {
+            site: result.newSite,
+            navbar: result.newNavbar,
+            footer: result.newFooter,
+          },
+          ctx.logger,
+        )
       },
     ),
   create: protectedProcedure
@@ -769,7 +781,7 @@ export const siteRouter = router({
             }),
         )
 
-      return db.transaction().execute(async (tx) => {
+      await db.transaction().execute(async (tx) => {
         await logPublishEvent(tx, {
           by: byUser,
           eventType: AuditLogEvent.Publish,
@@ -777,7 +789,8 @@ export const siteRouter = router({
           metadata: {},
           siteId,
         })
-        await publishSite(ctx.logger, { siteId: siteId })
       })
+
+      await publishSite(ctx.logger, { siteId })
     }),
 })

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -221,6 +221,7 @@ async function main() {
       logDebug(`Successfully wrote file: ${filePath}`)
     } catch (error) {
       console.error(`Error writing sitemap to file:`, error)
+      throw error
     }
   } finally {
     await client.end()
@@ -480,7 +481,7 @@ async function getAllResourcesWithFullPermalinks(
     return res.rows
   } catch (err) {
     console.error("Error fetching resources:", err)
-    return []
+    throw err
   }
 }
 
@@ -529,6 +530,7 @@ function writeContentToFile(
     logDebug(`Successfully wrote file: ${filePath}`)
   } catch (error) {
     console.error("Error writing content to file:", error)
+    throw error
   }
 }
 
@@ -560,6 +562,7 @@ async function fetchAndWriteSiteData(client: Client) {
     }
   } catch (err) {
     console.error("Error fetching site data:", err)
+    throw err
   }
 }
 
@@ -572,11 +575,7 @@ async function fetchAndWriteRedirects(client: Client) {
     logDebug(`Successfully wrote redirects: ${filePath}`)
   } catch (err) {
     console.error("Error fetching redirects:", err)
-    fs.writeFileSync(
-      path.join(OUTPUT_DIR, "redirects.json"),
-      JSON.stringify([]),
-      "utf-8",
-    )
+    throw err
   }
 }
 
@@ -593,6 +592,7 @@ function writeJsonToFile(content: any, filename: string) {
     logDebug(`Successfully wrote file: ${filePath}`)
   } catch (error) {
     console.error(`Error writing ${filename} to file:`, error)
+    throw error
   }
 }
 

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -69,26 +69,30 @@ function logDebug(message: string, ...optionalParams: any[]) {
 }
 
 async function main() {
-  const client = new Client({
-    user: DB_USERNAME,
-    host: DB_HOST,
-    database: DB_NAME,
-    password: DB_IAM_AUTH
-      ? (DB_PASSWORD ?? "")
-      : decodeURIComponent(DB_PASSWORD ?? ""),
-    port: Number(DB_PORT),
-    ...(DB_IAM_AUTH && DB_SSL_SERVERNAME
-      ? {
-          ssl: {
-            // IAM requires TLS. Node does not trust the Amazon RDS CA, and the
-            // SSM tunnel presents that cert on localhost, so we encrypt without
-            // verifying the issuer.
-            rejectUnauthorized: false,
-            servername: DB_SSL_SERVERNAME,
-          },
-        }
-      : {}),
-  })
+  const client = new Client(
+    process.env.DATABASE_URL
+      ? { connectionString: process.env.DATABASE_URL }
+      : {
+          user: DB_USERNAME,
+          host: DB_HOST,
+          database: DB_NAME,
+          password: DB_IAM_AUTH
+            ? (DB_PASSWORD ?? "")
+            : decodeURIComponent(DB_PASSWORD ?? ""),
+          port: Number(DB_PORT),
+          ...(DB_IAM_AUTH && DB_SSL_SERVERNAME
+            ? {
+                ssl: {
+                  // IAM requires TLS. Node does not trust the Amazon RDS CA, and the
+                  // SSM tunnel presents that cert on localhost, so we encrypt without
+                  // verifying the issuer.
+                  rejectUnauthorized: false,
+                  servername: DB_SSL_SERVERNAME,
+                },
+              }
+            : {}),
+        },
+  )
 
   const start = performance.now() // Start profiling
 
@@ -592,4 +596,7 @@ function writeJsonToFile(content: any, filename: string) {
   }
 }
 
-main().catch((err) => console.error(err))
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
+++ b/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 
-import { seedPublishingSite, TEST_DB_ENV, db } from "../seed"
+import { db, seedPublishingSite, TEST_DATABASE_URL } from "../seed"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PACKAGE_DIR = join(__dirname, "..", "..")
@@ -53,7 +53,7 @@ beforeAll(async () => {
       // dd-trace (loaded via NODE_OPTIONS in CI) breaks spawned subprocesses
       NODE_OPTIONS: "",
       SITE_ID: String(siteId),
-      ...TEST_DB_ENV,
+      DATABASE_URL: TEST_DATABASE_URL,
       OUTPUT_DIR: outputDir,
     },
   })

--- a/tooling/build/scripts/publishing/tests/publishing.test.ts
+++ b/tooling/build/scripts/publishing/tests/publishing.test.ts
@@ -14,7 +14,7 @@ import {
   seedPublishingSite,
   SITE_CONFIG,
   SITE_THEME,
-  TEST_DB_ENV,
+  TEST_DATABASE_URL,
 } from "./seed"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -68,7 +68,7 @@ beforeAll(async () => {
       // dd-trace (loaded via NODE_OPTIONS in CI) breaks spawned subprocesses
       NODE_OPTIONS: "",
       SITE_ID: String(siteId),
-      ...TEST_DB_ENV,
+      DATABASE_URL: TEST_DATABASE_URL,
       OUTPUT_DIR: outputDir,
     },
   })

--- a/tooling/build/scripts/publishing/tests/seed.ts
+++ b/tooling/build/scripts/publishing/tests/seed.ts
@@ -6,18 +6,11 @@ const DB_USERNAME = process.env.TEST_DB_USERNAME ?? ""
 const DB_PASSWORD = process.env.TEST_DB_PASSWORD ?? ""
 const DB_NAME = process.env.TEST_DB_NAME ?? ""
 
-export const db = createDb({
-  connectionString: `postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`,
-})
+export const TEST_DATABASE_URL = `postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`
 
-// Connection env vars for spawning the publishing script as a subprocess
-export const TEST_DB_ENV = {
-  DB_HOST,
-  DB_PORT,
-  DB_USERNAME,
-  DB_PASSWORD,
-  DB_NAME,
-}
+export const db = createDb({
+  connectionString: TEST_DATABASE_URL,
+})
 
 const USER_ID = "publishing-e2e-user"
 

--- a/tooling/template/app/[[...permalink]]/page.tsx
+++ b/tooling/template/app/[[...permalink]]/page.tsx
@@ -18,6 +18,10 @@ import { serializeForInlineScript } from "@isomer/validators"
 export const dynamic = "force-static"
 
 const INDEX_PAGE_PERMALINK = "_index"
+const isModuleNotFoundError = (error: unknown) =>
+  error instanceof Error &&
+  "code" in error &&
+  ["MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"].includes(error.code as string)
 
 interface ParamsContent {
   permalink: string[]
@@ -56,7 +60,9 @@ const getSchema = async ({ permalink }: Pick<ParamsContent, "permalink">) => {
     // this might be the case where the file is an index page
     // and has `_index` appended to the original permalink
     // so we have to do another import w the appended index path
-    .catch(async () => {
+    .catch(async (error: unknown) => {
+      if (!isModuleNotFoundError(error)) throw error
+
       if (joinedPermalink === "") {
         // oxlint-disable-next-line @typescript-eslint/no-unsafe-return
         return import(`@/schema/${INDEX_PAGE_PERMALINK}.json`).then(
@@ -70,7 +76,10 @@ const getSchema = async ({ permalink }: Pick<ParamsContent, "permalink">) => {
         // oxlint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
       ).then((module) => module.default)
     })
-    .catch(() => notFound())) as IsomerPageSchemaType
+    .catch((error: unknown) => {
+      if (isModuleNotFoundError(error)) notFound()
+      throw error
+    })) as IsomerPageSchemaType
 
   const lastModified =
     // TODO: fixup all the typing errors

--- a/tooling/template/app/[[...permalink]]/page.tsx
+++ b/tooling/template/app/[[...permalink]]/page.tsx
@@ -11,6 +11,7 @@ import {
   RenderEngine,
   shouldBlockIndexing,
 } from "@opengovsg/isomer-components"
+import { notFound } from "next/navigation"
 
 import { serializeForInlineScript } from "@isomer/validators"
 
@@ -68,7 +69,8 @@ const getSchema = async ({ permalink }: Pick<ParamsContent, "permalink">) => {
         `@/schema/${joinedPermalink}/${INDEX_PAGE_PERMALINK}.json`
         // oxlint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
       ).then((module) => module.default)
-    })) as IsomerPageSchemaType
+    })
+    .catch(() => notFound())) as IsomerPageSchemaType
 
   const lastModified =
     // TODO: fixup all the typing errors

--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import type { CSSProperties } from "react"
 import config from "@/data/config.json"
 import footer from "@/data/footer.json"
 import "@/styles/globals.css"
@@ -44,11 +45,28 @@ export const metadata: Metadata = {
 }
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
+  const localTheme =
+    process.env.NODE_ENV === "development"
+      ? ({
+          "--color-brand-canvas-default": config.colors.brand.canvas.default,
+          "--color-brand-canvas-alt": config.colors.brand.canvas.alt,
+          "--color-brand-canvas-backdrop": config.colors.brand.canvas.backdrop,
+          "--color-brand-canvas-inverse": config.colors.brand.canvas.inverse,
+          "--color-brand-interaction-default":
+            config.colors.brand.interaction.default,
+          "--color-brand-interaction-hover":
+            config.colors.brand.interaction.hover,
+          "--color-brand-interaction-pressed":
+            config.colors.brand.interaction.pressed,
+        } as CSSProperties)
+      : undefined
+
   return (
     <html
       lang="en"
       data-theme={config.site.theme || "isomer-next"}
       className={inter.variable}
+      style={localTheme}
     >
       <head>
         <RenderApplicationHeadScripts

--- a/tooling/template/next.config.mjs
+++ b/tooling/template/next.config.mjs
@@ -3,6 +3,23 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const isDevelopment = process.env.NODE_ENV === "development"
+const localPublishDir = path.join(__dirname, ".local-publish")
+
+if (isDevelopment) {
+  fs.mkdirSync(localPublishDir, { recursive: true })
+  for (const entry of ["data", "schema", "sitemap.json"]) {
+    const target = path.join(localPublishDir, entry)
+    if (!fs.existsSync(target)) {
+      fs.cpSync(path.join(__dirname, entry), target, { recursive: true })
+    }
+  }
+}
+
+/** @param {{ request: string }} resource */
+const useLocalJson = (resource) => {
+  resource.request = path.join(localPublishDir, resource.request.slice(2))
+}
 
 // `data/config.json` is written to disk (by the publisher) before `build:template` runs,
 // so we can read it here to drive build-time module pruning.
@@ -12,7 +29,7 @@ const { site } = JSON.parse(
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "export",
+  output: isDevelopment ? undefined : "export",
   reactStrictMode: true,
   trailingSlash: true,
   // isomer-components → isomorphic-dompurify → jsdom. Declare those deps in package.json too so
@@ -22,10 +39,23 @@ const nextConfig = {
   // No need as this only runs for packages of versions that passes in CI
   typescript: { ignoreBuildErrors: true },
   webpack(config, { webpack }) {
+    if (isDevelopment) {
+      config.plugins.push(
+        new webpack.NormalModuleReplacementPlugin(
+          /^@\/(?:data\/.*\.json|schema(?:\/.*)?|sitemap\.json)$/,
+          useLocalJson,
+        ),
+        new webpack.ContextReplacementPlugin(
+          /[\\/]tooling[\\/]template[\\/]schema$/,
+          path.join(localPublishDir, "schema"),
+        ),
+      )
+    }
+
     // Site doesn't use egazette's Algolia-powered search: replace the module with a
     // null-stub so `algoliasearch`/`react-instantsearch` never enter the client bundle.
     // Applies to both the server and client compilers; a `() => null` stub is correct in both.
-    if (site?.search?.type !== "egazette-algolia") {
+    if (!isDevelopment && site?.search?.type !== "egazette-algolia") {
       config.plugins.push(
         new webpack.NormalModuleReplacementPlugin(
           /[\\/]templates[\\/]next[\\/]layouts[\\/]Search[\\/]EgazetteAlgoliaSearch[\\/]index\.js$/,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 9 | +296 | -77 |
| 🧪 Test | 3 | +7 | -14 |
| 📄 Doc | 1 | +27 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem
Developers testing publishing changes had to publish through the real CodeBuild pipeline or manually copy JSON output to preview a site in the template app, which is slow and doesn't reflect live edits.

## Solution
In development, `publishSite` now runs the publishing script locally as a subprocess and writes its output straight into `tooling/template/.local-publish`, which the template's dev server reads via webpack module replacement. Publishing a site from local Studio therefore renders immediately at `http://localhost:3001`.

Details:
- `codebuild.service.ts`: in `development`, defers publishing until after the current transaction commits, spawns `pnpm start` in `tooling/build/scripts/publishing` with `SITE_ID`/`OUTPUT_DIR`, then atomically swaps the result into `.local-publish` (queued so concurrent publishes don't race).
- `tooling/build/scripts/publishing/index.ts`: accepts a `DATABASE_URL` connection string directly (used by the local flow and tests), and exits non-zero on failure instead of only logging.
- `next.config.mjs`: in development, seeds `.local-publish` from the checked-in `data`/`schema`/`sitemap.json`, disables static export, and rewrites `@/data`, `@/schema`, `@/sitemap.json` imports to read from `.local-publish` instead; skips the Algolia search stub swap since it's not needed for local preview.
- `app/layout.tsx` / `app/[[...permalink]]/page.tsx`: apply the published site's brand colors as CSS variables in dev, and 404 instead of crashing when a schema file is missing.
- Tests updated to pass `DATABASE_URL` instead of separate `TEST_DB_*` env vars, matching the script's new connection option.

`.local-publish*/` is gitignored as generated output.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=60247588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Runs local publishing through a serialized subprocess and atomically replaces generated preview data.
- Moves publish operations outside their owning database transactions so the exporter reads committed changes.
- Propagates publisher failures through a non-zero exit and preserves the previous preview when generation fails.
- Configures the template dev server to consume local published data and render development theme colors.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Studio
  participant DB
  participant Queue as Local publish queue
  participant Publisher
  participant Template as Template dev server
  Studio->>DB: Commit content/config mutation
  DB-->>Studio: Transaction resolved
  Studio->>Queue: Enqueue site publish
  Queue->>Publisher: Spawn with SITE_ID and OUTPUT_DIR
  Publisher->>DB: Read committed site data
  Publisher-->>Queue: Exit successfully
  Queue->>Queue: Swap generated directory atomically
  Template->>Queue: Load .local-publish JSON
  Template-->>Studio: Render updated local preview
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix: address local publishing review com..."](https://github.com/opengovsg/isomer/commit/9b7c6ca45c0976ecf4b5a8f7b3f8648411433bb8)</sub>

<!-- /greptile_comment -->