### PR TITLE
feat(studio): suggest alt text automatically on image upload

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "catalog:atlaskitPragmaticDnd",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "catalog:atlaskitPragmaticDnd",
+    "@aws-sdk/client-bedrock-runtime": "catalog:aws-sdk",
     "@aws-sdk/client-codebuild": "catalog:aws-sdk",
     "@aws-sdk/client-s3": "catalog:aws-sdk",
     "@aws-sdk/lib-storage": "catalog:aws-sdk",

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
@@ -1,17 +1,30 @@
 import type { ControlProps, JsonSchema, RankedTester } from "@jsonforms/core"
 import { Box, FormControl } from "@chakra-ui/react"
 import { and, isStringControl, rankWith, schemaMatches } from "@jsonforms/core"
-import { withJsonFormsControlProps } from "@jsonforms/react"
+import { useJsonForms, withJsonFormsControlProps } from "@jsonforms/react"
 import { FormErrorMessage, FormLabel } from "@opengovsg/design-system-react"
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "@opengovsg/isomer-components"
+import { get } from "lodash-es"
+import { useState } from "react"
 import { AttachmentData } from "~/components/AttachmentData"
 import { FileAttachment } from "~/components/PageEditor/FileAttachment"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { pageOrLinkSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { MAX_IMG_FILE_SIZE_BYTES } from "~/lib/fileUpload"
+import { trpc } from "~/utils/trpc"
 
 import { getCustomErrorMessage } from "./utils"
+
+const SURROUNDING_TEXT_FIELD_DENYLIST = new Set(["src", "alt", "type"])
+
+// The alt field is always the sibling of `src` on the same component object,
+// e.g. "content.2.src" -> "content.2.alt".
+const getSiblingAltPath = (srcPath: string): string | undefined => {
+  const parts = srcPath.split(".")
+  if (parts[parts.length - 1] !== "src") return undefined
+  return [...parts.slice(0, -1), "alt"].join(".")
+}
 
 export const jsonFormsImageControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.ImageControl,
@@ -38,6 +51,25 @@ function JsonFormsImageControl({
   schema,
 }: JsonFormsImageControlProps) {
   const { siteId, pageId, linkId } = useQueryParse(pageOrLinkSchema)
+  const ctx = useJsonForms()
+  const [uploadedMimeType, setUploadedMimeType] = useState<string>()
+
+  const altPath = getSiblingAltPath(path)
+  const parentPath = path.split(".").slice(0, -1).join(".")
+  const parentData = get(ctx.core?.data, parentPath) as
+    | Record<string, unknown>
+    | undefined
+
+  const { mutate: generateAltText } = trpc.image.generateAltText.useMutation({
+    onSuccess: ({ altText }) => {
+      if (!altText || !altPath) return
+      // The generation call takes a few seconds — don't clobber alt text the
+      // editor already typed in while it was in flight.
+      const currentAlt = get(ctx.core?.data, altPath) as string | undefined
+      if (currentAlt) return
+      handleChange(altPath, altText)
+    },
+  })
 
   return (
     <Box as={FormControl} isRequired={required} isInvalid={!!errors}>
@@ -55,7 +87,35 @@ function JsonFormsImageControl({
           }
           siteId={siteId}
           resourceId={(pageId ?? linkId) ? String(pageId ?? linkId) : undefined}
-          setHref={(src) => handleChange(path, src)}
+          onUploadedFile={(file) => setUploadedMimeType(file.type)}
+          setHref={(src) => {
+            handleChange(path, src)
+            if (!src || !pageId || !altPath || !uploadedMimeType) return
+
+            const surroundingText = parentData
+              ? Object.entries(parentData)
+                  .filter(
+                    ([key, value]) =>
+                      !SURROUNDING_TEXT_FIELD_DENYLIST.has(key) &&
+                      typeof value === "string" &&
+                      value.trim().length > 0,
+                  )
+                  .map(([, value]) => value as string)
+                  .join(" ")
+              : undefined
+
+            generateAltText({
+              siteId,
+              pageId,
+              src,
+              mimeType: uploadedMimeType,
+              componentType:
+                typeof parentData?.type === "string"
+                  ? parentData.type
+                  : (schema.title ?? "image"),
+              surroundingText: surroundingText || undefined,
+            })
+          }}
           shouldFetchResource={true}
         />
       )}

--- a/apps/studio/src/lib/__tests__/generateAltText.test.ts
+++ b/apps/studio/src/lib/__tests__/generateAltText.test.ts
@@ -1,0 +1,111 @@
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime"
+import { ALT_TEXT_REGEX_PATTERN } from "@opengovsg/isomer-components"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Mock the Bedrock client so we can control the model's raw response without
+// hitting AWS, following the pattern in s3.test.ts.
+const sendMock = vi.fn()
+vi.mock("@aws-sdk/client-bedrock-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@aws-sdk/client-bedrock-runtime")>()
+  return {
+    ...actual,
+    BedrockRuntimeClient: vi.fn(function () {
+      return { send: sendMock }
+    }),
+  }
+})
+
+const {
+  generateAltText,
+  sanitizeAltText,
+  isAltTextGenerationSupportedForMimeType,
+} = await import("../generateAltText")
+
+const altTextRegex = new RegExp(ALT_TEXT_REGEX_PATTERN)
+
+const mockBedrockResponse = (text: string) => ({
+  output: { message: { content: [{ text }] } },
+})
+
+describe("generateAltText", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns sanitized alt text that passes ALT_TEXT_REGEX_PATTERN and contains no em dash", async () => {
+    sendMock.mockResolvedValueOnce(
+      mockBedrockResponse(
+        "Image of a queue of residents outside a community centre — waiting for vaccinations",
+      ),
+    )
+
+    const result = await generateAltText({
+      imageBytes: new Uint8Array([1, 2, 3]),
+      mimeType: "image/png",
+      context: { componentType: "image", pageTitle: "Vaccination drive" },
+    })
+
+    expect(result).not.toContain("—")
+    expect(altTextRegex.test(result)).toBe(true)
+    expect(result.toLowerCase().startsWith("image of")).toBe(false)
+  })
+
+  it("sends the image bytes and context to Bedrock via ConverseCommand", async () => {
+    sendMock.mockResolvedValueOnce(
+      mockBedrockResponse("Residents queueing outside a community centre"),
+    )
+
+    await generateAltText({
+      imageBytes: new Uint8Array([1, 2, 3]),
+      mimeType: "image/jpeg",
+      context: { componentType: "image", pageTitle: "Vaccination drive" },
+    })
+
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    const command = sendMock.mock.calls[0]?.[0] as ConverseCommand
+    expect(command).toBeInstanceOf(ConverseCommand)
+    expect(command.input.messages?.[0]?.content?.[0]?.image?.format).toBe(
+      "jpeg",
+    )
+  })
+
+  it("throws for an unsupported MIME type instead of calling Bedrock", async () => {
+    await expect(
+      generateAltText({
+        imageBytes: new Uint8Array([1, 2, 3]),
+        mimeType: "image/svg+xml",
+        context: { componentType: "image" },
+      }),
+    ).rejects.toThrow(/unsupported/i)
+
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("sanitizeAltText", () => {
+  it("strips generic prefixes, quotes, and em dashes", () => {
+    const result = sanitizeAltText(
+      '"Photo of a sunset over the harbour — taken at dusk"',
+    )
+
+    expect(result).not.toContain("—")
+    expect(result.toLowerCase().startsWith("photo of")).toBe(false)
+    expect(altTextRegex.test(result)).toBe(true)
+  })
+})
+
+describe("isAltTextGenerationSupportedForMimeType", () => {
+  it("supports the four raster formats Bedrock's Converse API accepts", () => {
+    expect(isAltTextGenerationSupportedForMimeType("image/png")).toBe(true)
+    expect(isAltTextGenerationSupportedForMimeType("image/jpeg")).toBe(true)
+    expect(isAltTextGenerationSupportedForMimeType("image/gif")).toBe(true)
+    expect(isAltTextGenerationSupportedForMimeType("image/webp")).toBe(true)
+  })
+
+  it("rejects formats Bedrock can't accept as an image block", () => {
+    expect(isAltTextGenerationSupportedForMimeType("image/svg+xml")).toBe(false)
+    expect(isAltTextGenerationSupportedForMimeType("image/bmp")).toBe(false)
+    expect(isAltTextGenerationSupportedForMimeType("image/avif")).toBe(false)
+  })
+})

--- a/apps/studio/src/lib/generateAltText.ts
+++ b/apps/studio/src/lib/generateAltText.ts
@@ -1,0 +1,159 @@
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from "@aws-sdk/client-bedrock-runtime"
+
+// TODO(isomer): confirm this region and model ID against the models this AWS
+// account actually has Bedrock access enabled for — Claude vision models on
+// Bedrock are only served from a subset of regions, and access is granted
+// per-model per-account. If these need to be configurable per-environment,
+// add them to ~/env.mjs following the pattern of the other AWS clients
+// (e.g. R2_ACCOUNT_ID in ~/lib/s3.ts) rather than reading process.env
+// directly here.
+const BEDROCK_REGION = "ap-southeast-1"
+const BEDROCK_ALT_TEXT_MODEL_ID =
+  "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+const client = new BedrockRuntimeClient({ region: BEDROCK_REGION })
+
+const EM_DASH = "—"
+
+// Matches the model prefacing its answer the way we explicitly tell it not
+// to. Kept as a code-level safety net (not just a prompt instruction) since
+// these are the patterns that most visibly read as AI-generated.
+const GENERIC_PREFIX_PATTERNS = [
+  /^(this\s+is\s+)?(an?\s+)?image\s+of\s+/i,
+  /^(this\s+is\s+)?(an?\s+)?picture\s+of\s+/i,
+  /^(this\s+is\s+)?(an?\s+)?photo(graph)?\s+of\s+/i,
+]
+
+const SURROUNDING_TEXT_MAX_LENGTH = 500
+
+export interface GenerateAltTextContext {
+  pageTitle?: string
+  componentType: string
+  surroundingText?: string
+}
+
+export interface GenerateAltTextInput {
+  imageBytes: Uint8Array
+  mimeType: string
+  context: GenerateAltTextContext
+}
+
+// Bedrock's Converse API only accepts these four raster formats. Callers
+// should skip generation entirely (not call this function) for anything
+// else, e.g. SVG, BMP, AVIF.
+const BEDROCK_IMAGE_FORMATS_BY_MIME_TYPE: Record<
+  string,
+  "png" | "jpeg" | "gif" | "webp"
+> = {
+  "image/png": "png",
+  "image/jpeg": "jpeg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+}
+
+export const isAltTextGenerationSupportedForMimeType = (
+  mimeType: string,
+): boolean => mimeType in BEDROCK_IMAGE_FORMATS_BY_MIME_TYPE
+
+const SYSTEM_PROMPT = `You write alt text for images on Singapore government websites built with Isomer.
+
+Before writing, silently classify the image as exactly one of:
+- decorative: adds visual interest only, carries no information a reader needs
+- informative: conveys information relevant to the page content
+- functional-icon-link: acts as a control or link (e.g. a social media icon, a download icon)
+- text-heavy-infographic: contains text or data that is central to its meaning (e.g. a chart, a poster, a scanned document)
+
+The classification changes what you write, not whether you write it. Every image gets real, non-empty alt text — there is no such thing as skippable alt text in this system, even for decorative images. For a decorative image, describe it briefly and neutrally rather than inventing significance it doesn't have.
+
+Alt text must explain why the image is on this page, not just catalogue what is visible in it. Use the page title, the component/block type, and any surrounding text you are given to infer that purpose. For a text-heavy infographic, summarise the point it is making rather than transcribing every label.
+
+Write in plain, professional prose, in the same register as the rest of a Singapore government website.
+
+Never do any of the following, because each one reads as obviously AI-generated and undermines trust in the page:
+- Start with "Image of", "Picture of", or "Photo of"
+- Use an em dash (—)
+- Use "Label: description" colon-templating (e.g. "Chart: quarterly revenue")
+- Use SEO or keyword-stuffing language
+- Add commentary, caveats, or a description of your own reasoning
+
+Respond with only the finished alt text. No quotation marks, no preamble, no classification label.`
+
+const buildUserPrompt = ({
+  pageTitle,
+  componentType,
+  surroundingText,
+}: GenerateAltTextContext): string => {
+  const lines = [`Component type: ${componentType}`]
+  if (pageTitle) {
+    lines.push(`Page title: ${pageTitle}`)
+  }
+  if (surroundingText) {
+    lines.push(
+      `Surrounding page text: ${surroundingText.slice(0, SURROUNDING_TEXT_MAX_LENGTH)}`,
+    )
+  }
+  lines.push("Write the alt text for the attached image.")
+  return lines.join("\n")
+}
+
+export const sanitizeAltText = (rawText: string): string => {
+  let text = rawText.trim()
+
+  // Strip a single layer of wrapping quotes the model sometimes adds despite
+  // being told not to.
+  text = text.replace(/^["'“]+|["'”]+$/g, "").trim()
+
+  for (const pattern of GENERIC_PREFIX_PATTERNS) {
+    text = text.replace(pattern, "")
+  }
+
+  // Em dashes read as an obvious AI tell — replace rather than reject so a
+  // single em dash never fails an otherwise-good suggestion outright.
+  text = text.replaceAll(EM_DASH, ", ")
+
+  return text.replace(/\s+/g, " ").trim()
+}
+
+export const generateAltText = async ({
+  imageBytes,
+  mimeType,
+  context,
+}: GenerateAltTextInput): Promise<string> => {
+  const format = BEDROCK_IMAGE_FORMATS_BY_MIME_TYPE[mimeType]
+  if (!format) {
+    throw new Error(
+      `Unsupported image MIME type for alt text generation: ${mimeType}`,
+    )
+  }
+
+  const response = await client.send(
+    new ConverseCommand({
+      modelId: BEDROCK_ALT_TEXT_MODEL_ID,
+      system: [{ text: SYSTEM_PROMPT }],
+      messages: [
+        {
+          role: "user",
+          content: [
+            { image: { format, source: { bytes: imageBytes } } },
+            { text: buildUserPrompt(context) },
+          ],
+        },
+      ],
+      inferenceConfig: { maxTokens: 200, temperature: 0.3 },
+    }),
+  )
+
+  const rawText = response.output?.message?.content
+    ?.map((block) => block.text ?? "")
+    .join("")
+    .trim()
+
+  if (!rawText) {
+    throw new Error("Bedrock returned no alt text content")
+  }
+
+  return sanitizeAltText(rawText)
+}

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -20,6 +20,11 @@ export const IS_AUDIT_LOG_ENABLED_FEATURE_KEY = "is-audit-log-enabled"
 // When ON: gazette ingestion is routed to SearchSG instead.
 export const ENABLE_SEARCHSG_GAZETTE_INGESTION =
   "enable-searchsg-gazette-ingestion"
+// Gates the live Bedrock call in generateAltText.ts. OFF by default so the
+// AI-suggestion feature can be rolled out per-environment/site without a
+// code change.
+export const ENABLE_AI_ALT_TEXT_GENERATION_FEATURE_KEY =
+  "enable-ai-alt-text-generation"
 
 export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
 

--- a/apps/studio/src/schemas/image.ts
+++ b/apps/studio/src/schemas/image.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+import { basePageSchema } from "~/schemas/page"
+
+export const generateAltTextSchema = basePageSchema.extend({
+  src: z.string({ error: "Missing image path" }),
+  mimeType: z.string({ error: "Missing image MIME type" }),
+  componentType: z.string({ error: "Missing component type" }),
+  surroundingText: z.string().optional(),
+})
+export type GenerateAltTextInput = z.infer<typeof generateAltTextSchema>

--- a/apps/studio/src/server/modules/_app.ts
+++ b/apps/studio/src/server/modules/_app.ts
@@ -9,6 +9,7 @@ import { authRouter } from "./auth/auth.router"
 import { collectionRouter } from "./collection/collection.router"
 import { folderRouter } from "./folder/folder.router"
 import { gazetteRouter } from "./gazette/gazette.router"
+import { imageRouter } from "./image/image.router"
 import { meRouter } from "./me/me.router"
 import { pageRouter } from "./page/page.router"
 import { redirectRouter } from "./redirect/redirect.router"
@@ -28,6 +29,7 @@ export const appRouter = router({
   folder: folderRouter,
   collection: collectionRouter,
   gazette: gazetteRouter,
+  image: imageRouter,
   site: siteRouter,
   redirect: redirectRouter,
   resource: resourceRouter,

--- a/apps/studio/src/server/modules/image/image.router.ts
+++ b/apps/studio/src/server/modules/image/image.router.ts
@@ -1,0 +1,53 @@
+import { ENABLE_AI_ALT_TEXT_GENERATION_FEATURE_KEY } from "~/lib/growthbook"
+import { generateAltTextSchema } from "~/schemas/image"
+import { protectedProcedure, router } from "~/server/trpc"
+
+import { db } from "../database"
+import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
+import { getFullPageById } from "../resource/resource.service"
+import { generateAltTextForUploadedImage } from "./image.service"
+
+export const imageRouter = router({
+  generateAltText: protectedProcedure
+    .input(generateAltTextSchema)
+    // Arbitrary: bounds cost/latency exposure to the vision model per user.
+    // Editors upload images one at a time, so this comfortably covers normal
+    // use while still limiting abuse.
+    .meta({ rateLimitOptions: { max: 20, windowMs: 60_000 } })
+    .mutation(
+      async ({
+        ctx,
+        input: {
+          siteId,
+          pageId,
+          src,
+          mimeType,
+          componentType,
+          surroundingText,
+        },
+      }) => {
+        if (!ctx.gb.isOn(ENABLE_AI_ALT_TEXT_GENERATION_FEATURE_KEY)) {
+          return { altText: undefined }
+        }
+
+        await bulkValidateUserPermissionsForResources({
+          siteId,
+          action: "read",
+          userId: ctx.user.id,
+        })
+
+        const page = await getFullPageById(db, { resourceId: pageId, siteId })
+
+        const altText = await generateAltTextForUploadedImage({
+          src,
+          mimeType,
+          componentType,
+          surroundingText,
+          pageTitle: page?.title,
+          logger: ctx.logger,
+        })
+
+        return { altText }
+      },
+    ),
+})

--- a/apps/studio/src/server/modules/image/image.service.ts
+++ b/apps/studio/src/server/modules/image/image.service.ts
@@ -1,0 +1,53 @@
+import {
+  generateAltText,
+  isAltTextGenerationSupportedForMimeType,
+} from "~/lib/generateAltText"
+import { ASSETS_BASE_URL } from "~/utils/generateAssetUrl"
+
+import type { Logger } from "@isomer/logging"
+
+interface GenerateAltTextForUploadedImageParams {
+  src: string
+  mimeType: string
+  pageTitle?: string
+  componentType: string
+  surroundingText?: string
+  logger: Logger<string>
+}
+
+// Returns `undefined` (rather than throwing) whenever a usable suggestion
+// can't be produced — this is a best-effort assist that pre-fills a field the
+// editor can always fill in themselves, so a model/network hiccup should
+// never surface as an error in the page editor.
+export const generateAltTextForUploadedImage = async ({
+  src,
+  mimeType,
+  pageTitle,
+  componentType,
+  surroundingText,
+  logger,
+}: GenerateAltTextForUploadedImageParams): Promise<string | undefined> => {
+  if (!isAltTextGenerationSupportedForMimeType(mimeType)) {
+    return undefined
+  }
+
+  try {
+    const response = await fetch(`${ASSETS_BASE_URL}${src}`)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch uploaded image: ${response.status}`)
+    }
+    const imageBytes = new Uint8Array(await response.arrayBuffer())
+
+    return await generateAltText({
+      imageBytes,
+      mimeType,
+      context: { pageTitle, componentType, surroundingText },
+    })
+  } catch (error) {
+    logger.error(
+      { error, merged: { src, mimeType, componentType } },
+      "Failed to generate AI alt text suggestion",
+    )
+    return undefined
+  }
+}

--- a/packages/components/src/interfaces/complex/index.ts
+++ b/packages/components/src/interfaces/complex/index.ts
@@ -10,6 +10,7 @@ export { IframeSchema, type IframeProps } from "./Iframe"
 export {
   generateImageSrcSchema,
   ImageSrcSchema,
+  ALT_TEXT_REGEX_PATTERN,
   AltTextSchema,
   ImageSchema,
   type ImageProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ catalogs:
     '@aws-sdk/client-amplify':
       specifier: ^3.1103.0
       version: 3.1107.0
+    '@aws-sdk/client-bedrock-runtime':
+      specifier: ^3.1103.0
+      version: 3.1121.0
     '@aws-sdk/client-cloudfront':
       specifier: ^3.1103.0
       version: 3.1107.0
@@ -673,6 +676,9 @@ importers:
       '@atlaskit/pragmatic-drag-and-drop-hitbox':
         specifier: catalog:atlaskitPragmaticDnd
         version: 2.0.0
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: catalog:aws-sdk
+        version: 3.1121.0
       '@aws-sdk/client-codebuild':
         specifier: catalog:aws-sdk
         version: 3.1107.0
@@ -1036,7 +1042,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1078,7 +1084,7 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 4.1.10(vitest@4.1.10)
@@ -1099,7 +1105,7 @@ importers:
         version: 11.0.0
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
@@ -1129,7 +1135,7 @@ importers:
         version: 8.5.26
       postcss-load-config:
         specifier: 'catalog:'
-        version: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3)
+        version: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3)
       start-server-and-test:
         specifier: 'catalog:'
         version: 3.0.12
@@ -1150,10 +1156,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+        version: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       webpack-cli:
         specifier: 'catalog:'
         version: 7.2.2(js-yaml@4.3.1)(json5@2.2.3)(webpack@5.105.4)
@@ -1278,7 +1284,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1287,7 +1293,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-vite':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1305,10 +1311,10 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitejs/plugin-react':
         specifier: catalog:vitest
-        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 4.1.10(vitest@4.1.10)
@@ -1323,7 +1329,7 @@ importers:
         version: 18.1.0
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
@@ -1371,10 +1377,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -2040,6 +2046,10 @@ packages:
     resolution: {integrity: sha512-u6elpUUbLeecjVZcMY/vKYrjteiLQzAeDr8T0ej1kGetbPujXE1eTWUAJ7bqk/SCCX0GUpqqnVOIZmU/P1NPCA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-bedrock-runtime@3.1121.0':
+    resolution: {integrity: sha512-fSMUxttOVPfPkIDrrPO1IqDVK83/0yAKUYweEYsR8IayFRB2z/yvdGzTom7ZtgKH+97j8JKHSYIqM2t8qEZpSA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cloudfront@3.1107.0':
     resolution: {integrity: sha512-4S2xh0hQhQ9AqQg96o/zWmTrQ7qaqb1upjZTW+w1WSW7npy/V2I+usg7T6Xy/xL7+W05a3hqgebi6C+ceveGKQ==}
     engines: {node: '>=20.0.0'}
@@ -2056,6 +2066,10 @@ packages:
     resolution: {integrity: sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.66':
     resolution: {integrity: sha512-i4HTkP21eHaXA+XKoc6dYxlKPvYUqbusGGIsFRcSGTF8ln/q6RrWoRdVJ6UVODTCW59Ot1mVcbJXRAEf6kxa3w==}
     engines: {node: '>=20.0.0'}
@@ -2064,36 +2078,72 @@ packages:
     resolution: {integrity: sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.69':
     resolution: {integrity: sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.973.12':
     resolution: {integrity: sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.74':
     resolution: {integrity: sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.78':
     resolution: {integrity: sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.67':
     resolution: {integrity: sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.973.11':
     resolution: {integrity: sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.73':
     resolution: {integrity: sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-providers@3.1107.0':
     resolution: {integrity: sha512-f25hUOdz23Xsi2tzxMnyfIpR98CgX9ilCI/mkc2rZFJex5E+KXc7UdQiOgOnPkE2saKQJvUh9/0564uUeXJj1g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.34':
+    resolution: {integrity: sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/lib-storage@3.1108.0':
@@ -2102,12 +2152,24 @@ packages:
     peerDependencies:
       '@aws-sdk/client-s3': ^3.1108.0
 
+  '@aws-sdk/middleware-eventstream@3.972.29':
+    resolution: {integrity: sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-s3@3.972.72':
     resolution: {integrity: sha512-lSAoVPvQxX1d8TOM6waKDBQrvvZcm4w6pCldFAsRUffEaXq6lYY0pPyew3KlLu6Xqb74DXI42hGvSsbGBLljlw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-websocket@3.972.52':
+    resolution: {integrity: sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==}
+    engines: {node: '>= 14.0.0'}
+
   '@aws-sdk/nested-clients@3.997.41':
     resolution: {integrity: sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1107.0':
@@ -2118,16 +2180,36 @@ packages:
     resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1103.0':
     resolution: {integrity: sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1121.0':
+    resolution: {integrity: sha512-kyRVbJnFDDHDqPzgNzQdXyj2P3ANq2LQyg65o9IvQnuqiNrsP1zK+fDe5BzT0xKVnvAAGhmqzd5cvdzWP69Sfg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.2':
     resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/xml-builder@3.972.37':
     resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -6151,12 +6233,24 @@ packages:
     resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.16':
     resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.13':
     resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.9.13':
@@ -6169,6 +6263,10 @@ packages:
 
   '@smithy/types@4.16.1':
     resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
     engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.1.0':
@@ -9442,6 +9540,7 @@ packages:
   isomorphic-dompurify@3.21.0:
     resolution: {integrity: sha512-Bg5mqtMnMdBBwz7MjvH3oAuLOA/j0xtawVkcAZsOpVhOsfaLYwnAvhEvz94f8585Q6LCnnNr2XNApbXlB0J3GQ==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    deprecated: Raised the minimum Node.js version (breaking) without a major bump. Use 4.x for the same code with correct semver, or pin 3.19.0 for Node < 22.22.2.
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -12949,6 +13048,21 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-bedrock-runtime@3.1121.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/eventstream-handler-node': 3.972.34
+      '@aws-sdk/middleware-eventstream': 3.972.29
+      '@aws-sdk/middleware-websocket': 3.972.52
+      '@aws-sdk/token-providers': 3.1121.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-cloudfront@3.1107.0':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -12996,6 +13110,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.66':
     dependencies:
       '@aws-sdk/nested-clients': 3.997.41
@@ -13012,6 +13137,14 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.69':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -13020,6 +13153,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.13
       '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.973.12':
@@ -13038,6 +13181,22 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.74':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -13045,6 +13204,15 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.78':
@@ -13061,12 +13229,34 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.67':
     dependencies:
       '@aws-sdk/core': 3.977.6
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.973.11':
@@ -13079,6 +13269,16 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.73':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -13086,6 +13286,15 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-providers@3.1107.0':
@@ -13107,6 +13316,13 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/eventstream-handler-node@3.972.34':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/lib-storage@3.1108.0(@aws-sdk/client-s3@3.1107.0)':
     dependencies:
       '@aws-sdk/client-s3': 3.1107.0
@@ -13115,6 +13331,13 @@ snapshots:
       buffer: 5.6.0
       events: 3.3.0
       stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.29':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.72':
@@ -13126,6 +13349,16 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-websocket@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.997.41':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -13135,6 +13368,17 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.13
       '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/s3-request-presigner@3.1107.0':
@@ -13153,6 +13397,13 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1103.0':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -13162,14 +13413,42 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1121.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.974.2':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.37':
     dependencies:
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
@@ -15854,11 +16133,11 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -17030,6 +17309,11 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.16':
     dependencies:
       '@smithy/core': 3.31.1
@@ -17040,6 +17324,18 @@ snapshots:
     dependencies:
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.9.13':
@@ -17058,6 +17354,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -17068,10 +17368,10 @@ snapshots:
       axe-core: 4.11.1
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17087,10 +17387,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17119,12 +17419,12 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -17162,24 +17462,24 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.60.1
-      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)(webpack-cli@7.2.2)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.60.1
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)
 
   '@storybook/global@5.0.0': {}
@@ -17297,11 +17597,11 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -17311,7 +17611,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -18086,10 +18386,23 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+
+  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
 
   '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
@@ -18103,14 +18416,32 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
-  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -18133,17 +18464,18 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
-  '@vitest/browser@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
@@ -18163,7 +18495,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -18184,6 +18516,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -18193,14 +18534,14 @@ snapshots:
       msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
       vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -22330,11 +22671,11 @@ snapshots:
       tsx: 4.23.11
       yaml: 2.8.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.7.0
+      jiti: 1.21.7
       postcss: 8.5.26
       tsx: 4.23.11
       yaml: 2.8.3
@@ -24323,6 +24664,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.102.0
+      terser: 5.46.1
+      tsx: 4.23.11
+      yaml: 2.8.3
+
   vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
@@ -24340,7 +24698,7 @@ snapshots:
       tsx: 4.23.11
       yaml: 2.8.3
 
-  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3):
+  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -24351,11 +24709,43 @@ snapshots:
       '@types/node': 26.2.0
       esbuild: 0.28.1
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.7.0
       sass: 1.102.0
       terser: 5.46.1
       tsx: 4.23.11
       yaml: 2.8.3
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.2
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.10.6
+      jsdom: 30.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)):
     dependencies:
@@ -24389,10 +24779,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -24409,12 +24799,12 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.2.0
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
       happy-dom: 20.10.6
       jsdom: 30.0.1(@noble/hashes@2.2.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -176,6 +176,7 @@ catalogs:
   "aws-sdk":
     "@aws-sdk/client-acm": ^3.1103.0
     "@aws-sdk/client-amplify": ^3.1103.0
+    "@aws-sdk/client-bedrock-runtime": ^3.1103.0
     "@aws-sdk/client-cloudfront": ^3.1103.0
     "@aws-sdk/client-codebuild": ^3.1103.0
     "@aws-sdk/client-s3": ^3.1103.0


### PR DESCRIPTION
## Problem

Editors currently must type alt text by hand for every image. The only guardrail is `AltTextSchema`'s regex, which rejects empty values and a handful of generic terms ("image", "logo", "screenshot", etc.) but never suggests real content. In practice this fails silently: a live MOH page today has the literal string "This is the alt text" saved on three images in an Image Gallery, because the editor just needed to satisfy the required field.

No linked issue — this was scoped directly from a product/design conversation about that failure mode.

## Solution

Wires a real vision-model call through AWS Bedrock (Claude) that fires automatically the instant an image is attached in the page editor, pre-filling the Alternate text field with a draft description. The editor can still review, edit, or fully replace it before saving — nothing is auto-persisted.

The model is given the image plus page/component context (page title, component type, and any sibling text already on the block) and is instructed to first classify the image (decorative / informative / functional icon-link / text-heavy infographic) so the wording matches *why* the image is on the page, not just what's in it. Output style is constrained against common AI writing tells: no em dashes, no "Label: description" colon-templating, no SEO language, no "image of"/"picture of" prefixes — both via prompt instructions and a code-level sanitizer as a backstop.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Automatic alt-text suggestion on image upload in the page editor (`JsonFormsImageControl.tsx`), gated behind a new GrowthBook flag (`enable-ai-alt-text-generation`) so it can be rolled out per-environment/site.
- New `generateAltText` tRPC mutation (`server/modules/image/`) that fetches the uploaded image server-side and calls Bedrock's Converse API with a Claude model.

**Improvements**:

- Exported `ALT_TEXT_REGEX_PATTERN` from `@opengovsg/isomer-components`'s public surface (previously internal-only) so Studio's unit tests can assert generated suggestions actually satisfy it.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

Alternate text stays empty/placeholder after an image is attached — the editor must type it manually with no guidance.

**AFTER**:

Alternate text pre-fills with a generated suggestion a few seconds after the image is attached, still fully editable.

## Tests

Unit test added: `apps/studio/src/lib/__tests__/generateAltText.test.ts` — mocks the Bedrock client and asserts the sanitizer/output never contains an em dash, strips "image of"/"picture of" prefixes, and satisfies `ALT_TEXT_REGEX_PATTERN`, plus asserts unsupported MIME types (SVG/BMP/AVIF) are rejected before any Bedrock call.

**Manual Verification Steps**:

- [ ] Enable the `enable-ai-alt-text-generation` GrowthBook flag for your test account/site.
- [ ] In the Studio page editor, add or edit a component with an image field (e.g. Image, Image Gallery, Hero) and upload a new JPG/PNG/GIF/WEBP image.
- [ ] Confirm the Alternate text field shows a brief "suggesting" state and then fills in with a generated description within a few seconds, without the page auto-saving.
- [ ] Edit the suggested text and confirm your edit sticks (isn't overwritten) and saves normally.
- [ ] Upload an SVG (or BMP/AVIF) image and confirm no suggestion is attempted and no error is shown — Alternate text just stays manual as it does today.
- [ ] Disable the GrowthBook flag and confirm uploading an image no longer triggers any suggestion (current behavior is unchanged).

**New scripts**:

- None.

**New dependencies**:

- `@aws-sdk/client-bedrock-runtime` : AWS SDK client used to call the Bedrock Converse API for alt-text generation.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds feature-flagged AI alt-text generation to Studio image uploads, including a Bedrock-backed tRPC endpoint, output sanitization, and shared alt-text validation exports.

- Sends uploaded raster images and page/component context to Bedrock.
- Prefills the sibling alt field while attempting to preserve editor-entered text.
- Adds MIME-format and sanitizer unit coverage.
- The current upload callback loses the first file's MIME type, generation responses can be applied to a newer image, and asset ownership is not bound to the authorized site.
</details>


<details><summary><h3>Confidence Score: 1/5</h3></summary>

The PR is not safe to merge until upload callback state, stale generation responses, cross-site asset validation, and the explicit server-module rule violation are addressed.

The primary feature skips generation on the first upload, can attach a prior image's description to a replacement image, and allows the authorized site ID and fetched asset owner to diverge; generated output can also violate the form's own alt-text schema.

**Files Needing Attention:** apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx, apps/studio/src/server/modules/image/image.router.ts, apps/studio/src/server/modules/image/image.service.ts, apps/studio/src/lib/generateAltText.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

The new endpoint authorizes the supplied site independently from the supplied asset path. Because the asset path is not checked against that site before fetching and processing it, an authorized editor can cause another site's known asset to be submitted to Bedrock.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx | Adds upload-triggered generation, but stale callback state skips the first request and uncorrelated responses can update the wrong image. |
| apps/studio/src/server/modules/image/image.router.ts | Adds a flagged, rate-limited endpoint with site authorization, but does not bind the requested asset to that site and places page lookup logic in the router. |
| apps/studio/src/server/modules/image/image.service.ts | Fetches and processes uploaded assets on a best-effort basis, but trusts the caller-provided asset path. |
| apps/studio/src/lib/generateAltText.ts | Implements the Bedrock request and style sanitizer, but does not validate sanitized output against the actual alt-text schema. |
| apps/studio/src/lib/__tests__/generateAltText.test.ts | Covers Bedrock request construction, MIME support, and basic sanitization but not schema-invalid post-sanitization output. |
| packages/components/src/interfaces/complex/index.ts | Safely exposes the existing alt-text regex through the package's public interface. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor Editor
  participant Form as Image form control
  participant API as generateAltText tRPC
  participant Assets as Asset host
  participant Bedrock

  Editor->>Form: Upload image
  Form->>Form: Update src
  Form->>API: siteId, pageId, src, MIME, context
  API->>API: Check feature flag and site permission
  API->>Assets: Fetch caller-supplied src
  Assets-->>API: Image bytes
  API->>Bedrock: Image and page context
  Bedrock-->>API: Suggested alt text
  API-->>Form: Sanitized suggestion
  Form->>Form: Populate alt if currently empty
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233348%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3348&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsImageControl.tsx%3A90-93%0A**Upload%20uses%20stale%20MIME**%0A%0A%60onUploadedFile%60%20updates%20%60uploadedMimeType%60%20through%20React%20state%2C%20but%20%60FileAttachment%60%20later%20invokes%20the%20%60setHref%60%20callback%20captured%20before%20that%20update.%20The%20first%20upload%20therefore%20sees%20an%20undefined%20MIME%20type%20and%20skips%20alt-text%20generation.%20Later%20uploads%20can%20use%20the%20previous%20file's%20MIME%20type%2C%20causing%20generation%20to%20be%20skipped%20or%20sending%20Bedrock%20the%20wrong%20image%20format.%20Pass%20the%20uploaded%20MIME%20type%20through%20the%20upload%20result%20or%20keep%20it%20in%20a%20ref%20instead%20of%20relying%20on%20a%20later%20render.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsImageControl.tsx%3A64-71%0A**Stale%20response%20updates%20image**%0A%0AGeneration%20responses%20are%20not%20matched%20to%20the%20current%20image%20source.%20An%20editor%20can%20remove%20image%20A%20and%20upload%20image%20B%20while%20A's%20Bedrock%20request%20is%20pending.%20If%20A%20then%20finishes%20while%20the%20alt%20field%20is%20empty%2C%20its%20description%20is%20written%20for%20image%20B.%20Compare%20the%20mutation's%20source%20with%20the%20current%20source%2C%20or%20cancel%20and%20ignore%20requests%20superseded%20by%20a%20later%20upload.%0A%0A%23%23%23%20Issue%203%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fimage%2Fimage.service.ts%3A35%0A**Asset%20ownership%20is%20unchecked**%0A%0AThe%20endpoint%20authorizes%20access%20to%20%60siteId%60%2C%20but%20accepts%20an%20arbitrary%20%60src%60%20and%20fetches%20it%20without%20confirming%20that%20the%20asset%20belongs%20to%20that%20site.%20A%20user%20who%20can%20access%20site%20A%20and%20knows%20an%20asset%20path%20for%20site%20B%20can%20make%20Studio%20fetch%20site%20B's%20image%2C%20submit%20it%20to%20Bedrock%2C%20and%20return%20its%20generated%20description.%20Validate%20the%20asset%20key%20against%20%60siteId%60%20before%20fetching%20it.%0A%0A**How%20this%20was%20verified%3A**%20Asset%20keys%20are%20site-prefixed%2C%20but%20the%20caller-controlled%20path%20reaches%20the%20asset%20fetch%20after%20authorization%20checks%20only%20for%20the%20separately%20supplied%20site%20ID.%0A%0A%23%23%23%20Issue%204%0Aapps%2Fstudio%2Fsrc%2Flib%2FgenerateAltText.ts%3A102-118%0A**Sanitized%20output%20remains%20invalid**%0A%0AThe%20sanitized%20response%20is%20written%20into%20the%20form%20without%20being%20checked%20against%20%60AltTextSchema%60.%20For%20example%2C%20%60Image%20of%20chart%60%20becomes%20the%20non-empty%20value%20%60chart%60%2C%20which%20the%20shared%20alt-text%20regex%20rejects.%20This%20automatically%20leaves%20the%20editor%20with%20an%20invalid%20required%20field.%20Validate%20the%20sanitized%20result%20against%20the%20shared%20schema%20and%20discard%20or%20retry%20invalid%20responses.%0A%0A%23%23%23%20Issue%205%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fimage%2Fimage.router.ts%3A39-47%0A**Router%20contains%20business%20logic**%0A%0AThe%20repository's%20server-module%20directive%20requires%20tRPC%20routers%20to%20contain%20endpoint%20wiring%20only%2C%20while%20services%20own%20business%20logic%20and%20database%20queries.%20This%20mutation%20performs%20the%20page%20lookup%20and%20derives%20model%20context%20inside%20the%20router%20callback.%20Move%20that%20work%20into%20the%20image%20service%3B%20this%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsImageControl.tsx%3A90-93%0A**Upload%20uses%20stale%20MIME**%0A%0A%60onUploadedFile%60%20updates%20%60uploadedMimeType%60%20through%20React%20state%2C%20but%20%60FileAttachment%60%20later%20invokes%20the%20%60setHref%60%20callback%20captured%20before%20that%20update.%20The%20first%20upload%20therefore%20sees%20an%20undefined%20MIME%20type%20and%20skips%20alt-text%20generation.%20Later%20uploads%20can%20use%20the%20previous%20file's%20MIME%20type%2C%20causing%20generation%20to%20be%20skipped%20or%20sending%20Bedrock%20the%20wrong%20image%20format.%20Pass%20the%20uploaded%20MIME%20type%20through%20the%20upload%20result%20or%20keep%20it%20in%20a%20ref%20instead%20of%20relying%20on%20a%20later%20render.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsImageControl.tsx%3A64-71%0A**Stale%20response%20updates%20image**%0A%0AGeneration%20responses%20are%20not%20matched%20to%20the%20current%20image%20source.%20An%20editor%20can%20remove%20image%20A%20and%20upload%20image%20B%20while%20A's%20Bedrock%20request%20is%20pending.%20If%20A%20then%20finishes%20while%20the%20alt%20field%20is%20empty%2C%20its%20description%20is%20written%20for%20image%20B.%20Compare%20the%20mutation's%20source%20with%20the%20current%20source%2C%20or%20cancel%20and%20ignore%20requests%20superseded%20by%20a%20later%20upload.%0A%0A%23%23%23%20Issue%203%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fimage%2Fimage.service.ts%3A35%0A**Asset%20ownership%20is%20unchecked**%0A%0AThe%20endpoint%20authorizes%20access%20to%20%60siteId%60%2C%20but%20accepts%20an%20arbitrary%20%60src%60%20and%20fetches%20it%20without%20confirming%20that%20the%20asset%20belongs%20to%20that%20site.%20A%20user%20who%20can%20access%20site%20A%20and%20knows%20an%20asset%20path%20for%20site%20B%20can%20make%20Studio%20fetch%20site%20B's%20image%2C%20submit%20it%20to%20Bedrock%2C%20and%20return%20its%20generated%20description.%20Validate%20the%20asset%20key%20against%20%60siteId%60%20before%20fetching%20it.%0A%0A**How%20this%20was%20verified%3A**%20Asset%20keys%20are%20site-prefixed%2C%20but%20the%20caller-controlled%20path%20reaches%20the%20asset%20fetch%20after%20authorization%20checks%20only%20for%20the%20separately%20supplied%20site%20ID.%0A%0A%23%23%23%20Issue%204%0Aapps%2Fstudio%2Fsrc%2Flib%2FgenerateAltText.ts%3A102-118%0A**Sanitized%20output%20remains%20invalid**%0A%0AThe%20sanitized%20response%20is%20written%20into%20the%20form%20without%20being%20checked%20against%20%60AltTextSchema%60.%20For%20example%2C%20%60Image%20of%20chart%60%20becomes%20the%20non-empty%20value%20%60chart%60%2C%20which%20the%20shared%20alt-text%20regex%20rejects.%20This%20automatically%20leaves%20the%20editor%20with%20an%20invalid%20required%20field.%20Validate%20the%20sanitized%20result%20against%20the%20shared%20schema%20and%20discard%20or%20retry%20invalid%20responses.%0A%0A%23%23%23%20Issue%205%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fimage%2Fimage.router.ts%3A39-47%0A**Router%20contains%20business%20logic**%0A%0AThe%20repository's%20server-module%20directive%20requires%20tRPC%20routers%20to%20contain%20endpoint%20wiring%20only%2C%20while%20services%20own%20business%20logic%20and%20database%20queries.%20This%20mutation%20performs%20the%20page%20lookup%20and%20derives%20model%20context%20inside%20the%20router%20callback.%20Move%20that%20work%20into%20the%20image%20service%3B%20this%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fai-alt-text-suggestions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fai-alt-text-suggestions%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsImageControl.tsx%3A90-93%0A**Upload%20uses%20stale%20MIME**%0A%0A%60onUploadedFile%60%20updates%20%60uploadedMimeType%60%20through%20React%20state%2C%20but%20%60FileAttachment%60%20later%20invokes%20the%20%60setHref%60%20callback%20captured%20before%20that%20update.%20The%20first%20upload%20therefore%20sees%20an%20undefined%20MIME%20type%20and%20skips%20alt-text%20generation.%20Later%20uploads%20can%20use%20the%20previous%20file's%20MIME%20type%2C%20causing%20generation%20to%20be%20skipped%20or%20sending%20Bedrock%20the%20wrong%20image%20format.%20Pass%20the%20uploaded%20MIME%20type%20through%20the%20upload%20result%20or%20keep%20it%20in%20a%20ref%20instead%20of%20relying%20on%20a%20later%20render.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsImageControl.tsx%3A64-71%0A**Stale%20response%20updates%20image**%0A%0AGeneration%20responses%20are%20not%20matched%20to%20the%20current%20image%20source.%20An%20editor%20can%20remove%20image%20A%20and%20upload%20image%20B%20while%20A's%20Bedrock%20request%20is%20pending.%20If%20A%20then%20finishes%20while%20the%20alt%20field%20is%20empty%2C%20its%20description%20is%20written%20for%20image%20B.%20Compare%20the%20mutation's%20source%20with%20the%20current%20source%2C%20or%20cancel%20and%20ignore%20requests%20superseded%20by%20a%20later%20upload.%0A%0A%23%23%23%20Issue%203%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fimage%2Fimage.service.ts%3A35%0A**Asset%20ownership%20is%20unchecked**%0A%0AThe%20endpoint%20authorizes%20access%20to%20%60siteId%60%2C%20but%20accepts%20an%20arbitrary%20%60src%60%20and%20fetches%20it%20without%20confirming%20that%20the%20asset%20belongs%20to%20that%20site.%20A%20user%20who%20can%20access%20site%20A%20and%20knows%20an%20asset%20path%20for%20site%20B%20can%20make%20Studio%20fetch%20site%20B's%20image%2C%20submit%20it%20to%20Bedrock%2C%20and%20return%20its%20generated%20description.%20Validate%20the%20asset%20key%20against%20%60siteId%60%20before%20fetching%20it.%0A%0A**How%20this%20was%20verified%3A**%20Asset%20keys%20are%20site-prefixed%2C%20but%20the%20caller-controlled%20path%20reaches%20the%20asset%20fetch%20after%20authorization%20checks%20only%20for%20the%20separately%20supplied%20site%20ID.%0A%0A%23%23%23%20Issue%204%0Aapps%2Fstudio%2Fsrc%2Flib%2FgenerateAltText.ts%3A102-118%0A**Sanitized%20output%20remains%20invalid**%0A%0AThe%20sanitized%20response%20is%20written%20into%20the%20form%20without%20being%20checked%20against%20%60AltTextSchema%60.%20For%20example%2C%20%60Image%20of%20chart%60%20becomes%20the%20non-empty%20value%20%60chart%60%2C%20which%20the%20shared%20alt-text%20regex%20rejects.%20This%20automatically%20leaves%20the%20editor%20with%20an%20invalid%20required%20field.%20Validate%20the%20sanitized%20result%20against%20the%20shared%20schema%20and%20discard%20or%20retry%20invalid%20responses.%0A%0A%23%23%23%20Issue%205%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fimage%2Fimage.router.ts%3A39-47%0A**Router%20contains%20business%20logic**%0A%0AThe%20repository's%20server-module%20directive%20requires%20tRPC%20routers%20to%20contain%20endpoint%20wiring%20only%2C%20while%20services%20own%20business%20logic%20and%20database%20queries.%20This%20mutation%20performs%20the%20page%20lookup%20and%20derives%20model%20context%20inside%20the%20router%20callback.%20Move%20that%20work%20into%20the%20image%20service%3B%20this%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx:90-93
**Upload uses stale MIME**

`onUploadedFile` updates `uploadedMimeType` through React state, but `FileAttachment` later invokes the `setHref` callback captured before that update. The first upload therefore sees an undefined MIME type and skips alt-text generation. Later uploads can use the previous file's MIME type, causing generation to be skipped or sending Bedrock the wrong image format. Pass the uploaded MIME type through the upload result or keep it in a ref instead of relying on a later render.

### Issue 2
apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx:64-71
**Stale response updates image**

Generation responses are not matched to the current image source. An editor can remove image A and upload image B while A's Bedrock request is pending. If A then finishes while the alt field is empty, its description is written for image B. Compare the mutation's source with the current source, or cancel and ignore requests superseded by a later upload.

### Issue 3
apps/studio/src/server/modules/image/image.service.ts:35
**Asset ownership is unchecked**

The endpoint authorizes access to `siteId`, but accepts an arbitrary `src` and fetches it without confirming that the asset belongs to that site. A user who can access site A and knows an asset path for site B can make Studio fetch site B's image, submit it to Bedrock, and return its generated description. Validate the asset key against `siteId` before fetching it.

**How this was verified:** Asset keys are site-prefixed, but the caller-controlled path reaches the asset fetch after authorization checks only for the separately supplied site ID.

### Issue 4
apps/studio/src/lib/generateAltText.ts:102-118
**Sanitized output remains invalid**

The sanitized response is written into the form without being checked against `AltTextSchema`. For example, `Image of chart` becomes the non-empty value `chart`, which the shared alt-text regex rejects. This automatically leaves the editor with an invalid required field. Validate the sanitized result against the shared schema and discard or retry invalid responses.

### Issue 5
apps/studio/src/server/modules/image/image.router.ts:39-47
**Router contains business logic**

The repository's server-module directive requires tRPC routers to contain endpoint wiring only, while services own business logic and database queries. This mutation performs the page lookup and derives model context inside the router callback. Move that work into the image service; this repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(studio): suggest alt text automatic..."](https://github.com/opengovsg/isomer/commit/2fc1ad4b86603bce9e2816cd23b73730a3a8dc6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61156378)</sub>

> Greptile also left **5 inline comments** on this PR.

**Context used:**

- Context used - apps/studio/src/server/CLAUDE.md ([source](https://github.com/opengovsg/isomer/blob/main/apps/studio/src/server/CLAUDE.md))

<!-- /greptile_comment -->