### PR TITLE
fix: fit default callout colour to match other callouts variants' faintness

### DIFF
--- a/packages/components/src/templates/next/components/complex/Callout/Callout.tsx
+++ b/packages/components/src/templates/next/components/complex/Callout/Callout.tsx
@@ -29,7 +29,7 @@ const calloutStyles = tv({
     variant: {
       information: {
         container:
-          "border-utility-feedback-info bg-utility-feedback-info-subtle",
+          "border-utility-feedback-info-subtle bg-utility-feedback-info-faint",
       },
       goodToKnow: {
         container:

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -377,6 +377,42 @@ export const Default: Story = {
         },
       },
       {
+        type: "callout",
+        variant: "urgent",
+        content: {
+          type: "prose",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "Applications close on 31 December 2024. Submissions received after this date will not be considered.",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        type: "callout",
+        variant: "information",
+        content: {
+          type: "prose",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "Processing of proposals typically takes 6 to 8 weeks. You will be notified of the outcome via email.",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
         type: "prose",
         content: [
           {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +1 | -1 |
| 🧪 Test | 1 | +36 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
