### PR TITLE
fix(components): exclude files and links from siderail

### DIFF
--- a/packages/components/src/utils/__tests__/getSiderailFromSiteMap.test.ts
+++ b/packages/components/src/utils/__tests__/getSiderailFromSiteMap.test.ts
@@ -1,0 +1,68 @@
+import type { IsomerSitemap } from "~/types"
+import { describe, expect, it } from "vitest"
+
+import { getSiderailFromSiteMap } from "../getSiderailFromSiteMap"
+
+describe("getSiderailFromSiteMap", () => {
+  it("excludes file and link layouts from the siderail", () => {
+    const sitemap: IsomerSitemap = {
+      id: "root",
+      title: "Home",
+      permalink: "/",
+      lastModified: "",
+      layout: "homepage",
+      summary: "",
+      children: [
+        {
+          id: "collection",
+          title: "Collection",
+          permalink: "/collection",
+          lastModified: "",
+          layout: "collection",
+          summary: "",
+          children: [
+            {
+              id: "page",
+              title: "Page",
+              permalink: "/collection/page",
+              lastModified: "",
+              layout: "article",
+              summary: "",
+            },
+            {
+              id: "file",
+              title: "File",
+              permalink: "/collection/file",
+              lastModified: "",
+              layout: "file",
+              summary: "",
+              ref: "file.pdf",
+              fileDetails: { type: "PDF", size: "1 MB" },
+            },
+            {
+              id: "link",
+              title: "Link",
+              permalink: "/collection/link",
+              lastModified: "",
+              layout: "link",
+              summary: "",
+              ref: "https://example.com",
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(getSiderailFromSiteMap(sitemap, "/collection/page")).toEqual({
+      parentTitle: "Collection",
+      parentUrl: "/collection",
+      pages: [
+        {
+          title: "Page",
+          url: "/collection/page",
+          isCurrent: true,
+        },
+      ],
+    })
+  })
+})

--- a/packages/components/src/utils/__tests__/getSiderailFromSiteMap.test.ts
+++ b/packages/components/src/utils/__tests__/getSiderailFromSiteMap.test.ts
@@ -5,6 +5,7 @@ import { getSiderailFromSiteMap } from "../getSiderailFromSiteMap"
 
 describe("getSiderailFromSiteMap", () => {
   it("excludes file and link layouts from the siderail", () => {
+    // Arrange
     const sitemap: IsomerSitemap = {
       id: "root",
       title: "Home",
@@ -53,7 +54,11 @@ describe("getSiderailFromSiteMap", () => {
       ],
     }
 
-    expect(getSiderailFromSiteMap(sitemap, "/collection/page")).toEqual({
+    // Act
+    const result = getSiderailFromSiteMap(sitemap, "/collection/page")
+
+    // Assert
+    expect(result).toEqual({
       parentTitle: "Collection",
       parentUrl: "/collection",
       pages: [

--- a/packages/components/src/utils/getSiderailFromSiteMap.ts
+++ b/packages/components/src/utils/getSiderailFromSiteMap.ts
@@ -21,10 +21,12 @@ export const getSiderailFromSiteMap = (
   return {
     parentTitle: parentNode.title,
     parentUrl: parentNode.permalink,
-    pages: parentNode.children.map((sibling) => ({
-      title: sibling.title,
-      url: sibling.permalink,
-      isCurrent: sibling.permalink === permalink,
-    })),
+    pages: parentNode.children
+      .filter(({ layout }) => layout !== "file" && layout !== "link")
+      .map((sibling) => ({
+        title: sibling.title,
+        url: sibling.permalink,
+        isCurrent: sibling.permalink === permalink,
+      })),
   }
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +7 | -5 |
| 🧪 Test | 1 | +73 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem
The siderail on collection pages was listing every sibling item, including uploaded files and external links — not just actual pages. This cluttered the page navigation with entries that aren't real content pages.

## Solution
Filter out siblings with `layout: "file"` or `layout: "link"` before building the siderail's page list, so only real pages appear.

### Details
- `getSiderailFromSiteMap.ts`: added a `.filter()` step excluding `file` and `link` layouts before mapping siblings to siderail entries.
- Added a unit test covering a collection with a page, a file, and a link, asserting only the page shows up in the siderail.

### Testing
- Added `getSiderailFromSiteMap.test.ts` verifying files and links are excluded from siderail output.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61219561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with the intended filtering behavior covered by a focused regression test.

<details><summary><h3>Summary</h3></summary>

- Excludes file and external-link sitemap entries before constructing siderail items.
- Adds a focused regression test covering a page, file, and link within one collection.
</details>

<sub>Reviews (2) · Last reviewed commit: ["test(components): follow arrange act ass..."](https://github.com/opengovsg/isomer/commit/1cbf90ea9a60c22b05890faf25e6c35e755392cb)</sub>

<!-- /greptile_comment -->