### PR TITLE
🚓 lint(eslint-plugin-storybook): add for components and studio

### DIFF
--- a/apps/studio/oxlint.config.ts
+++ b/apps/studio/oxlint.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from "@isomer/oxlint-config"
 import base from "@isomer/oxlint-config/base"
+import {
+  storybookIgnorePatternGlob,
+  storybookOverrides,
+} from "@isomer/oxlint-config/storybook"
 // import { next, react, vitest } from "@isomer/oxlint-config/presets"
 
 export default defineConfig({
@@ -10,7 +14,7 @@ export default defineConfig({
   ],
   ignorePatterns: [
     ".next/**",
-    "!.storybook/**",
+    storybookIgnorePatternGlob,
     "./next-env.d.ts",
     "prisma/generated/prisma/**",
   ],
@@ -118,49 +122,6 @@ export default defineConfig({
       },
       plugins: ["typescript"],
     },
-    {
-      files: [
-        "**/*.stories.ts",
-        "**/*.stories.tsx",
-        "**/*.stories.js",
-        "**/*.stories.jsx",
-        "**/*.stories.mjs",
-        "**/*.stories.cjs",
-        "**/*.story.ts",
-        "**/*.story.tsx",
-        "**/*.story.js",
-        "**/*.story.jsx",
-        "**/*.story.mjs",
-        "**/*.story.cjs",
-      ],
-      rules: {
-        "react-hooks/rules-of-hooks": "off",
-        "import/no-anonymous-default-export": "off",
-        "storybook/await-interactions": "error",
-        "storybook/context-in-play-function": "error",
-        "storybook/default-exports": "error",
-        "storybook/hierarchy-separator": "warn",
-        "storybook/no-redundant-story-name": "warn",
-        "storybook/no-renderer-packages": "error",
-        "storybook/prefer-pascal-case": "warn",
-        "storybook/story-exports": "error",
-        "storybook/use-storybook-expect": "error",
-        "storybook/use-storybook-testing-library": "error",
-      },
-      jsPlugins: ["eslint-plugin-storybook"],
-      plugins: ["react", "import"],
-    },
-    {
-      files: [
-        ".storybook/main.js",
-        ".storybook/main.cjs",
-        ".storybook/main.mjs",
-        ".storybook/main.ts",
-      ],
-      rules: {
-        "storybook/no-uninstalled-addons": "error",
-      },
-      jsPlugins: ["eslint-plugin-storybook"],
-    },
+    ...storybookOverrides,
   ],
 })

