### PR TITLE
refactor!: remove file page layout support

### DIFF
--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -370,57 +370,6 @@ describe("page.router", async () => {
       })
     })
 
-    it("should return prefill data for file ref page layout", async () => {
-      // Arrange
-      const fileBlob = await db
-        .insertInto("Blob")
-        .values({
-          content: jsonb({
-            layout: "file",
-            page: {
-              description: "File description text",
-              image: { src: "/images/file-thumb.png", alt: "File image" },
-            },
-            content: [],
-            version: "0.1.0",
-          }),
-        })
-        .returningAll()
-        .executeTakeFirstOrThrow()
-
-      const { site } = await setupSite()
-      const page = await db
-        .insertInto("Resource")
-        .values({
-          title: "Test File Page",
-          permalink: "test-file",
-          siteId: site.id,
-          draftBlobId: fileBlob.id,
-          type: ResourceType.Page,
-        })
-        .returningAll()
-        .executeTakeFirstOrThrow()
-
-      await setupEditorPermissions({
-        userId: session.userId ?? undefined,
-        siteId: site.id,
-      })
-
-      // Act
-      const result = await caller.getPrefill({
-        siteId: site.id,
-        resourceId: page.id,
-      })
-
-      // Assert
-      expect(result).toEqual({
-        title: "Test File Page",
-        description: "File description text",
-        thumbnail: "/images/file-thumb.png",
-        thumbnailAlt: "File image",
-      })
-    })
-
     it("should return prefill data for link ref page layout", async () => {
       // Arrange
       const linkBlob = await db

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -1,7 +1,6 @@
 import type {
   ArticlePagePageProps,
   CollectionPagePageProps,
-  FileRefPageProps,
   IsomerSitemap,
   LinkRefPageProps,
 } from "@opengovsg/isomer-components"
@@ -266,7 +265,6 @@ export const injectTagMappings = async (
 
   const childPageProps = draftBlobOfResource.content.page as
     | ArticlePagePageProps
-    | FileRefPageProps
     | LinkRefPageProps
 
   const collectionPageProps = publishedIndexBlob.content

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -184,7 +184,6 @@ const getMetaDescription = (props: GetPageJsonLdProps) => {
         props.content.find((item) => item.type === "hero")?.subtitle ||
         props.site.siteName
       )
-    case ISOMER_PAGE_LAYOUTS.File:
     case ISOMER_PAGE_LAYOUTS.Link:
     case ISOMER_PAGE_LAYOUTS.Search:
     case ISOMER_PAGE_LAYOUTS.NotFound:
@@ -211,7 +210,6 @@ const getMetaImage = (props: IsomerPageSchemaType) => {
         props.meta?.image ||
         props.content.find((item) => item.type === "hero")?.backgroundUrl
       )
-    case ISOMER_PAGE_LAYOUTS.File:
     case ISOMER_PAGE_LAYOUTS.Link:
     case ISOMER_PAGE_LAYOUTS.Search:
     case ISOMER_PAGE_LAYOUTS.NotFound:
@@ -284,7 +282,6 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
     description: getMetaDescription(props),
     robots: {
       index:
-        props.layout !== ISOMER_PAGE_LAYOUTS.File &&
         props.layout !== ISOMER_PAGE_LAYOUTS.Link &&
         props.layout !== ISOMER_PAGE_LAYOUTS.Search &&
         props.layout !== ISOMER_PAGE_LAYOUTS.NotFound &&
@@ -354,11 +351,7 @@ export const getRobotsTxt = (props: IsomerPageSchemaType) => {
 
 export const getSitemapXml = (sitemap: IsomerSitemap, siteUrl?: string) => {
   return getSitemapAsArray(sitemap)
-    .filter(
-      (item) =>
-        item.layout !== ISOMER_PAGE_LAYOUTS.File &&
-        item.layout !== ISOMER_PAGE_LAYOUTS.Link,
-    )
+    .filter((item) => item.layout !== ISOMER_PAGE_LAYOUTS.Link)
     .map(({ permalink, lastModified }) => {
       const permalinkWithTrailingSlash = permalink.endsWith("/")
         ? permalink

--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -1,10 +1,6 @@
 import type { ImageProps } from "~/interfaces"
 import type { FormattedDate, IsomerSiteProps, TagGroup } from "~/types"
 
-interface FileDetails {
-  type: string
-  size: string
-}
 interface BaseCardProps {
   // NOTE: All groups (pills + plaintext combined), used for filter matching
   // (see getFilteredItems/getTagFilters) — derived from `tagged` + `tagCategories`,
@@ -31,16 +27,11 @@ interface ArticleCardProps extends BaseCardProps {
   variant: "article"
 }
 
-export interface FileCardProps extends BaseCardProps {
-  variant: "file"
-  fileDetails: FileDetails
-}
-
 interface LinkCardProps extends BaseCardProps {
   variant: "link"
 }
 
-export type AllCardProps = ArticleCardProps | FileCardProps | LinkCardProps
+export type AllCardProps = ArticleCardProps | LinkCardProps
 
 // NOTE: This is client-side rendering and we want as much pre-processing
 // on the server as possible to improve performance + reduce file and bandwidth size

--- a/packages/components/src/schemas/__tests__/pageLayout.test.ts
+++ b/packages/components/src/schemas/__tests__/pageLayout.test.ts
@@ -1,0 +1,19 @@
+import { Value } from "@sinclair/typebox/value"
+import { describe, expect, it } from "vitest"
+import { IsomerPageSchema } from "~/types/schema"
+
+describe("page layouts", () => {
+  it("accepts file URLs through link layouts and rejects the removed file layout", () => {
+    const page = {
+      version: "0.1.0",
+      layout: "link",
+      page: { category: "Publications", ref: "https://example.com/report.pdf" },
+      content: [],
+    }
+
+    expect(Value.Check(IsomerPageSchema, page)).toBe(true)
+    expect(Value.Check(IsomerPageSchema, { ...page, layout: "file" })).toBe(
+      false,
+    )
+  })
+})

--- a/packages/components/src/schemas/__tests__/scopedSchema.test.ts
+++ b/packages/components/src/schemas/__tests__/scopedSchema.test.ts
@@ -132,19 +132,6 @@ describe("getScopedSchema", () => {
     })
   })
 
-  describe("file layout", () => {
-    it("should return schema for page", () => {
-      const schema = getScopedSchema({
-        layout: "file",
-        scope: "page",
-      })
-
-      expect(schema).toBeDefined()
-      expect(schema.type).toBe("object")
-      expect(schema.properties).toBeDefined()
-    })
-  })
-
   describe("exclude functionality", () => {
     it("should exclude specified fields from database page schema", () => {
       const schema = getScopedSchema({

--- a/packages/components/src/schemas/meta.ts
+++ b/packages/components/src/schemas/meta.ts
@@ -5,7 +5,6 @@ import {
   CollectionPageMetaSchema,
   ContentPageMetaSchema,
   DatabasePageMetaSchema,
-  FileRefMetaSchema,
   HomePageMetaSchema,
   LinkRefMetaSchema,
   NotFoundPageMetaSchema,
@@ -22,7 +21,6 @@ const LAYOUT_METADATA_MAP = {
   search: SearchPageMetaSchema,
   link: LinkRefMetaSchema,
   collection: CollectionPageMetaSchema,
-  file: FileRefMetaSchema,
 }
 
 export const getLayoutMetadataSchema = (

--- a/packages/components/src/schemas/page.ts
+++ b/packages/components/src/schemas/page.ts
@@ -4,7 +4,6 @@ import {
   CollectionPagePageSchema,
   ContentPagePageSchema,
   DatabasePagePageSchema,
-  FileRefPageSchema,
   HomePagePageSchema,
   IndexPagePageSchema,
   LinkRefPageSchema,
@@ -22,7 +21,6 @@ export const LAYOUT_PAGE_MAP = {
   search: SearchPagePageSchema,
   link: LinkRefPageSchema,
   collection: CollectionPagePageSchema,
-  file: FileRefPageSchema,
 } as const
 
 export const getLayoutPageSchema = (layout: IsomerPageLayoutType) => {

--- a/packages/components/src/schemas/scopedSchema.ts
+++ b/packages/components/src/schemas/scopedSchema.ts
@@ -6,7 +6,6 @@ import {
   CollectionPageSchema,
   ContentPageSchema,
   DatabasePageSchema,
-  FileRefSchema,
   HomePageSchema,
   IndexPageSchema,
   LinkRefSchema,
@@ -24,7 +23,6 @@ const LAYOUT_SCHEMA_MAP: Record<ScopedSchemaLayout, TSchema> = {
   index: IndexPageSchema,
   link: LinkRefSchema,
   collection: CollectionPageSchema,
-  file: FileRefSchema,
 } as const
 
 // Utility type to extract all possible dot-separated paths from an object type
@@ -62,7 +60,6 @@ interface ScopeLayoutMap {
   homepage: SchemaPathsFrom<typeof HomePageSchema>
   index: SchemaPathsFrom<typeof IndexPageSchema>
   link: SchemaPathsFrom<typeof LinkRefSchema>
-  file: SchemaPathsFrom<typeof FileRefSchema>
 }
 
 type FilterMode = "include" | "exclude"

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -27,7 +27,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       title: `This is the title for a collection item that shows the Isomer hero banner-${index}`,
       permalink: `/publications/item-two-${index}`,
       lastModified: "",
-      layout: "file",
+      layout: "link",
       image: {
         src: "https://images.unsplash.com/photo-1728931710331-7f74dca643eb?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
         alt: "placeholder",
@@ -37,7 +37,6 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       date: "07/05/2024",
       category: "Category Name",
       ref: "https://www.isomer.gov.sg/images/Homepage/hero%20banner_10.png",
-      fileDetails: { type: "png", size: "1.2MB" },
     },
     {
       id: `${index}`,
@@ -185,16 +184,12 @@ export const FilteredEmptyResults: Story = {
         title: `2025 File`,
         permalink: `/publications/item-twenty-twenty-five`,
         lastModified: "",
-        layout: "file",
+        layout: "link",
         summary:
           "This is supposed to be a description of the hero banner that Isomer uses on their official website.",
         date: "2025-05-07",
         tagged: [CATEGORY_NAME_2_OPTION_ID],
         ref: "https://www.isomer.gov.sg/images/Homepage/hero%20banner_10.png",
-        fileDetails: {
-          type: "png",
-          size: "1.2MB",
-        },
       },
     ],
   }),
@@ -332,13 +327,13 @@ export const NoFiltersBlogCard: Story = {
   play: NoFiltersCollectionCard.play,
 }
 
-export const FileCard: Story = {
+export const LinkToFile: Story = {
   args: generateArgs({
     collectionItems: [COLLECTION_ITEMS[1]] as IsomerSitemap[],
   }),
 }
 
-export const FileCardNoImage: Story = {
+export const LinkToFileNoImage: Story = {
   args: generateArgs({
     collectionItems: [
       { ...COLLECTION_ITEMS[1], image: undefined } as IsomerSitemap,

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
@@ -4,6 +4,7 @@ import { generateSiteConfig } from "~/stories/helpers/generateSiteConfig"
 import { TAG_CATEGORY_DISPLAY_OPTIONS } from "~/types/constants"
 
 import { getCollectionItems } from "../getCollectionItems"
+import { processCollectionItems } from "../processCollectionItems"
 
 const SITE_LOGO_URL = "/isomer-logo.svg"
 const SITE_NAME = "Isomer Next"
@@ -50,6 +51,22 @@ const createSiteWithChildren = (children: IsomerSitemap[]) =>
   })
 
 describe("getCollectionItems", () => {
+  it("renders a link to a file using its reference URL and title", () => {
+    const ref = "https://example.com/report.pdf"
+    const site = createSiteWithChildren([
+      createArticleChild({ layout: "link", ref, title: "Annual report" }),
+    ])
+
+    const items = getCollectionItems({ site, permalink: "/collection" })
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ variant: "link", url: ref })
+    expect(processCollectionItems(items)[0]).toMatchObject({
+      referenceLinkHref: ref,
+      itemTitle: "Annual report",
+    })
+  })
+
   describe("showThumbnail is undefined", () => {
     it("should not include image when showThumbnail is undefined, even if item has an image", () => {
       const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -108,12 +108,7 @@ export const getCollectionItems = ({
 
   const items = currSitemap.children
     .flatMap((child) => getSitemapAsArray(child))
-    .filter(
-      (item) =>
-        item.layout === "file" ||
-        item.layout === "link" ||
-        item.layout === "article",
-    )
+    .filter((item) => item.layout === "link" || item.layout === "article")
 
   const transformedItems = items.map((item) => {
     const date =
@@ -146,14 +141,7 @@ export const getCollectionItems = ({
       pillTags,
     }
 
-    if (item.layout === "file") {
-      return {
-        ...baseItem,
-        variant: "file",
-        url: item.ref,
-        fileDetails: item.fileDetails,
-      }
-    } else if (item.layout === "link") {
+    if (item.layout === "link") {
       return {
         ...baseItem,
         variant: "link",

--- a/packages/components/src/templates/next/layouts/Collection/utils/processCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/processCollectionItems.ts
@@ -13,7 +13,6 @@ export const processCollectionItems = (
     const {
       id,
       site,
-      variant,
       date,
       plaintextTags,
       title,
@@ -24,7 +23,6 @@ export const processCollectionItems = (
       tags,
       pillTags,
     } = item
-    const file = variant === "file" ? item.fileDetails : null
     return {
       id,
       date,
@@ -41,7 +39,7 @@ export const processCollectionItems = (
         site.assetsBaseUrl,
       ),
       imageSrc: item.image?.src,
-      itemTitle: `${item.title}${file ? ` [${file.type.toUpperCase()}, ${file.size.toUpperCase()}]` : ""}`,
+      itemTitle: title,
       formattedDate: date ? getFormattedDate(date.toISOString()) : undefined,
     } as Exact<ProcessedCollectionCardProps, ProcessedCollectionCardProps>
   })

--- a/packages/components/src/templates/next/render/renderLayout.tsx
+++ b/packages/components/src/templates/next/render/renderLayout.tsx
@@ -28,7 +28,6 @@ export const renderLayout = (props: IsomerPageSchemaType) => {
     case "search":
       return <SearchLayout {...props} />
     // These are references that we should not render to the user
-    case "file":
     case "link":
       return <></>
     default:

--- a/packages/components/src/templates/next/render/renderPrefillText.ts
+++ b/packages/components/src/templates/next/render/renderPrefillText.ts
@@ -76,7 +76,6 @@ export const renderPrefillText = (content: IsomerSchema): PrefillContent => {
         description: page.subtitle,
       }
     }
-    case "file":
     case "link": {
       const page = refPageSchema.parse(content.page)
       return {

--- a/packages/components/src/types/constants.ts
+++ b/packages/components/src/types/constants.ts
@@ -5,7 +5,6 @@ export const ISOMER_USABLE_PAGE_LAYOUTS = {
   Homepage: "homepage",
   Index: "index",
   Database: "database",
-  File: "file",
   Link: "link",
 } as const
 

--- a/packages/components/src/types/meta.ts
+++ b/packages/components/src/types/meta.ts
@@ -44,7 +44,6 @@ export const HomePageMetaSchema = BasePageMetaSchema
 export const NotFoundPageMetaSchema = BasePageMetaSchema
 export const SearchPageMetaSchema = BasePageMetaSchema
 
-export const FileRefMetaSchema = BaseItemMetaSchema
 export const LinkRefMetaSchema = BaseItemMetaSchema
 
 export type ArticlePageMetaProps = Static<typeof ArticlePageMetaSchema>
@@ -54,5 +53,4 @@ export type HomePageMetaProps = Static<typeof HomePageMetaSchema>
 export type NotFoundPageMetaProps = Static<typeof NotFoundPageMetaSchema>
 export type SearchPageMetaProps = Static<typeof SearchPageMetaSchema>
 
-export type FileRefMetaProps = Static<typeof FileRefMetaSchema>
 export type LinkRefMetaProps = Static<typeof LinkRefMetaSchema>

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -371,7 +371,6 @@ export const HomePagePageSchema = Type.Object({})
 export const NotFoundPagePageSchema = Type.Object({})
 export const SearchPagePageSchema = Type.Object({})
 
-export const FileRefPageSchema = BaseRefPageSchema
 export const LinkRefPageSchema = BaseRefPageSchema
 
 // These are props that are required by the render engine, but not enforced by
@@ -417,7 +416,5 @@ export type NotFoundPagePageProps = Static<typeof NotFoundPagePageSchema> &
 export type SearchPagePageProps = Static<typeof SearchPagePageSchema> &
   BasePageAdditionalProps
 
-export type FileRefPageProps = Static<typeof FileRefPageSchema> &
-  BaseItemAdditionalProps
 export type LinkRefPageProps = Static<typeof LinkRefPageSchema> &
   BaseItemAdditionalProps

--- a/packages/components/src/types/schema.ts
+++ b/packages/components/src/types/schema.ts
@@ -5,7 +5,6 @@ import type {
   CollectionPagePageProps,
   ContentPagePageProps,
   DatabasePagePageProps,
-  FileRefPageProps,
   HomePagePageProps,
   LinkRefPageProps,
   NotFoundPagePageProps,
@@ -22,7 +21,6 @@ import {
   CollectionPageMetaSchema,
   ContentPageMetaSchema,
   DatabasePageMetaSchema,
-  FileRefMetaSchema,
   HomePageMetaSchema,
   LinkRefMetaSchema,
   SearchPageMetaSchema,
@@ -32,7 +30,6 @@ import {
   CollectionPagePageSchema,
   ContentPagePageSchema,
   DatabasePagePageSchema,
-  FileRefPageSchema,
   HomePagePageSchema,
   IndexPagePageSchema,
   LinkRefPageSchema,
@@ -174,29 +171,6 @@ export const DatabasePageSchema = Type.Object(
   },
 )
 
-export const FileRefSchema = Type.Object(
-  {
-    layout: Type.Literal(ISOMER_PAGE_LAYOUTS.File, {
-      default: ISOMER_PAGE_LAYOUTS.File,
-    }),
-    meta: Type.Optional(FileRefMetaSchema),
-    page: FileRefPageSchema,
-    content: Type.Array(IsomerComponentsSchemas, {
-      title: "Page content",
-      description:
-        "This should be empty for file pages, make sure to remove any items here.",
-      default: [],
-      minItems: 0,
-      maxItems: 0,
-    }),
-  },
-  {
-    title: "File Reference",
-    description:
-      "This is a layout used exclusively within collections. Use this layout if you want to link to a file, such as a PDF or a Word document, from within a Collection page.",
-  },
-)
-
 export const LinkRefSchema = Type.Object(
   {
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Link, {
@@ -230,7 +204,6 @@ export const IsomerPageSchema = Type.Composite([
     HomePageSchema,
     SearchPageSchema,
     IndexPageSchema,
-    FileRefSchema,
     LinkRefSchema,
   ]),
 ])
@@ -280,10 +253,6 @@ export type IndexPageSchemaType = Static<typeof IndexPageSchema> &
   BasePageAdditionalProps & {
     page: ContentPagePageProps
   }
-export type FileRefSchemaType = Static<typeof FileRefSchema> &
-  BasePageAdditionalProps & {
-    page: FileRefPageProps
-  }
 export type LinkRefSchemaType = Static<typeof LinkRefSchema> &
   BasePageAdditionalProps & {
     page: LinkRefPageProps
@@ -298,7 +267,6 @@ export type IsomerPageSchemaType =
   | IndexPageSchemaType
   | NotFoundPageSchemaType
   | SearchPageSchemaType
-  | FileRefSchemaType
   | LinkRefSchemaType
 
 export type IsomerPageLayoutType = IsomerPageSchemaType["layout"]

--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -1,5 +1,4 @@
 import type { CollectionCardProps } from "~/interfaces"
-import type { FileCardProps } from "~/interfaces/internal/CollectionCard"
 import type { ArticlePagePageProps, CollectionPagePageProps } from "~/types"
 
 import type { IsomerPageLayoutType } from "./schema"
@@ -25,7 +24,7 @@ interface IsomerBaseSitemap {
 }
 
 interface IsomerPageSitemap extends IsomerBaseSitemap {
-  layout: Exclude<IsomerPageLayoutType, "collection" | "file" | "link">
+  layout: Exclude<IsomerPageLayoutType, "collection" | "link">
 }
 
 export interface IsomerCollectionPageSitemap extends IsomerBaseSitemap {
@@ -40,11 +39,6 @@ export interface IsomerCollectionPageSitemap extends IsomerBaseSitemap {
   }
 }
 
-interface IsomerFileSitemap extends IsomerBaseSitemap {
-  layout: "file"
-  ref: string
-  fileDetails: FileCardProps["fileDetails"]
-}
 interface IsomerLinkSitemap extends IsomerBaseSitemap {
   layout: "link"
   ref: string
@@ -53,5 +47,4 @@ interface IsomerLinkSitemap extends IsomerBaseSitemap {
 export type IsomerSitemap =
   | IsomerPageSitemap
   | IsomerCollectionPageSitemap
-  | IsomerFileSitemap
   | IsomerLinkSitemap

--- a/packages/components/src/utils/__tests__/getSiderailFromSiteMap.test.ts
+++ b/packages/components/src/utils/__tests__/getSiderailFromSiteMap.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest"
 import { getSiderailFromSiteMap } from "../getSiderailFromSiteMap"
 
 describe("getSiderailFromSiteMap", () => {
-  it("excludes file and link layouts from the siderail", () => {
+  it("excludes link layouts, including file URLs, from the siderail", () => {
     // Arrange
     const sitemap: IsomerSitemap = {
       id: "root",
@@ -35,10 +35,9 @@ describe("getSiderailFromSiteMap", () => {
               title: "File",
               permalink: "/collection/file",
               lastModified: "",
-              layout: "file",
+              layout: "link",
               summary: "",
               ref: "file.pdf",
-              fileDetails: { type: "PDF", size: "1 MB" },
             },
             {
               id: "link",

--- a/packages/components/src/utils/getSiderailFromSiteMap.ts
+++ b/packages/components/src/utils/getSiderailFromSiteMap.ts
@@ -22,7 +22,7 @@ export const getSiderailFromSiteMap = (
     parentTitle: parentNode.title,
     parentUrl: parentNode.permalink,
     pages: parentNode.children
-      .filter(({ layout }) => layout !== "file" && layout !== "link")
+      .filter(({ layout }) => layout !== "link")
       .map((sibling) => ({
         title: sibling.title,
         url: sibling.permalink,

--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -38,24 +38,6 @@ const getDirectoryItemStats = async (filePath) => {
   }
 }
 
-const getHumanReadableFileSize = (bytes) => {
-  const unit = 1000
-
-  if (Math.abs(bytes) < unit) {
-    return bytes + " B"
-  }
-
-  const units = ["kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
-  let index = -1
-
-  while (Math.abs(bytes) >= unit && index < units.length - 1) {
-    bytes /= unit
-    index++
-  }
-
-  return `${bytes.toFixed(1)} ${units[index]}`
-}
-
 const getSiteMapEntry = async (fullPath, relativePath, name) => {
   const permalink = relativePath.split(".").slice(0, -1).join("-")
   const schemaData = await getSchemaJson(fullPath)
@@ -97,24 +79,6 @@ const getSiteMapEntry = async (fullPath, relativePath, name) => {
         defaultSortBy: collectionProps.defaultSortBy,
         defaultSortDirection: collectionProps.defaultSortDirection,
       }
-    }
-  }
-
-  if (schemaData.layout === "file") {
-    const refFilePath = path.join(__dirname, "../public", schemaData.page.ref)
-    const refFileStats = await getDirectoryItemStats(refFilePath)
-
-    if (!refFileStats) {
-      return null
-    }
-
-    return {
-      ...siteMapEntry,
-      ref: schemaData.page.ref,
-      fileDetails: {
-        type: path.extname(refFilePath).slice(1).toUpperCase(),
-        size: getHumanReadableFileSize(refFileStats.size),
-      },
     }
   }
 

--- a/tooling/export-import/migrate.ts
+++ b/tooling/export-import/migrate.ts
@@ -156,13 +156,8 @@ async function seedDatabase(client: Client, siteId: number) {
       const permalink = isRootPage
         ? "" // FIXME: This should be "_index" but Studio is not fully ready for this yet
         : path.basename(page.name, ".json").toLowerCase(); // Only use the file name without extension
-      const isCollectionLink =
-        content.layout === "link" || content.layout === "file";
+      const isCollectionLink = content.layout === "link";
       const isPageOrder = page.name === "_meta.json";
-
-      if (content.layout === "file") {
-        content.layout = "link";
-      }
 
       const blobId = await createBlob(client, content);
       const resourceId = await createResource(client, {

--- a/tooling/scripts/isomer-admin/apps/create-content-from-local.ts
+++ b/tooling/scripts/isomer-admin/apps/create-content-from-local.ts
@@ -41,17 +41,9 @@ const getChildPageType = (
   return content.layout === "link" ? "CollectionLink" : "CollectionPage"
 }
 
-const normalizePageContent = (content: PageContent): PageContent => {
-  if (content.layout === "file") {
-    return { ...content, layout: "link" }
-  }
-
-  return content
-}
-
 const readJsonFile = (filePath: string): PageContent => {
   const rawContent = fs.readFileSync(filePath, "utf-8")
-  return normalizePageContent(JSON.parse(rawContent) as PageContent)
+  return JSON.parse(rawContent) as PageContent
 }
 
 const getDefaultIndexPageContent = (title: string): PageContent => ({

--- a/tooling/seed-from-repo/index.ts
+++ b/tooling/seed-from-repo/index.ts
@@ -212,13 +212,8 @@ async function seedDatabase(client: Client, siteId: number, siteName: string) {
       const permalink = isRootPage
         ? "" // FIXME: This should be "_index" but Studio is not fully ready for this yet
         : path.basename(page.name, ".json").toLowerCase(); // Only use the file name without extension
-      const isCollectionLink =
-        content.layout === "link" || content.layout === "file";
+      const isCollectionLink = content.layout === "link";
       const isPageOrder = page.name === "_meta.json";
-
-      if (content.layout === "file") {
-        content.layout = "link";
-      }
 
       const blobId = await createBlob(client, content);
       const resourceId = await createResource(client, {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 20 | +10 | -150 |
| 🧪 Test | 6 | +42 | -76 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem
Isomer supported a `file` page layout used only inside Collections to link to a file (PDF, Word doc, etc). This duplicated the `link` layout's job of pointing to an external reference, adding an extra schema, extra card variant, and file-size/type metadata that added maintenance cost without adding real capability — a plain `link` layout works just as well for files.

## Solution
Remove the `file` layout entirely and route file references through the existing `link` layout instead.

- Deleted `FileRefSchema`/`FileRefPageSchema`/`FileRefMetaSchema` and the `File` entry from `ISOMER_USABLE_PAGE_LAYOUTS`.
- Removed the `file` variant from `CollectionCard`/`AllCardProps`, `IsomerSitemap`, and collection item processing (`getCollectionItems`, `processCollectionItems`); dropped the file-type/size suffix rendering.
- Updated `renderLayout`, `renderPrefillText`, `metadata.ts` (sitemap/robots/meta description) to drop the `file` case.
- Migration tooling (`export-import/migrate.ts`, `seed-from-repo`, `create-content-from-local`) now treats any existing `file` content as `link` on ingest, and `generate-sitemap.js` no longer computes file size/type.
- Removed the file-layout prefill test and `scopedSchema` test; added a `pageLayout.test.ts` covering that `link` still accepts file URLs and that `file` is now rejected by the schema.
- Updated Storybook stories (`Collection.stories.tsx`) to use `link` instead of `file`.

Breaking change: content with `layout: "file"` is no longer valid in the schema; existing seed/migration scripts auto-convert it to `link`.





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61221513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule findings.

<details><summary><h3>Summary</h3></summary>

- Removes file-layout schemas, types, rendering branches, metadata handling, and collection-card variants.
- Updates collection processing and sitemap generation to treat file URLs as ordinary links.
- Updates tests and Storybook fixtures to verify that `link` accepts file URLs while `file` is rejected.
- Removes obsolete compatibility normalization from repository import and seeding tools.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Collection content] --> B{Page layout}
    B -->|article| C[Article collection card]
    B -->|link, including file URL| D[Link collection card]
    D --> E[Reference URL]
    B -->|file| F[Rejected by schema]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["refactor!: remove file page layout suppo..."](https://github.com/opengovsg/isomer/commit/21b9b5bc6d8b9a13ac179036643cb1242e65ef30)</sub>

<!-- /greptile_comment -->