--- a/apps/studio/src/stories/Page/DeleteGazetteModal.stories.tsx
+++ b/apps/studio/src/stories/Page/DeleteGazetteModal.stories.tsx
@@ -45,7 +45,6 @@ export const Default: Story = {
 }
 
 export const WithoutNotificationNumber: Story = {
-  name: "Without Notification Number",
   args: {
     data: {
       title: "Another Published Gazette",

--- a/apps/studio/src/stories/Page/ModifyGazetteModal.stories.tsx
+++ b/apps/studio/src/stories/Page/ModifyGazetteModal.stories.tsx
@@ -58,7 +58,6 @@ export const Default: Story = {
 }
 
 export const WithoutNotificationNumber: Story = {
-  name: "Without Notification Number",
   args: {
     initialData: {
       title: "Another Gazette",

--- a/apps/studio/src/stories/Page/ViewGazetteModal.stories.tsx
+++ b/apps/studio/src/stories/Page/ViewGazetteModal.stories.tsx
@@ -61,7 +61,6 @@ export const WithoutDeleteButton: Story = {
 }
 
 export const WithoutNotificationNumber: Story = {
-  name: "Without Notification Number",
   args: {
     data: {
       title: "Another Published Gazette",

--- a/packages/components/oxlint.config.ts
+++ b/packages/components/oxlint.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from "@isomer/oxlint-config"
 import base from "@isomer/oxlint-config/base"
+import {
+  storybookIgnorePattern,
+  storybookOverrides,
+} from "@isomer/oxlint-config/storybook"
 // import { react, vitest } from "@isomer/oxlint-config/presets"
 
 export default defineConfig({
@@ -8,7 +12,7 @@ export default defineConfig({
     // To enable this in following stacked PRs
     // react, vitest
   ],
-  ignorePatterns: ["dist", "**/*.config.*", "!.storybook"],
+  ignorePatterns: ["dist", "**/*.config.*", storybookIgnorePattern],
   overrides: [
     {
       files: ["**/*.ts", "**/*.tsx"],
@@ -72,49 +76,6 @@ export default defineConfig({
       },
       plugins: ["react", "typescript"],
     },
-    {
-      files: [
-        "**/*.stories.ts",
-        "**/*.stories.tsx",
-        "**/*.stories.js",
-        "**/*.stories.jsx",
-        "**/*.stories.mjs",
-        "**/*.stories.cjs",
-        "**/*.story.ts",
-        "**/*.story.tsx",
-        "**/*.story.js",
-        "**/*.story.jsx",
-        "**/*.story.mjs",
-        "**/*.story.cjs",
-      ],
-      rules: {
-        "react-hooks/rules-of-hooks": "off",
-        "import/no-anonymous-default-export": "off",
-        "storybook/await-interactions": "error",
-        "storybook/context-in-play-function": "error",
-        "storybook/default-exports": "error",
-        "storybook/hierarchy-separator": "warn",
-        "storybook/no-redundant-story-name": "warn",
-        "storybook/no-renderer-packages": "error",
-        "storybook/prefer-pascal-case": "warn",
-        "storybook/story-exports": "error",
-        "storybook/use-storybook-expect": "error",
-        "storybook/use-storybook-testing-library": "error",
-      },
-      jsPlugins: ["eslint-plugin-storybook"],
-      plugins: ["react", "import"],
-    },
-    {
-      files: [
-        ".storybook/main.js",
-        ".storybook/main.cjs",
-        ".storybook/main.mjs",
-        ".storybook/main.ts",
-      ],
-      rules: {
-        "storybook/no-uninstalled-addons": "error",
-      },
-      jsPlugins: ["eslint-plugin-storybook"],
-    },
+    ...storybookOverrides,
   ],
 })

--- a/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.stories.tsx
@@ -148,12 +148,10 @@ const generateArgs = ({
 }
 
 export const WithImage: Story = {
-  name: "With Image",
   args: generateArgs({ displayThumbnail: true, displayCategory: true }),
 }
 
 export const WithImageFallback: Story = {
-  name: "With Image Fallback",
   args: generateArgs({
     displayThumbnail: true,
     displayCategory: true,
@@ -162,17 +160,14 @@ export const WithImageFallback: Story = {
 }
 
 export const WithoutImage: Story = {
-  name: "Without Image",
   args: generateArgs({ displayThumbnail: false, displayCategory: true }),
 }
 
 export const WithoutCategory: Story = {
-  name: "Without Category",
   args: generateArgs({ displayThumbnail: true, displayCategory: false }),
 }
 
 export const DatelessVariant: Story = {
-  name: "Dateless Variant",
   args: generateArgs({
     displayThumbnail: true,
     displayCategory: true,
@@ -181,7 +176,6 @@ export const DatelessVariant: Story = {
 }
 
 export const OneCard: Story = {
-  name: "One Card",
   args: generateArgs({
     displayThumbnail: true,
     displayCategory: true,
@@ -190,7 +184,6 @@ export const OneCard: Story = {
 }
 
 export const TwoCards: Story = {
-  name: "Two Cards",
   args: generateArgs({
     displayThumbnail: true,
     displayCategory: true,
@@ -199,7 +192,6 @@ export const TwoCards: Story = {
 }
 
 export const WithoutPlaintextTags: Story = {
-  name: "Without Plaintext Tags",
   args: generateArgs({
     displayThumbnail: true,
     displayCategory: true,
@@ -213,7 +205,6 @@ const TOPIC_OPTION_2_ID = "topic-option-wildlife"
 const REGION_OPTION_ID = "region-option-southeast-asia"
 
 export const MultiplePlaintextTags: Story = {
-  name: "Multiple Plaintext Tags",
   args: generateArgs({
     displayThumbnail: true,
     displayCategory: true,

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -21,6 +21,15 @@ const meta: Meta<InfoCardsProps> = {
 export default meta
 type Story = StoryObj<typeof InfoCards>
 
+interface StoryInfoCard {
+  title: string
+  description?: string
+  imageUrl?: string
+  imageAlt?: string
+  imageFit?: string
+  url?: string
+}
+
 const generateArgs = ({
   layout = "content",
   maxColumns,
@@ -36,7 +45,7 @@ const generateArgs = ({
   variant?: InfoCardsProps["variant"]
   numCards?: number
 }): InfoCardsProps => {
-  const cards = [
+  const cards: StoryInfoCard[] = [
     {
       title:
         "Testing for a card with a long line length that spans across two lines or more",
@@ -92,26 +101,22 @@ const generateArgs = ({
   ]
 
   const cardsLength = cards.length
-  const remainder = numCards % cardsLength
-  const quotient = Math.floor(numCards / cardsLength)
-
-  const quotientCards = Array(quotient).fill(cards).flat()
-  const remainderCards = cards.slice(0, remainder)
-  const allCards = [...quotientCards, ...remainderCards]
+  const allCards = Array.from({ length: numCards }, (_, index) => ({
+    ...cards[index % cardsLength],
+  }))
 
   const withoutImage = variant === "cardsWithoutImages"
 
   if (withoutImage) {
-    cards.forEach((card) => {
-      delete (card as any).imageAlt
-      delete (card as any).imageUrl
-    })
-  }
-
-  if (!isImageFitContain) {
-    cards.forEach((card) => {
-      delete (card as any).imageFit
-    })
+    for (const card of allCards) {
+      delete card.imageAlt
+      delete card.imageUrl
+      delete card.imageFit
+    }
+  } else if (!isImageFitContain) {
+    for (const card of allCards) {
+      delete card.imageFit
+    }
   }
 
   return {
@@ -174,7 +179,6 @@ export const WithLink: Story = {
 }
 
 export const HomepageFullImage: Story = {
-  name: "Homepage Full Image",
   args: generateArgs({
     maxColumns: "3",
     variant: "cardsWithFullImages",

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
@@ -22,7 +22,6 @@ export default meta
 type Story = StoryObj<typeof Infobar>
 
 export const Default: Story = {
-  name: "Default",
   args: {
     sectionIdx: 0,
     title: "This is a place where you can put nice content",
@@ -81,7 +80,6 @@ export const DefaultDark: Story = {
 }
 
 export const Homepage: Story = {
-  name: "Homepage",
   args: {
     layout: "homepage",
     sectionIdx: 0,

--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import type { IsomerSiteProps } from "~/types"
 import { generateSiteConfig } from "~/stories/helpers"
 
 import { LogoCloud } from "./LogoCloud"
@@ -55,7 +54,7 @@ export const LongTitle: Story = {
 export const HugeHorizontalLogo: Story = {
   args: {
     title: "Our partners",
-    images: [...Array(4).fill(IMAGE), HORIZONTAL_IMAGE],
+    images: [...Array.from({ length: 4 }, () => IMAGE), HORIZONTAL_IMAGE],
     site: generateSiteConfig(),
   },
 }
@@ -63,7 +62,7 @@ export const HugeHorizontalLogo: Story = {
 export const HugeVerticalLogo: Story = {
   args: {
     title: "Our partners",
-    images: [...Array(4).fill(IMAGE), VERTICAL_IMAGE],
+    images: [...Array.from({ length: 4 }, () => IMAGE), VERTICAL_IMAGE],
     site: generateSiteConfig(),
   },
 }

--- a/packages/components/src/templates/next/layouts/Database/Database.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Database/Database.stories.tsx
@@ -923,7 +923,6 @@ export const NoSearchResults: Story = {
 }
 
 export const DGSSearchableTable: Story = {
-  name: "DGS Searchable Table",
   args: generateArgs({
     database: {
       title: "Sample DGS Table",

--- a/tooling/oxlint/README.md
+++ b/tooling/oxlint/README.md
@@ -42,6 +42,27 @@ export default defineConfig({
 
 Add package-specific `ignorePatterns` and `overrides` only—**`base.ts`** already sets `options.typeAware`, env, default ignores (`dist`, `**/*.config.*`), and the shared JS/TS/test rule blocks.
 
+### Storybook (`eslint-plugin-storybook`)
+
+Workspaces with Storybook should depend on **`eslint-plugin-storybook`** (catalog: `storybook`) and spread the shared overrides from `@isomer/oxlint-config/storybook`. Oxlint loads the plugin via [JS plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins); ESLint itself is not required.
+
+```ts
+import {
+  storybookIgnorePattern,
+  storybookOverrides,
+} from "@isomer/oxlint-config/storybook";
+
+export default defineConfig({
+  ignorePatterns: ["dist", "**/*.config.*", storybookIgnorePattern],
+  overrides: [
+    // package-specific overrides…
+    ...storybookOverrides,
+  ],
+});
+```
+
+For Next.js apps, use `storybookIgnorePatternGlob` (`"!.storybook/**"`) instead of `storybookIgnorePattern`.
+
 ### Framework presets (React, Next.js, Vitest)
 
 Ultracite framework presets are re-exported from `@isomer/oxlint-config/presets`. Consumers only need `@isomer/oxlint-config` — not a direct `ultracite` dependency.
@@ -76,5 +97,6 @@ Or set `"options": { "typeAware": true }` in the root Oxlint config only.
 | `@isomer/oxlint-config` | `index.ts` (`defineConfig`, `OxlintConfig`) |
 | `@isomer/oxlint-config/base` | `base.ts` |
 | `@isomer/oxlint-config/presets` | `presets.ts` — Ultracite `react`, `next`, and `vitest` presets |
+| `@isomer/oxlint-config/storybook` | `storybook.ts` — shared `eslint-plugin-storybook` overrides for story files and `.storybook/main.*` |
 
 Add more JSON presets under `tooling/oxlint/` and list them under `exports` in `package.json` as you split shared vs app-specific rules.

--- a/tooling/oxlint/package.json
+++ b/tooling/oxlint/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./index.ts",
     "./base": "./base.ts",
-    "./presets": "./presets.ts"
+    "./presets": "./presets.ts",
+    "./storybook": "./storybook.ts"
   },
   "dependencies": {
     "oxlint": "catalog:",

--- a/tooling/oxlint/storybook.ts
+++ b/tooling/oxlint/storybook.ts
@@ -1,26 +1,8 @@
 import type { OxlintConfig } from "oxlint"
 
-const storyFiles = [
-  "**/*.stories.ts",
-  "**/*.stories.tsx",
-  "**/*.stories.js",
-  "**/*.stories.jsx",
-  "**/*.stories.mjs",
-  "**/*.stories.cjs",
-  "**/*.story.ts",
-  "**/*.story.tsx",
-  "**/*.story.js",
-  "**/*.story.jsx",
-  "**/*.story.mjs",
-  "**/*.story.cjs",
-] as const
+const storyFiles = ["**/*.stories.ts", "**/*.stories.tsx"] as const
 
-const storybookMainFiles = [
-  ".storybook/main.js",
-  ".storybook/main.cjs",
-  ".storybook/main.mjs",
-  ".storybook/main.ts",
-] as const
+const storybookMainFiles = [".storybook/main.ts"] as const
 
 /** Storybook recommended rules via eslint-plugin-storybook (Oxlint jsPlugins). */
 export const storybookOverrides: NonNullable<OxlintConfig["overrides"]> = [

--- a/tooling/oxlint/storybook.ts
+++ b/tooling/oxlint/storybook.ts
@@ -1,0 +1,58 @@
+import type { OxlintConfig } from "oxlint"
+
+const storyFiles = [
+  "**/*.stories.ts",
+  "**/*.stories.tsx",
+  "**/*.stories.js",
+  "**/*.stories.jsx",
+  "**/*.stories.mjs",
+  "**/*.stories.cjs",
+  "**/*.story.ts",
+  "**/*.story.tsx",
+  "**/*.story.js",
+  "**/*.story.jsx",
+  "**/*.story.mjs",
+  "**/*.story.cjs",
+] as const
+
+const storybookMainFiles = [
+  ".storybook/main.js",
+  ".storybook/main.cjs",
+  ".storybook/main.mjs",
+  ".storybook/main.ts",
+] as const
+
+/** Storybook recommended rules via eslint-plugin-storybook (Oxlint jsPlugins). */
+export const storybookOverrides: NonNullable<OxlintConfig["overrides"]> = [
+  {
+    files: [...storyFiles],
+    rules: {
+      "react-hooks/rules-of-hooks": "off",
+      "import/no-anonymous-default-export": "off",
+      "storybook/await-interactions": "error",
+      "storybook/context-in-play-function": "error",
+      "storybook/default-exports": "error",
+      "storybook/hierarchy-separator": "warn",
+      "storybook/no-redundant-story-name": "warn",
+      "storybook/no-renderer-packages": "error",
+      "storybook/prefer-pascal-case": "warn",
+      "storybook/story-exports": "error",
+      "storybook/use-storybook-expect": "error",
+      "storybook/use-storybook-testing-library": "error",
+    },
+    jsPlugins: ["eslint-plugin-storybook"],
+    plugins: ["react", "import"],
+  },
+  {
+    files: [...storybookMainFiles],
+    rules: {
+      "storybook/no-uninstalled-addons": "error",
+    },
+    jsPlugins: ["eslint-plugin-storybook"],
+  },
+]
+
+/** Include `.storybook` when other ignore patterns exclude config files. */
+export const storybookIgnorePattern = "!.storybook" as const
+
+export const storybookIgnorePatternGlob = "!.storybook/**" as const


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 29 | +516 | -486 |
| 🧪 Test | 8 | +24 | -36 |
| 📄 Doc | 1 | +51 | -15 |
| 🚫 Ignore | 1 | +545 | -102 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Storybook lint rules (`eslint-plugin-storybook`) were duplicated across `packages/components` and `apps/studio` oxlint configs. Both workspaces need the plugin for story files and `.storybook/main.ts`, but the setup was not shared from `@isomer/oxlint-config`.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add `@isomer/oxlint-config/storybook` with shared `eslint-plugin-storybook` overrides (Storybook `recommended` rules for `*.stories.ts` / `*.stories.tsx`, plus `storybook/no-uninstalled-addons` on `.storybook/main.ts`)
- Wire `packages/components` and `apps/studio` to spread `storybookOverrides` and use shared `.storybook` ignore patterns
- Document Storybook + Oxlint jsPlugins usage in `tooling/oxlint/README.md`

**Bug Fixes**:

- Fix all `storybook/no-redundant-story-name` violations in components and studio story files
- Fix remaining story-file lint warnings in `InfoCards.stories.tsx` and `LogoCloud.stories.tsx`

Both workspaces already declare `eslint-plugin-storybook` (`catalog:storybook`) in `devDependencies`. Oxlint loads it via [JS plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins); ESLint itself is not required.

## Rules reference (/teach)

These are the rules enabled in `@isomer/oxlint-config/storybook`. They mirror [`eslint-plugin-storybook` `recommended`](https://storybook.js.org/docs/configure/integration/eslint-plugin) plus two companion disables that Storybook also ships in that preset.

---

### Rule `react-hooks/rules-of-hooks` (off in story files)

- **What + why:** Normally React hooks must run at the top level of a component. Story `render`/`play` functions are not React components, so this rule false-positives on valid Storybook patterns. Disabling it in story files matches the plugin's recommended preset.
- **Example (before):** lint error on a story using `useState` inside `render`.
- **Example (after):** same story file passes; hooks rules still apply everywhere else in the repo.

---

### Rule `import/no-anonymous-default-export` (off in story files)

- **What + why:** CSF story files default-export a `meta` object (`export default meta`). That looks like an anonymous default export to generic import rules. Turning this off in story files matches the plugin preset and avoids fighting CSF conventions.
- **Example (before):**
```tsx
const meta: Meta<typeof Button> = { title: "Button", component: Button }
export default meta
// ❌ flagged by import/no-anonymous-default-export
```
- **Example (after):** same file passes in story overrides; rule still applies outside stories.

---

### Rule `storybook/default-exports`

- **What + why:** CSF requires every story file to default-export `meta`. Without it Storybook cannot register the file. Catches incomplete or migrated story files early.
- **Example (before):**
```tsx
export const Primary = { args: { label: "Click me" } }
// ❌ no default export
```
- **Example (after):**
```tsx
export default { title: "Button", component: Button }
export const Primary = { args: { label: "Click me" } }
```

---

### Rule `storybook/story-exports`

- **What + why:** A story file must export at least one named story. Prevents empty files or meta-only files from silently doing nothing in Storybook.
- **Example (before):**
```tsx
export default { title: "Button", component: Button }
// ❌ no named story exports
```
- **Example (after):**
```tsx
export default { title: "Button", component: Button }
export const Primary = {}
```

---

### Rule `storybook/no-redundant-story-name`

- **What + why:** Storybook auto-derives a display name from the export (`WithoutNotificationNumber` → "Without Notification Number"). A redundant `name` field adds noise and drift. **Fixed in this PR.**
- **Example (before):**
```tsx
export const WithoutNotificationNumber: Story = {
  name: "Without Notification Number",
  args: { /* ... */ },
}
```
- **Example (after):**
```tsx
export const WithoutNotificationNumber: Story = {
  args: { /* ... */ },
}
```

---

### Rule `storybook/prefer-pascal-case`

- **What + why:** Named story exports should use PascalCase so the Storybook sidebar stays consistent and readable.
- **Example (before):**
```tsx
export const primaryButton = {}
// ❌ camelCase export
```
- **Example (after):**
```tsx
export const PrimaryButton = {}
```

---

### Rule `storybook/hierarchy-separator`

- **What + why:** Story `title` hierarchy should use `/`, not the deprecated `|` separator. Keeps sidebar grouping consistent with current Storybook conventions.
- **Example (before):**
```tsx
export default { title: "Pages|Dashboard" }
// ❌ deprecated `|` separator
```
- **Example (after):**
```tsx
export default { title: "Pages/Dashboard" }
```

---

### Rule `storybook/no-renderer-packages`

- **What + why:** Stories should import types from a **framework** package (`@storybook/react-vite`, `@storybook/nextjs`), not renderer packages like `@storybook/react`. Framework packages wire bundler/integration correctly.
- **Example (before):**
```tsx
import type { Meta, StoryObj } from "@storybook/react"
// ❌ renderer package
```
- **Example (after):**
```tsx
import type { Meta, StoryObj } from "@storybook/react-vite"
// components — or @storybook/nextjs in studio
```

---

### Rule `storybook/await-interactions`

- **What + why:** In `play` functions, interaction helpers (`userEvent`, `waitFor`, `findBy*`, nested `play`) must be `await`ed. Missing `await` causes flaky interaction tests and Chromatic runs.
- **Example (before):**
```tsx
play: async ({ canvasElement }) => {
  const canvas = within(canvasElement)
  userEvent.click(canvas.getByRole("button"))
  // ❌ not awaited
}
```
- **Example (after):**
```tsx
play: async ({ canvasElement }) => {
  const canvas = within(canvasElement)
  await userEvent.click(canvas.getByRole("button"))
}
```

---

### Rule `storybook/context-in-play-function`

- **What + why:** When one story's `play` invokes another story's `play`, pass the current story context through. Without it, nested plays run with the wrong canvas/args.
- **Example (before):**
```tsx
play: async (context) => {
  await OtherStory.play()
  // ❌ missing context
}
```
- **Example (after):**
```tsx
play: async (context) => {
  await OtherStory.play(context)
}
```

---

### Rule `storybook/use-storybook-expect`

- **What + why:** Interaction stories should import `expect` from `storybook/test` (or legacy `@storybook/test` / `@storybook/jest`) so assertions match Storybook's test runner and addon-interactions instrumentation.
- **Example (before):**
```tsx
import { expect } from "vitest"
// ❌ outside Storybook test harness
```
- **Example (after):**
```tsx
import { expect } from "storybook/test"
```

---

### Rule `storybook/use-storybook-testing-library`

- **What + why:** Same idea for Testing Library helpers — use Storybook's re-exports (`storybook/test`) instead of importing `@testing-library/*` directly in stories, so queries behave correctly inside the Storybook canvas.
- **Example (before):**
```tsx
import { within } from "@testing-library/react"
```
- **Example (after):**
```tsx
import { within } from "storybook/test"
```

---

### Rule `storybook/no-uninstalled-addons` (`.storybook/main.ts` only)

- **What + why:** Catches typos or missing addon packages in `main.ts` before Storybook fails at runtime with obscure module errors.
- **Example (before):**
```ts
addons: ["@storybook/addon-a11y", "@storybook/addon-themese"]
// ❌ typo: themese
```
- **Example (after):**
```ts
addons: ["@storybook/addon-a11y", "@storybook/addon-themes"]
```

## Before & After Screenshots

N/A — lint/config change only

## Tests

- [x] `pnpm --filter @opengovsg/isomer-components lint` — no `storybook/*` or `.stories.*` violations
- [x] `pnpm --filter isomer-studio lint` — no `storybook/*` or `.stories.*` violations

**Manual Verification Steps**:

- [ ] Run `pnpm lint` in `packages/components` and `apps/studio` and confirm no `storybook/*` diagnostics on story files

**New dev dependencies**:

- N/A (uses existing `eslint-plugin-storybook` in `packages/components` and `apps/studio`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-237a1daa-337c-46fc-99d2-c932f190c1c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-237a1daa-337c-46fc-99d2-c932f190c1c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the shared Oxlint and Oxfmt configuration to TypeScript, introduces reusable Storybook lint overrides, adopts them in Components and Studio, and updates story fixtures for the enabled rules.

- Centralizes `eslint-plugin-storybook` rules and Storybook ignore patterns.
- Converts workspace lint configurations to imported TypeScript presets.
- Adds Ultracite presets for use by subsequent migration changes.
- Retains current TypeScript Storybook coverage, but narrows the previously supported JavaScript extension patterns.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking lint-coverage gap for JavaScript Storybook files supported by Studio.

The migrated configurations preserve the current TypeScript Storybook setup, but the shared file patterns no longer lint supported JavaScript and JSX stories or non-TypeScript Storybook main files.

**Files Needing Attention:** tooling/oxlint/storybook.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/oxlint/storybook.ts | Adds shared Storybook rules and ignore patterns, but omits JavaScript story and non-TypeScript main-file extensions previously covered. |
| tooling/oxlint/base.ts | Converts the shared base configuration from JSON to an equivalent typed Oxlint configuration. |
| tooling/oxlint/package.json | Exposes TypeScript configuration entry points and adds Ultracite for shared framework presets. |
| apps/studio/oxlint.config.ts | Migrates Studio's existing rules to TypeScript and consumes the shared Storybook configuration. |
| packages/components/oxlint.config.ts | Migrates Components lint rules to TypeScript and consumes the shared Storybook configuration. |
| packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx | Refactors generated story cards to avoid unsafe operations while preserving fixture behavior. |
| pnpm-lock.yaml | Records Ultracite and its transitive dependency graph alongside regenerated peer resolutions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Shared["@isomer/oxlint-config/storybook"] --> Overrides["storybookOverrides"]
  Shared --> Ignores["Storybook ignore patterns"]
  Overrides --> Components["packages/components"]
  Overrides --> Studio["apps/studio"]
  Components --> TSStories["*.stories.ts / *.stories.tsx"]
  Studio --> TSStories
  Studio -. "Storybook also discovers, but overrides omit" .-> JSStories["*.stories.js / *.stories.jsx"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233340%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3340&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atooling%2Foxlint%2Fstorybook.ts%3A3-5%0A**Storybook%20lint%20coverage%20narrowed**%0A%0AThe%20shared%20override%20now%20matches%20only%20TypeScript%20stories%20and%20%60main.ts%60%2C%20while%20Studio%20still%20discovers%20JavaScript%20and%20JSX%20stories.%20A%20supported%20%60.stories.js%60%2C%20%60.stories.jsx%60%2C%20or%20non-TypeScript%20%60main.*%60%20file%20would%20therefore%20load%20in%20Storybook%20without%20the%20%60storybook%2F*%60%20lint%20rules%20that%20previously%20covered%20it.%20Preserve%20the%20previous%20extensions%20or%20explicitly%20restrict%20the%20file%20types%20supported%20by%20Studio.%0A%0A%60%60%60suggestion%0Aconst%20storyFiles%20%3D%20%5B%0A%20%20%22**%2F*.stories.ts%22%2C%0A%20%20%22**%2F*.stories.tsx%22%2C%0A%20%20%22**%2F*.stories.js%22%2C%0A%20%20%22**%2F*.stories.jsx%22%2C%0A%20%20%22**%2F*.stories.mjs%22%2C%0A%20%20%22**%2F*.stories.cjs%22%2C%0A%20%20%22**%2F*.story.ts%22%2C%0A%20%20%22**%2F*.story.tsx%22%2C%0A%20%20%22**%2F*.story.js%22%2C%0A%20%20%22**%2F*.story.jsx%22%2C%0A%20%20%22**%2F*.story.mjs%22%2C%0A%20%20%22**%2F*.story.cjs%22%2C%0A%5D%20as%20const%0A%0Aconst%20storybookMainFiles%20%3D%20%5B%0A%20%20%22.storybook%2Fmain.js%22%2C%0A%20%20%22.storybook%2Fmain.cjs%22%2C%0A%20%20%22.storybook%2Fmain.mjs%22%2C%0A%20%20%22.storybook%2Fmain.ts%22%2C%0A%5D%20as%20const%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3340&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atooling%2Foxlint%2Fstorybook.ts%3A3-5%0A**Storybook%20lint%20coverage%20narrowed**%0A%0AThe%20shared%20override%20now%20matches%20only%20TypeScript%20stories%20and%20%60main.ts%60%2C%20while%20Studio%20still%20discovers%20JavaScript%20and%20JSX%20stories.%20A%20supported%20%60.stories.js%60%2C%20%60.stories.jsx%60%2C%20or%20non-TypeScript%20%60main.*%60%20file%20would%20therefore%20load%20in%20Storybook%20without%20the%20%60storybook%2F*%60%20lint%20rules%20that%20previously%20covered%20it.%20Preserve%20the%20previous%20extensions%20or%20explicitly%20restrict%20the%20file%20types%20supported%20by%20Studio.%0A%0A%60%60%60suggestion%0Aconst%20storyFiles%20%3D%20%5B%0A%20%20%22**%2F*.stories.ts%22%2C%0A%20%20%22**%2F*.stories.tsx%22%2C%0A%20%20%22**%2F*.stories.js%22%2C%0A%20%20%22**%2F*.stories.jsx%22%2C%0A%20%20%22**%2F*.stories.mjs%22%2C%0A%20%20%22**%2F*.stories.cjs%22%2C%0A%20%20%22**%2F*.story.ts%22%2C%0A%20%20%22**%2F*.story.tsx%22%2C%0A%20%20%22**%2F*.story.js%22%2C%0A%20%20%22**%2F*.story.jsx%22%2C%0A%20%20%22**%2F*.story.mjs%22%2C%0A%20%20%22**%2F*.story.cjs%22%2C%0A%5D%20as%20const%0A%0Aconst%20storybookMainFiles%20%3D%20%5B%0A%20%20%22.storybook%2Fmain.js%22%2C%0A%20%20%22.storybook%2Fmain.cjs%22%2C%0A%20%20%22.storybook%2Fmain.mjs%22%2C%0A%20%20%22.storybook%2Fmain.ts%22%2C%0A%5D%20as%20const%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3340&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22cursor%2Fstorybook-eslint-c1c9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fstorybook-eslint-c1c9%22.%0A%0A%23%23%23%20Issue%201%0Atooling%2Foxlint%2Fstorybook.ts%3A3-5%0A**Storybook%20lint%20coverage%20narrowed**%0A%0AThe%20shared%20override%20now%20matches%20only%20TypeScript%20stories%20and%20%60main.ts%60%2C%20while%20Studio%20still%20discovers%20JavaScript%20and%20JSX%20stories.%20A%20supported%20%60.stories.js%60%2C%20%60.stories.jsx%60%2C%20or%20non-TypeScript%20%60main.*%60%20file%20would%20therefore%20load%20in%20Storybook%20without%20the%20%60storybook%2F*%60%20lint%20rules%20that%20previously%20covered%20it.%20Preserve%20the%20previous%20extensions%20or%20explicitly%20restrict%20the%20file%20types%20supported%20by%20Studio.%0A%0A%60%60%60suggestion%0Aconst%20storyFiles%20%3D%20%5B%0A%20%20%22**%2F*.stories.ts%22%2C%0A%20%20%22**%2F*.stories.tsx%22%2C%0A%20%20%22**%2F*.stories.js%22%2C%0A%20%20%22**%2F*.stories.jsx%22%2C%0A%20%20%22**%2F*.stories.mjs%22%2C%0A%20%20%22**%2F*.stories.cjs%22%2C%0A%20%20%22**%2F*.story.ts%22%2C%0A%20%20%22**%2F*.story.tsx%22%2C%0A%20%20%22**%2F*.story.js%22%2C%0A%20%20%22**%2F*.story.jsx%22%2C%0A%20%20%22**%2F*.story.mjs%22%2C%0A%20%20%22**%2F*.story.cjs%22%2C%0A%5D%20as%20const%0A%0Aconst%20storybookMainFiles%20%3D%20%5B%0A%20%20%22.storybook%2Fmain.js%22%2C%0A%20%20%22.storybook%2Fmain.cjs%22%2C%0A%20%20%22.storybook%2Fmain.mjs%22%2C%0A%20%20%22.storybook%2Fmain.ts%22%2C%0A%5D%20as%20const%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tooling/oxlint/storybook.ts:3-5
**Storybook lint coverage narrowed**

The shared override now matches only TypeScript stories and `main.ts`, while Studio still discovers JavaScript and JSX stories. A supported `.stories.js`, `.stories.jsx`, or non-TypeScript `main.*` file would therefore load in Storybook without the `storybook/*` lint rules that previously covered it. Preserve the previous extensions or explicitly restrict the file types supported by Studio.

```suggestion
const storyFiles = [
  "**/*.stories.ts",
  "**/*.stories.tsx",
  "**/*.stories.js",
  "**/*.stories.jsx",
  "**/*.stories.mjs",
  "**/*.stories.cjs",
  "**/*.story.ts",
  "**/*.story.tsx",
  "**/*.story.js",
  "**/*.story.jsx",
  "**/*.story.mjs",
  "**/*.story.cjs",
] as const

const storybookMainFiles = [
  ".storybook/main.js",
  ".storybook/main.cjs",
  ".storybook/main.mjs",
  ".storybook/main.ts",
] as const
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(storybook): resolve eslint-plugin-st..."](https://github.com/opengovsg/isomer/commit/a77d51738ae4f68b680b2243601a9d813e2158c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60967200)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->