### PR TITLE
docs: wayfinder map for audit log batch zip delivery

### DIFF
--- a/.scratch/audit-log-zip-delivery/MAP.md
+++ b/.scratch/audit-log-zip-delivery/MAP.md
@@ -1,0 +1,75 @@
+---
+label: wayfinder:map
+status: open
+tracker: local-markdown
+---
+
+# Audit log batch export delivered as a single zip
+
+## Destination
+
+A locked technical design — recorded as resolved tickets plus a new ADR — for
+delivering **batch** (all-sites) audit-log-export emails as a single zip
+archive per batch, with each CSV inside the zip named so the site it came
+from is unambiguous (siteName + siteId). Scope is the batch email only; the
+single-site/single-report ready email (`auditLogExportReadyTemplate`) is
+unchanged. This map produces the design; implementation is a separate
+follow-up pass (see [Plan, don't do](../../.claude/skills/wayfinder/SKILL.md)
+— no execution override for this map).
+
+Reaching the end looks like: every ticket below closed, a new ADR written
+under `docs/adr/` recording the delivery-mechanism decision, and
+`CONTEXT.md` updated with whatever new vocabulary (e.g. "Export Batch" /
+zip artifact naming) the tickets settle on.
+
+## Notes
+
+- Touches: `apps/studio/src/server/modules/audit/auditLogExport.service.ts`,
+  `apps/studio/src/server/modules/audit/auditLogExport.query.ts`,
+  `apps/studio/src/features/mail/templates/templates.ts`,
+  `apps/studio/src/features/mail/templates/types.ts`,
+  `apps/studio/src/lib/mail.ts`,
+  `apps/studio/src/pages/api/audit-log-exports/download.ts`.
+- Prior art: `docs/adr/0004-emailed-signed-url-delivery-for-audit-exports.md`
+  (superseded), `docs/adr/0005-complete-artifact-reuse-for-audit-exports.md`
+  (accepted, per-site CSV reuse — **unaffected** by this map), `docs/adr/0006-sealed-download-tokens-for-audit-exports.md`
+  (accepted — this map's ADR extends it for the batch case).
+- Glossary in root `CONTEXT.md` under "Audit and access logging" — consult
+  before naming anything new; "batch"/all-sites export currently has no
+  glossary entry (added by commit c573c2208, undocumented).
+- **Settled going in** (from grilling before tickets were cut):
+  - Delivery stays link-based, not a real email attachment: the zip is one
+    S3 object, emailed as a click-to-download link via the same sealed
+    Download Token pattern (ADR 0006) already used for CSVs — not a
+    literal Postman.gov.sg email attachment.
+  - The zip is **rebuilt fresh every time a batch completes** — no new
+    reuse/caching layer for the zip itself. Per-site CSV reuse (ADR 0005)
+    is untouched and keeps working exactly as it does today underneath.
+  - A zip-build failure **retries on the next cron tick**; per-site rows
+    already `Done` are left alone (zip assembly is a separate, idempotent,
+    retry-safe step layered on top of `maybeSendAuditLogExportBatchEmail`).
+  - Filenames inside the zip must make the source site unambiguous to a
+    human (siteName), and per the original ask also carry siteId.
+- Sessions working a ticket here should consult the `grilling` and
+  `domain-modeling` skills; the deeper design tickets are expected to
+  produce a new ADR and a CONTEXT.md glossary addition.
+
+## Decisions so far
+
+_(none yet — no tickets closed)_
+
+## Not yet specified
+
+- Rollout/feature-flag strategy for switching the batch email over to the
+  new zip format (fog until the design tickets below settle what "the new
+  format" actually is).
+
+## Out of scope
+
+- Changing the single-site/single-report ready email
+  (`auditLogExportReadyTemplate`) to also zip its one CSV — explicitly
+  ruled out when naming the destination; that path keeps its plain
+  download link.
+- The pre-existing data-at-rest lifecycle gap noted in ADR 0004/0006 (no
+  S3 object deletion policy after link expiry) — a known, already-deferred
+  gap that predates this map and isn't reopened by it.

--- a/.scratch/audit-log-zip-delivery/MAP.md
+++ b/.scratch/audit-log-zip-delivery/MAP.md
@@ -13,14 +13,24 @@ delivering **batch** (all-sites) audit-log-export emails as a single zip
 archive per batch, with each CSV inside the zip named so the site it came
 from is unambiguous (siteName + siteId). Scope is the batch email only; the
 single-site/single-report ready email (`auditLogExportReadyTemplate`) is
-unchanged. This map produces the design; implementation is a separate
-follow-up pass (see [Plan, don't do](../../.claude/skills/wayfinder/SKILL.md)
-— no execution override for this map).
+unchanged.
+
+**Status: reached, then extended.** All 7 tickets are closed and ADR 0009
+records the full design. The map's original posture was design-only (no
+execution override in these Notes) — implementation was meant to be a
+separate follow-up pass — but partway through resolving ticket 04 the user
+explicitly asked to continue straight into code in the same session.
+Tickets 03/05/06/07 were consequently resolved as part of implementing,
+not one-at-a-time grilling sessions; each still records its own resolution
+below for the same reason a grilled ticket would. The implementation
+itself is [PR #3367](https://github.com/opengovsg/isomer/pull/3367)
+(`feat/audit-log-zip-delivery`, stacked on `fix/batch-audit-logs`).
 
 Reaching the end looks like: every ticket below closed, a new ADR written
 under `docs/adr/` recording the delivery-mechanism decision, and
-`CONTEXT.md` updated with whatever new vocabulary (e.g. "Export Batch" /
-zip artifact naming) the tickets settle on.
+`CONTEXT.md` updated with whatever new vocabulary the tickets settle on —
+all done. What's left is ordinary code review of PR #3367, not further
+wayfinding.
 
 ## Notes
 
@@ -65,12 +75,19 @@ zip artifact naming) the tickets settle on.
 - [Select a streaming Node zip library for batch export assembly](tickets/01-zip-library-research.md): use `archiver` — streams directly into the existing S3 multipart-upload sink, no full-archive buffering.
 - [Confirm Postman.gov.sg attachment support and limits](tickets/02-postman-attachment-research.md): attachments exist but are capped at 2MB/file and need a sending domain Isomer hasn't provisioned — confirmed, stay link-based (zip in S3 behind the existing download-token link).
 - [Design zip assembly, storage, and its interaction with existing CSV reuse](tickets/04-zip-assembly-storage-design.md): recorded as [ADR 0009](../../docs/adr/0009-batch-audit-log-exports-delivered-as-one-zip.md) — extends `maybeSendAuditLogExportBatchEmail` in place with `archiver`, moves the `batchEmailedAt` claim to after send succeeds, new `AuditLogExportBatch` table for zip metadata. Confirmed this whole map stacks on `fix/batch-audit-logs`, not `main`.
+- [Decide the zip entry filename convention](tickets/03-zip-entry-filename-convention.md): `{sanitizedSiteName}-{siteId}-{reportKind}-{rangeSlug}.csv`; siteId always appended so sanitized collisions can't collide.
+- [Extend the sealed Download Token flow to resolve a shared batch zip](tickets/05-download-token-flow-for-batch-zip.md): new `audit-log-export-batch` token purpose keyed on `batchId`; window anchors to `AuditLogExportBatch.emailedAt`.
+- [Design zip-build failure and retry handling in the cron job](tickets/06-zip-build-failure-retry-handling.md): `AuditLogExportBatch.claimedAt` as a 15-minute lease, plus a new `processPendingAuditLogExportBatchEmails` sweep — needed because a fully-terminal batch no longer self-triggers a retry.
+- [Rework the batch-ready email template for a single zip link](tickets/07-batch-email-template-rework.md): `zipLink` (optional — undefined when every site fails) + `includedSiteNames` replace the old per-site `links` array.
 
 ## Not yet specified
 
 - Rollout/feature-flag strategy for switching the batch email over to the
-  new zip format (fog until the design tickets below settle what "the new
-  format" actually is).
+  new zip format — **still genuinely open**: PR #3367 ships the new format
+  as the only behavior (no flag), which is a real gap this map flagged but
+  never explicitly closed. Worth a decision before merging, not fog
+  anymore now that the design is locked — a reviewer of PR #3367 should
+  weigh in rather than this map reopening it.
 
 ## Out of scope
 

--- a/.scratch/audit-log-zip-delivery/MAP.md
+++ b/.scratch/audit-log-zip-delivery/MAP.md
@@ -24,6 +24,12 @@ zip artifact naming) the tickets settle on.
 
 ## Notes
 
+- **Stacking dependency (confirmed while resolving ticket 04)**: this map's
+  destination code (`maybeSendAuditLogExportBatchEmail`, `batchId`,
+  `batchEmailedAt`) exists only on `origin/fix/batch-audit-logs` (commit
+  `c573c2208`), not on `main`. This map's own branch was cut fresh from
+  `main` (a wayfinder charting artifact, docs-only), but any
+  implementation must branch from `fix/batch-audit-logs` instead.
 - Touches: `apps/studio/src/server/modules/audit/auditLogExport.service.ts`,
   `apps/studio/src/server/modules/audit/auditLogExport.query.ts`,
   `apps/studio/src/features/mail/templates/templates.ts`,
@@ -58,6 +64,7 @@ zip artifact naming) the tickets settle on.
 
 - [Select a streaming Node zip library for batch export assembly](tickets/01-zip-library-research.md): use `archiver` — streams directly into the existing S3 multipart-upload sink, no full-archive buffering.
 - [Confirm Postman.gov.sg attachment support and limits](tickets/02-postman-attachment-research.md): attachments exist but are capped at 2MB/file and need a sending domain Isomer hasn't provisioned — confirmed, stay link-based (zip in S3 behind the existing download-token link).
+- [Design zip assembly, storage, and its interaction with existing CSV reuse](tickets/04-zip-assembly-storage-design.md): recorded as [ADR 0009](../../docs/adr/0009-batch-audit-log-exports-delivered-as-one-zip.md) — extends `maybeSendAuditLogExportBatchEmail` in place with `archiver`, moves the `batchEmailedAt` claim to after send succeeds, new `AuditLogExportBatch` table for zip metadata. Confirmed this whole map stacks on `fix/batch-audit-logs`, not `main`.
 
 ## Not yet specified
 

--- a/.scratch/audit-log-zip-delivery/MAP.md
+++ b/.scratch/audit-log-zip-delivery/MAP.md
@@ -56,7 +56,8 @@ zip artifact naming) the tickets settle on.
 
 ## Decisions so far
 
-_(none yet — no tickets closed)_
+- [Select a streaming Node zip library for batch export assembly](tickets/01-zip-library-research.md): use `archiver` — streams directly into the existing S3 multipart-upload sink, no full-archive buffering.
+- [Confirm Postman.gov.sg attachment support and limits](tickets/02-postman-attachment-research.md): attachments exist but are capped at 2MB/file and need a sending domain Isomer hasn't provisioned — confirmed, stay link-based (zip in S3 behind the existing download-token link).
 
 ## Not yet specified
 

--- a/.scratch/audit-log-zip-delivery/research/01-zip-library-research.md
+++ b/.scratch/audit-log-zip-delivery/research/01-zip-library-research.md
@@ -1,0 +1,121 @@
+# Zip library selection for batch audit-log-export delivery
+
+## Recommendation
+
+Use **[`archiver`](https://www.npmjs.com/package/archiver)** (`archiverjs/node-archiver`, MIT license). It is a pure streaming zip/tar library built directly on Node's `stream.Transform` — you `.append()` each per-site CSV as its own readable stream (or the same `createCsvTransform()` output already used today) and `.pipe()` the archive's own readable output straight into `@aws-sdk/lib-storage`'s `Upload`, the exact same multipart-upload sink `uploadAuditLogExport` already uses in `apps/studio/src/lib/s3.ts:422-442`. Nothing about the existing "Postgres cursor → CSV transform → S3" pipeline needs to change in kind — the zip step is just one more transform stage inserted in the middle, and the whole chain stays O(1) memory regardless of how many sites or how large each site's CSV is.
+
+`yazl` is also a legitimate streaming option (lower-level, smaller, `ZipFile` exposes an `outputStream`) and would work too, but it requires you to manually track per-entry sizes/CRCs in some code paths and has a much smaller community/usage footprint. `jszip` is disqualified outright for this use case: it is an in-memory, buffer-everything API (`generateAsync` returns one Buffer/Blob for the whole archive) with no true streaming output, which directly conflicts with the entire point of the existing pattern — never materializing a full export in memory. Given batch exports can already include every Site row on the platform (see Q4), buffering the whole zip is the wrong default. `archiver` is the safer, better-trodden choice for a Node backend job with the strongest community track record of the three.
+
+---
+
+## 1. Comparing archiver, yazl, and jszip
+
+| | `archiver` | `yazl` | `jszip` |
+|---|---|---|---|
+| Model | Stream-based; wraps `zip-stream`/`tar-stream`; the whole archiver instance IS a readable stream | Stream-based; lower-level, you build a `ZipFile` and read its `outputStream` | Buffer-based; builds the whole zip in memory, `generateAsync()`/`generateNodeStream()` (a *thin* wrapper that still needs the full structure built first) |
+| API ergonomics | High-level: `archive.append(readableStream, { name })`, `archive.pipe(dest)`, `archive.finalize()` | Low-level: `zipfile.addReadStream(stream, name)`, `zipfile.outputStream.pipe(dest)`, `zipfile.end()` — no built-in progress/error aggregation helpers | High-level but memory-oriented: `zip.file(name, streamOrBuffer)`, `zip.generateAsync({type: 'nodebuffer'})` |
+| Memory behavior for N large CSV streams | Backpressure-aware; each entry is compressed and flushed as it's appended, only current entry + zip encoder buffers live in memory | Same class of behavior as archiver — genuinely streaming, entry by entry | Effectively requires holding entry contents (or produces the full central directory + all compressed bytes) before it can hand back a stream/buffer — not suited to large multi-GB aggregates |
+| Fit for "many large CSV streams, server job, then to S3" | Best fit — this is its explicit design goal (its own docs advertise it for exactly this: streaming large archives without buffering) | Workable, but you own more plumbing (manual entry bookkeeping, no built-in `.append()` convenience for arbitrary readables the way archiver has, though it does accept streams) | Poor fit — the "streaming" JSZip offers is streaming the *serialization of an already-buffered/being-built* zip, not streaming multiple independent large source streams through it without holding them |
+| Ecosystem maturity | Very large (~37M weekly downloads, see §3), long history, used widely for exactly this kind of "N files → one zip → HTTP/S3" job | Smaller footprint (~2.5M weekly downloads), stable, minimal-scope by design | Very large (~30M weekly downloads) but that usage skew is dominated by browser/client-side use cases (build zip in browser, download via Blob), not server-side streaming pipelines |
+
+**Verdict**: `archiver`'s append-many-streams-then-pipe-once API maps almost one-to-one onto what this job already does per-site (stream a Kysely cursor through `createCsvTransform()`), so adopting it changes the shape of the pipeline the least. `yazl` would also technically satisfy the "no full buffering" requirement, but there's no material advantage over `archiver` here, and `archiver`'s bigger community/download numbers make it the lower-risk pick for a codebase that otherwise has zero zip-library precedent to lean on.
+
+---
+
+## 2. Streaming a zip straight into the existing S3 multipart pattern
+
+Yes — `archiver`'s `Archiver` instance is itself a `Readable` stream (it extends through `zip-stream`, which extends Node's `stream.Transform`), so it can be piped directly into `@aws-sdk/lib-storage`'s `Upload`, exactly the way `uploadAuditLogExport` already hands a `Readable | string` body to `Upload` today (`apps/studio/src/lib/s3.ts:422-441`). No full-archive buffering is required — `Upload` auto-switches to multipart once the piped stream exceeds one part, per the comment already in that file (`apps/studio/src/lib/s3.ts:417-421`).
+
+Illustrative sketch (does not need to compile), mirroring the existing per-site generate path in `apps/studio/src/server/modules/audit/auditLogExport.service.ts:551-587`:
+
+```ts
+import archiver from "archiver"
+import { Upload } from "@aws-sdk/lib-storage"
+
+// One archive per batch request, one entry per site.
+const zipStream = archiver("zip", { zlib: { level: 9 } })
+zipStream.on("warning", (err) => { /* non-fatal (e.g. stat failures) */ })
+zipStream.on("error", (err) => { throw err }) // surfaces into the caller's catch/retry path
+
+// Kick off the S3 upload against the archive's own readable output —
+// same shape as today's `uploadAuditLogExport({ key, body: csvStream })`.
+const upload = new Upload({
+  client: storage,
+  params: {
+    Bucket,
+    Key: `audit-log-exports/batch/${requestId}/audit-logs.zip`,
+    Body: zipStream, // archiver is itself a Readable
+    ContentType: "application/zip",
+  },
+})
+const uploadDone = upload.done()
+
+// For each site, build the same rowStream -> createCsvTransform() pipeline
+// already used per-site today, and append it as one zip entry instead of
+// uploading it directly.
+for (const site of sites) {
+  const rowStream = Readable.from(
+    activityReportQuery({ siteId: site.id, auditLogDateRange }).stream(STREAM_CHUNK_SIZE),
+  )
+  const csvStream = createCsvTransform()
+  rowStream.on("error", (error) => csvStream.destroy(error))
+  rowStream.pipe(csvStream)
+
+  // archive.append() takes a readable stream + an entry name; it does not
+  // resolve until archiver has consumed it, but you can queue several —
+  // archiver serializes entries internally.
+  zipStream.append(csvStream, { name: `${site.name}.csv` })
+}
+
+zipStream.finalize() // signals "no more entries"; archive's readable end fires after flushing
+await uploadDone
+```
+
+The only structural change versus today's per-site path is: (a) `createCsvTransform()` output streams get named and `.append()`-ed to an `Archiver` instead of being handed straight to `uploadAuditLogExport`, and (b) there is one `Upload`/multipart-upload call per *batch request* instead of one per site. Backpressure is preserved end-to-end: Postgres cursor → CSV transform → zip entry → zip encoder → S3 multipart part, with no full-file or full-archive buffering at any stage.
+
+---
+
+## 3. Maintenance status and license
+
+**WebFetch was available and used** for this section (via `WebFetch` against `registry.npmjs.org`, `api.npmjs.org`, and the GitHub repo pages). Two caveats on reliability, noted explicitly below: (1) `npmjs.com` package *pages* (the human-facing site) returned HTTP 403 to WebFetch — the data below instead comes from the raw `registry.npmjs.org` JSON API and `api.npmjs.org` downloads API, which did return data; (2) WebFetch summarizes large JSON through a small model and truncated at least one registry response (noted inline), so treat exact dates as best-effort rather than guaranteed byte-accurate.
+
+| Package | Latest version | License | Weekly downloads (npm, week of Aug 31–Sep 6, 2026) | GitHub open issues / open PRs / stars |
+|---|---|---|---|---|
+| [`archiver`](https://registry.npmjs.org/archiver) ([GitHub](https://github.com/archiverjs/node-archiver)) | 8.0.0 (publish date not retrievable — registry response was truncated before reaching version 8.0.0's `time` entry) | MIT | 36,818,154 | 142 / 31 / ~3,000 stars, 249 forks, 954 commits |
+| [`yazl`](https://registry.npmjs.org/yazl) ([GitHub](https://github.com/thejoshwolfe/yazl)) | 3.3.1, published 2024-11-23 | MIT | 2,545,510 | 14 / 6 / 150 total commits |
+| [`jszip`](https://registry.npmjs.org/jszip) ([GitHub](https://github.com/Stuk/jszip)) | 3.10.2 — registry reported this as published 2026-09-08 (i.e. essentially "yesterday" relative to today, 2026-09-09); this is surprising for a version number that has been stable for years in general usage, so **treat this specific date as unverified/possibly a metadata-only republish or a tool artifact**, not a confirmed fresh feature release | MIT OR GPL-3.0-or-later (dual-licensed) | 30,245,822 | 358 / 29 / 10.4k stars, 743 commits |
+
+None of the three is abandoned. `archiver` has the largest download share and the most community usage precedent for exactly this "assemble many streams into one zip, server-side" job, at the cost of a larger open-issue backlog (142) than `yazl`'s (14) — consistent with `archiver` simply having a much bigger, more general-purpose surface area (zip *and* tar, glob support, etc.) than `yazl`'s narrowly-scoped zip-only API. `jszip`'s issue count (358) is the largest of the three and its usage is dominated by browser-side, buffer-oriented use cases rather than the server streaming pattern this project needs — reinforcing the §1 disqualification independent of maintenance status.
+
+---
+
+## 4. Scale: how many sites can one "all sites" batch include today?
+
+Traced end-to-end:
+
+- `audit.router.ts:61-63` (`createExportRequest` mutation): when `scope !== "site"` (i.e. `"allSites"`), `siteIds = await getAdminSiteIds(ctx.user.id)` — resolved **server-side**, never trusted from client input.
+- `apps/studio/src/server/modules/site/site.service.ts:54-76` (`getAdminSiteIds`): if the caller is an active Isomer Admin, it returns **every single `Site` row in the entire platform** (`db.selectFrom("Site").select("id")...execute()` — no `LIMIT`, no pagination). If the caller is a regular per-site Admin, it's scoped down to just the sites where they hold an active `Admin` `ResourcePermission`.
+- `auditLogExport.service.ts:112-131` (`createAuditLogExportRequestsForSites`): takes that `siteIds: number[]` and fans it out into one `AuditLogExportRequest` row per site, batched into set-based queries in a single transaction — the code comment explicitly frames this design around avoiding "one DB transaction per site" for exactly this "for an Isomer Admin, every site on the platform" case (see the comment at `auditLogExport.service.ts:104-111`).
+
+So **an Isomer Admin's "all sites" batch export request today includes literally every `Site` row that exists**, with no cap in code.
+
+Order-of-magnitude estimate for how many `Site` rows that actually is: I could not find a live count, a seed script that creates a representative number of sites, or explicit documentation stating a production site count anywhere in this repo (checked `packages/db/prisma/schema.prisma:154-179` for the `Site` model itself — no comment with a count; searched for `seed*` files — `apps/studio/prisma/seed.ts`, `apps/studio/tests/e2e/fixtures/seed.ts`, and `tooling/seed-from-repo` exist but are dev/test fixtures seeding a handful of demo sites, not indicative of production scale). Reasoning from the domain instead: Isomer is described in this repo's own `CLAUDE.md` as "a government CMS/site builder platform (Open Government Products, Singapore)" — i.e., it hosts individual sites for Singapore government ministries, statutory boards, and agencies. Singapore's whole-of-government agency count (ministries + statutory boards + department-level entities) is commonly cited in the low hundreds, and a next-gen CMS platform mid-rollout would realistically host anywhere from dozens up to perhaps ~300-500 sites at scale, not thousands. **This is a rough guess reasoned from domain knowledge of Singapore's government structure, not a number found in code — flagged explicitly as such.**
+
+Given each site's audit-log CSV can itself be arbitrarily large (a full month of `AuditLog` activity across every resource on a site — the query in `auditLogExport.query.ts:250-429` has no row cap, and rows are already streamed in `STREAM_CHUNK_SIZE = 500` cursor batches per `auditLogExport.service.ts:333-336`), a batch of "low hundreds of sites × potentially large per-site CSVs" is squarely in the range where streaming assembly (not buffering) matters. This confirms the `archiver`-over-`jszip` recommendation in §1 independent of the exact site count: even if the true count turns out to be on the smaller end (dozens), there's no downside to the streaming approach, and if it's on the larger end (hundreds), buffering the whole zip in memory would be a real risk.
+
+---
+
+## Citations
+
+- `apps/studio/src/server/modules/audit/auditLogExport.query.ts:513-530` — `createCsvTransform`, the existing streaming CSV serializer.
+- `apps/studio/src/server/modules/audit/auditLogExport.service.ts:333-336` — `STREAM_CHUNK_SIZE`, Kysely cursor batch size.
+- `apps/studio/src/server/modules/audit/auditLogExport.service.ts:551-587` — per-site generate path: Postgres cursor → `createCsvTransform()` → `uploadAuditLogExport`.
+- `apps/studio/src/server/modules/audit/auditLogExport.service.ts:104-131` — `createAuditLogExportRequestsForSites`, including the comment framing "for an Isomer Admin, every site on the platform."
+- `apps/studio/src/server/modules/audit/audit.router.ts:38-63` — `createExportRequest` mutation, `scope === "allSites"` → `getAdminSiteIds`.
+- `apps/studio/src/server/modules/site/site.service.ts:54-76` — `getAdminSiteIds`, unpaginated `SELECT id FROM Site` for Isomer Admins.
+- `apps/studio/src/lib/s3.ts:412-442` — `uploadAuditLogExport`, the existing `@aws-sdk/lib-storage` `Upload` streaming-multipart pattern this zip step should mirror.
+- `packages/db/prisma/schema.prisma:154-179` — `Site` model (no count hints in comments).
+- `apps/studio/package.json`, root `package.json` — confirmed no existing dependency matching `archiver|jszip|adm-zip|yazl|zip-stream` (`grep` returned no matches).
+- [npm: archiver](https://www.npmjs.com/package/archiver) / [registry.npmjs.org/archiver](https://registry.npmjs.org/archiver) / [GitHub: archiverjs/node-archiver](https://github.com/archiverjs/node-archiver)
+- [npm: yazl](https://www.npmjs.com/package/yazl) / [registry.npmjs.org/yazl](https://registry.npmjs.org/yazl) / [GitHub: thejoshwolfe/yazl](https://github.com/thejoshwolfe/yazl)
+- [npm: jszip](https://www.npmjs.com/package/jszip) / [registry.npmjs.org/jszip](https://registry.npmjs.org/jszip) / [GitHub: Stuk/jszip](https://github.com/Stuk/jszip)

--- a/.scratch/audit-log-zip-delivery/research/02-postman-attachment-research.md
+++ b/.scratch/audit-log-zip-delivery/research/02-postman-attachment-research.md
@@ -1,0 +1,87 @@
+# Does Postman.gov.sg support email attachments, and would a batch audit-log zip fit?
+
+## Answer, up front
+
+**Yes, Postman.gov.sg's transactional email API technically supports file attachments — but the limits are small and there's a gating prerequisite Isomer hasn't set up.**
+
+- Up to **10 attachments per email**
+- **2 MB per attachment**
+- **10 MB cumulative** across all attachments in one email
+- A `413` is returned if either limit is exceeded
+- Attachments require **multipart/form-data** requests (Isomer's current integration sends plain JSON)
+- Attachments are **only available once a custom "from" sending domain is set up** with Postman — "If you are sending attachments in your API emails, then a custom from address is necessary" (FAQ). Isomer's deploy checklist for this exact feature area (`docs/deploy/audit-log-exports.md`) states export emails "ride the existing `sendMail` pipeline; **no new provider config**" was added, i.e. no custom-domain/attachment setup exists today.
+
+A single zip archive is one attachment, so the binding cap for "does the zip fit" is **2 MB** (per-attachment), not 10 MB (that's only relevant if you split into >1 attachment, which isn't the plan here). That is a materially tighter constraint than it sounds once weighed against "every site on the platform" batch scope (see below) — plausible only for a small/early-stage set of sites with modest monthly log volume, and not something to bank on as the platform grows.
+
+## 1. Primary sources read
+
+- Postman Guide — Attachments page: https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments (canonical `guide.postman.gov.sg/api-guide/...` URL 307-redirects here; both are the same official OGP docs site — note the doc site was mid-migration between an `api-guide` and `email-api-guide` path prefix, both point at the same official content)
+  - Field: `attachments`, sent as `multipart/form-data` (example given as curl `--form 'attachments=@"/path/to/file"'`, repeatable for multiple files)
+  - "Each email can have up to 10 attachments"
+  - "Each attachment should not exceed 2MB in size"
+  - "The cumulative size of all attachments should not exceed 10MB"
+  - `413` returned when these are violated
+  - 33 supported file types (asc, avi, bmp, csv, docx, gif, jpeg, jpg, pdf, png, pptx, txt, xlsx, mpeg, mpg, wmv, etc. — no explicit mention of `.zip` in the list surfaced by the fetch; worth double-checking directly against the live page before relying on zip being an accepted MIME type)
+- Postman Guide — FAQ: https://postman-v1.guides.gov.sg/email-api-guide/frequently-asked-questions
+  - "If you are sending attachments in your API emails, then a custom from address is necessary" — i.e. attachments gate on having a custom sending domain provisioned with Postman, not just an API key
+- Postman client repo (found via search, not fetched in depth): https://github.com/opengovsg/postmangovsg-client — an OpenAPI client/nodemailer transport; corroborates that attachments are a first-class, documented API capability rather than an internal-only feature
+
+**Caveat on source freshness:** the docs live at a versioned-looking host (`postman-v1.guides.gov.sg`), and the search also surfaced a differently-prefixed `guide.postman.gov.sg/api-guide/...` path that redirects into it — consistent with a docs-site migration in progress. The content is still the authoritative Postman Guide (not a third-party mirror), but if this becomes load-bearing for an implementation decision, re-verify against the live page rather than trusting this snapshot indefinitely, and separately confirm `.zip` is on the accepted-type list.
+
+## 2. Isomer's current integration (`apps/studio/src/lib/mail.ts`)
+
+`sendMail` posts **JSON**, not multipart, to `https://api.postman.gov.sg/v1/transactional/email/send`:
+
+```ts
+const payload = {
+  recipient: params.recipient,
+  subject: params.subject,
+  body: params.body,
+  ...(cc.length > 0 && { cc }),
+}
+...
+const response = await wretch("https://api.postman.gov.sg/v1/transactional/email/send")
+  .auth(`Bearer ${env.POSTMAN_API_KEY}`)
+  .post(payload)
+  .res()
+```
+(`apps/studio/src/lib/mail.ts:44-56`)
+
+There is no `attachments` field, no multipart body construction, and (per the FAQ requirement above) no evidence Isomer has a custom Postman sending domain configured — `docs/deploy/audit-log-exports.md` explicitly says the audit-export feature added "no new provider config" to the mail pipeline. Wiring in real attachments would require both a code change (multipart request) and an operational change (provisioning a custom domain with Postman support), not just a payload tweak.
+
+## 3. Would a multi-site zip plausibly fit under 2 MB?
+
+Scale inputs found in-repo:
+
+- **"All sites" batch scope is unbounded in code.** `getAdminSiteIds` (`apps/studio/src/server/modules/site/site.service.ts:54-76`) resolves "all sites" for an Isomer Admin to **every row in the `Site` table, platform-wide** — no pagination, no cap, no sampling. `createAuditLogExportRequestsForSites` (`apps/studio/src/server/modules/audit/auditLogExport.service.ts:112-273`) then fans that out into one export-request row (and eventually one CSV) per site, explicitly designed to scale to "an Isomer Admin, every site on the platform" (comment at `auditLogExport.service.ts:104-111`). Neither file states a current site count — the code makes no assumption about how many that is, by design, which is exactly the property that makes "would N CSVs zip under 2 MB" scale-dependent rather than fixed.
+- **Per-CSV size is unbounded and unmeasured at request time.** The export pipeline streams query results straight to S3 via cursor batches (`STREAM_CHUNK_SIZE = 500`, `auditLogExport.service.ts:333-336`) specifically because CSVs are not assumed to be small enough to buffer in memory. `AuditLog` rows (`packages/db/prisma/schema.prisma:302-316`) carry `metadata: Json` and `delta: Json` columns of unbounded size (diff payloads), so per-row CSV width is itself variable, not fixed-width.
+- No file in this repo states an expected site count or expected monthly audit-log row count per site — I could not find a scale estimate to cite (checked `docs/`, `schema.prisma`, `tooling/*/README.md`; nothing quantifies "how many sites" or "how many rows/month" for the platform).
+
+Given that, the honest answer is: **it depends entirely on current platform scale, which isn't documented anywhere I could find**, but the shape of the risk is clear either way:
+- 2 MB (compressed) is very little headroom. A batch export designed to scale to "every site on the platform" with no cap is architecturally the wrong shape to fit inside a hard-coded 2 MB single-attachment ceiling — it might fit today with a handful of low-traffic sites, and then silently stop fitting the moment either site count or per-site audit volume grows, since nothing in the code enforces or even measures against that ceiling.
+- CSV text compresses well (typically 5–10x with zip/deflate), which helps, but doesn't change the fact that the input side (site count × rows/site) is explicitly designed to be uncapped while the Postman limit is a hard, unconditional 2 MB.
+
+**Conclusion for the design decision:** attachments are real, but they impose a tight, silently-enforced (413, not a graceful degrade) ceiling on a feature whose own code comments describe its scope as intentionally unbounded ("every site on the platform"). Treat 2 MB as a hard architectural constraint to design around (e.g. explicit size-checking + fallback before attempting to attach), not a limit to assume away.
+
+## 4. Prior internal discussion of attachments vs. links
+
+Searched via `git log --all --grep` for `attachment`, `postman`, `zip`, and `audit.*export` (case-insensitive) across the full history. Findings:
+
+- **No commit ever discusses email attachments as an option for audit-log exports.** The only `attachment` hits in history are unrelated — the in-Studio `FileAttachment` React component (page-content file uploads: PDFs/images users attach to CMS pages), not anything about outbound email.
+- **The one `postman` hit** (`f9507ebbc Feat/enhance logging for auth (#1833)`) is unrelated to email attachments — it's about auth logging.
+- **`zip` hits** are unrelated to email delivery — a template-bundle build script (`eb25cbc86` extracts zip files for a benchmark) and this same wayfinder-mapping commit's own docs.
+- The two ADRs (`docs/adr/0004-...` and `docs/adr/0006-...`) — both read in full — design the **single-site** link-delivery flow (presigned S3 URL → sealed download token) in detail, including an explicit "Considered options" section in ADR 0004. Neither ADR's considered-options list mentions attachments at all; the alternatives discussed are all still link-based (authenticated Studio route, Exports page with history). This reads as **attachments were never considered, not that they were considered and rejected** — there is no record of anyone evaluating Postman's attachment support for this feature before now.
+
+## Files/URLs referenced
+
+- `apps/studio/src/lib/mail.ts:1-56` — current JSON-only Postman integration, no attachment support
+- `apps/studio/src/server/modules/audit/audit.router.ts:37-96` — batch ("allSites") request entry point
+- `apps/studio/src/server/modules/audit/auditLogExport.service.ts:104-273` — fan-out to one export row per site, explicitly scoped to "every site on the platform"
+- `apps/studio/src/server/modules/site/site.service.ts:54-76` — `getAdminSiteIds`, unbounded platform-wide site resolution for Isomer Admins
+- `packages/db/prisma/schema.prisma:302-316` — `AuditLog` model (unbounded `Json` columns driving variable CSV row width)
+- `docs/adr/0004-emailed-signed-url-delivery-for-audit-exports.md` — link-delivery rationale, no attachment consideration recorded
+- `docs/adr/0006-sealed-download-tokens-for-audit-exports.md` — current link-delivery design, no attachment consideration recorded
+- `docs/deploy/audit-log-exports.md` — confirms "no new provider config" was added to the mail pipeline for this feature
+- https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments — Postman Guide, attachment field/limits/error codes
+- https://postman-v1.guides.gov.sg/email-api-guide/frequently-asked-questions — Postman Guide FAQ, custom-domain prerequisite for attachments
+- https://github.com/opengovsg/postmangovsg-client — official Postman.gov.sg API client (corroborating, not primary)

--- a/.scratch/audit-log-zip-delivery/tickets/01-zip-library-research.md
+++ b/.scratch/audit-log-zip-delivery/tickets/01-zip-library-research.md
@@ -1,0 +1,37 @@
+---
+id: 01-zip-library-research
+title: Select a streaming Node zip library for batch export assembly
+label: wayfinder:research
+status: open
+assignee: null
+blocked_by: []
+map: ../MAP.md
+---
+
+## Question
+
+Which Node zip-archive library should assemble the batch export zip, and
+how does it stream into the existing S3-multipart-upload pattern already
+used for per-site CSV generation (`apps/studio/src/server/modules/audit/auditLogExport.query.ts`,
+see `createCsvTransform` and the streamed multipart upload around it)?
+
+No zip library is currently a dependency anywhere in the repo (checked
+`apps/studio/package.json` and the root `package.json` for
+`archiver|jszip|adm-zip|zip` — no hits).
+
+Cover:
+
+- Candidates: `archiver` (stream-based, widely used), `yazl` (lower-level,
+  stream-based), `jszip` (buffers in memory — likely a poor fit for
+  potentially many/large per-site CSVs). Recommend one.
+- Does the chosen library expose a readable stream that can be piped
+  directly into an S3 multipart upload (mirroring how CSV generation
+  already streams Postgres cursor rows straight to S3), or does it require
+  buffering the whole archive first?
+- Maintenance status and license of the recommended package.
+- A rough sense of scale: how many sites can appear in one "all sites"
+  batch export request today (check `createAuditLogExportRequestsForSites`
+  / how "all sites" is resolved in `apps/studio/src/server/modules/audit/audit.router.ts`
+  and however many sites currently exist on the platform), so the design
+  ticket downstream (04) knows whether streaming vs. buffering actually
+  matters at current scale.

--- a/.scratch/audit-log-zip-delivery/tickets/01-zip-library-research.md
+++ b/.scratch/audit-log-zip-delivery/tickets/01-zip-library-research.md
@@ -2,7 +2,7 @@
 id: 01-zip-library-research
 title: Select a streaming Node zip library for batch export assembly
 label: wayfinder:research
-status: open
+status: closed
 assignee: null
 blocked_by: []
 map: ../MAP.md
@@ -35,3 +35,27 @@ Cover:
   and however many sites currently exist on the platform), so the design
   ticket downstream (04) knows whether streaming vs. buffering actually
   matters at current scale.
+
+## Resolution
+
+Full findings: [`research/01-zip-library-research.md`](../research/01-zip-library-research.md) (from branch `research/audit-zip-library-selection`).
+
+**Use `archiver`** (MIT, `archiverjs/node-archiver`). Its `Archiver` instance
+is itself a `Readable` stream — each site's existing `createCsvTransform()`
+output gets `.append()`-ed as a named zip entry, and the archive's readable
+output pipes straight into the same `@aws-sdk/lib-storage` `Upload` sink
+`uploadAuditLogExport` already uses (`apps/studio/src/lib/s3.ts:422-441`).
+No full-archive or full-file buffering at any stage — the "never buffer an
+export" property of the current pipeline is preserved end-to-end.
+
+`yazl` is a viable but lower-level alternative with a much smaller
+community footprint; no material advantage over `archiver` here. `jszip`
+is disqualified: it builds the whole zip in memory before it can emit
+anything, which directly conflicts with the existing streaming pattern —
+"all sites" batch scope resolves to every `Site` row on the platform with
+no cap (`getAdminSiteIds`, `site.service.ts:54-76`), so buffering the
+whole archive is a real risk, not a theoretical one. No documented site
+count exists in-repo; the research flags a reasoned (not measured)
+low-hundreds estimate, which doesn't change the recommendation either way.
+
+This unblocks half of ticket 04 (paired with ticket 02's resolution).

--- a/.scratch/audit-log-zip-delivery/tickets/02-postman-attachment-research.md
+++ b/.scratch/audit-log-zip-delivery/tickets/02-postman-attachment-research.md
@@ -2,7 +2,7 @@
 id: 02-postman-attachment-research
 title: Confirm Postman.gov.sg attachment support and limits
 label: wayfinder:research
-status: open
+status: closed
 assignee: null
 blocked_by: []
 map: ../MAP.md
@@ -32,3 +32,29 @@ Notes already record the working assumption (link-based, not an
 attachment) settled during grilling — this ticket exists to confirm that
 assumption is correct before it's locked into the ADR that ticket 04
 produces, not to reopen the question.
+
+## Resolution
+
+Full findings: [`research/02-postman-attachment-research.md`](../research/02-postman-attachment-research.md) (from branch `research/postman-attachment-support`).
+
+**Confirmed: stay link-based, not a literal attachment.** Postman.gov.sg's
+API does technically support attachments (up to 10 files, 2MB each, 10MB
+cumulative, `413` on overflow), per the official Postman Guide — but two
+things rule it out here:
+
+1. Attachments require a **custom "from" sending domain** provisioned with
+   Postman; Isomer's audit-export deploy checklist
+   (`docs/deploy/audit-log-exports.md`) confirms "no new provider config"
+   was added for this feature, and `mail.ts` sends plain JSON, not the
+   `multipart/form-data` attachments require.
+2. Even if that were set up, **2MB per attachment is the binding limit for
+   a single zip**, and the batch scope is explicitly unbounded — "every
+   site on the platform" with no cap (`getAdminSiteIds`,
+   `site.service.ts:54-76`). No in-repo evidence bounds how large that zip
+   could get, so a hard-coded 2MB ceiling with a `413` failure mode (not a
+   graceful degrade) is the wrong foundation to build on.
+
+No prior ADR or commit ever evaluated attachments for this feature —
+this was an open question, not a previously-rejected option. This
+confirms the map's settled assumption; combined with ticket 01's `archiver`
+recommendation, it fully unblocks ticket 04.

--- a/.scratch/audit-log-zip-delivery/tickets/02-postman-attachment-research.md
+++ b/.scratch/audit-log-zip-delivery/tickets/02-postman-attachment-research.md
@@ -1,0 +1,34 @@
+---
+id: 02-postman-attachment-research
+title: Confirm Postman.gov.sg attachment support and limits
+label: wayfinder:research
+status: open
+assignee: null
+blocked_by: []
+map: ../MAP.md
+---
+
+## Question
+
+`apps/studio/src/lib/mail.ts` sends transactional email via the
+Postman.gov.sg API with payload `{recipient, subject, body, cc}` — no
+attachment field exists in the current integration, and grepping the repo
+for "attachment" turns up nothing related to email.
+
+Confirm, from Postman.gov.sg's own API documentation:
+
+- Does the transactional email API support real file attachments at all?
+- If so, what are the size/type limits, and would a multi-site zip
+  plausibly fit within them at realistic scale (see ticket 01 for how many
+  sites can be in one batch)?
+- Is there any prior internal decision (search this repo's ADRs, e.g.
+  `docs/adr/0004-emailed-signed-url-delivery-for-audit-exports.md`, and any
+  Isomer engineering docs) explaining why links were chosen over
+  attachments for audit exports in the first place?
+
+This closes off, with an actual citation rather than an assumption,
+whether "deliver as a zip" could mean a literal email attachment. The map's
+Notes already record the working assumption (link-based, not an
+attachment) settled during grilling — this ticket exists to confirm that
+assumption is correct before it's locked into the ADR that ticket 04
+produces, not to reopen the question.

--- a/.scratch/audit-log-zip-delivery/tickets/03-zip-entry-filename-convention.md
+++ b/.scratch/audit-log-zip-delivery/tickets/03-zip-entry-filename-convention.md
@@ -2,8 +2,8 @@
 id: 03-zip-entry-filename-convention
 title: Decide the zip entry filename convention
 label: wayfinder:grilling
-status: open
-assignee: null
+status: closed
+assignee: claude
 blocked_by: []
 map: ../MAP.md
 ---
@@ -31,3 +31,25 @@ Decide the exact filename format, e.g. something like
   there and this is a display-name derived from it, not a new domain
   concept in its own right — use `domain-modeling` judgment on whether it
   warrants an entry or is just an implementation detail).
+
+## Resolution
+
+Resolved directly during implementation (PR [feat: deliver batch audit log
+exports as a single zip file](https://github.com/opengovsg/isomer/pull/3367)),
+once the user asked to move from design to code.
+
+Format: `{sanitizedSiteName}-{siteId}-{reportKind}-{rangeSlug}.csv`
+(`getZipEntryName` in `auditLogExport.service.ts`).
+
+- Sanitization: non-alphanumeric runs replaced with a single `-`, leading/
+  trailing `-` trimmed; an empty result (e.g. an all-emoji site name) falls
+  back to the literal `site`. `siteId` is always appended regardless, so
+  sanitized collisions never cause a real collision.
+- `reportKind`/`rangeSlug` reuse the exact vocabulary the per-CSV S3 key
+  already uses (`access`/`activity`, and the same `getRangeSlug` inclusive-
+  range format), so the in-zip name stays recognizable against the
+  underlying artifact.
+- Not added to `CONTEXT.md` as its own glossary entry — it's a display-name
+  derivation of the already-defined Export Artifact, not a new domain
+  concept. The `CONTEXT.md` update this map's Notes anticipated instead
+  landed as the "Export Batch" entry (see ticket 04's resolution).

--- a/.scratch/audit-log-zip-delivery/tickets/03-zip-entry-filename-convention.md
+++ b/.scratch/audit-log-zip-delivery/tickets/03-zip-entry-filename-convention.md
@@ -1,0 +1,33 @@
+---
+id: 03-zip-entry-filename-convention
+title: Decide the zip entry filename convention
+label: wayfinder:grilling
+status: open
+assignee: null
+blocked_by: []
+map: ../MAP.md
+---
+
+## Question
+
+Each CSV inside the batch zip must make its source site unambiguous to a
+human opening the archive: the original ask calls for siteName **and**
+siteId in the filename.
+
+Decide the exact filename format, e.g. something like
+`{siteName}-{siteId}-{type}-{rangeSlug}.csv`, and settle:
+
+- **Sanitization**: siteName is free-text (site owners choose it) and may
+  contain spaces, slashes, or other filesystem-unsafe characters. What's
+  the sanitization rule (e.g. strip/replace non-alphanumerics), and does
+  the sanitized form still need siteId appended to guarantee uniqueness
+  even if two sites sanitize to the same string?
+- **`type` and `rangeSlug`**: reuse whatever vocabulary the existing S3 key
+  pattern already uses (`audit-log-exports/{siteId}/{requestId}/{access|activity}-{rangeSlug}.csv`,
+  `apps/studio/src/server/modules/audit/auditLogExport.service.ts`) so the
+  in-zip name stays recognizable against the underlying artifact.
+- Whether this convention should be documented in `CONTEXT.md` (a
+  candidate glossary entry, since "Export Artifact" is already defined
+  there and this is a display-name derived from it, not a new domain
+  concept in its own right — use `domain-modeling` judgment on whether it
+  warrants an entry or is just an implementation detail).

--- a/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
+++ b/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
@@ -1,0 +1,50 @@
+---
+id: 04-zip-assembly-storage-design
+title: Design zip assembly, storage, and its interaction with existing CSV reuse
+label: wayfinder:grilling
+status: open
+assignee: null
+blocked_by: [01-zip-library-research, 02-postman-attachment-research]
+map: ../MAP.md
+---
+
+## Question
+
+Design where and how the batch zip gets built and stored, using the
+library ticket 01 selects and the confirmed delivery mechanism from
+ticket 02. This ticket is expected to produce a new ADR (supersedes/extends
+`docs/adr/0006-sealed-download-tokens-for-audit-exports.md` for the batch
+case) — see the `domain-modeling` skill's ADR criteria; this change is
+hard to reverse, surprising without context, and the result of a real
+trade-off, so it qualifies.
+
+Cover:
+
+- **Where in the pipeline**: extend `maybeSendAuditLogExportBatchEmail`
+  (`apps/studio/src/server/modules/audit/auditLogExport.service.ts:407`) to
+  build the zip once every sibling site's row is terminal, or introduce a
+  separate step? The map's Notes already settle that this must be
+  retry-safe and idempotent (see ticket 06 for the failure-handling
+  detail — don't re-decide that here, just make sure the assembly point
+  you choose is compatible with retrying).
+- **S3 key pattern** for the zip object, following the existing
+  `audit-log-exports/{siteId}/{requestId}/{type}-{rangeSlug}.csv`
+  convention's spirit — likely keyed by `batchId` and range rather than
+  siteId/requestId since it spans multiple sites.
+- **Interaction with ADR 0005 reuse**: confirm (per the map's settled
+  answer) that per-site CSV reuse keeps working completely unchanged
+  underneath, and that the zip itself introduces no new
+  reuse/dedup/caching mechanism — it just streams whatever CSVs exist
+  (fresh or reused) into a new zip object every time.
+- **Failed sites**: the zip contains only successfully-generated CSVs;
+  failed site names continue to be listed as plain text in the email body
+  (as `auditLogExportBatchReadyTemplate` already does today) rather than,
+  say, a manifest file inside the zip.
+- What the zip's total `sizeInBytes` is computed from, for use in the
+  email template (ticket 07).
+
+## Downstream
+
+Resolving this unblocks ticket 05 (Download Token flow) and ticket 06
+(failure/retry handling), both of which need the object-key and
+assembly-point decisions made here.

--- a/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
+++ b/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
@@ -2,8 +2,8 @@
 id: 04-zip-assembly-storage-design
 title: Design zip assembly, storage, and its interaction with existing CSV reuse
 label: wayfinder:grilling
-status: open
-assignee: null
+status: in-progress
+assignee: claude
 blocked_by: []  # was [01-zip-library-research, 02-postman-attachment-research], both closed — see their Resolutions
 map: ../MAP.md
 ---

--- a/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
+++ b/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
@@ -2,7 +2,7 @@
 id: 04-zip-assembly-storage-design
 title: Design zip assembly, storage, and its interaction with existing CSV reuse
 label: wayfinder:grilling
-status: in-progress
+status: closed
 assignee: claude
 blocked_by: []  # was [01-zip-library-research, 02-postman-attachment-research], both closed — see their Resolutions
 map: ../MAP.md
@@ -48,3 +48,33 @@ Cover:
 Resolving this unblocks ticket 05 (Download Token flow) and ticket 06
 (failure/retry handling), both of which need the object-key and
 assembly-point decisions made here.
+
+## Resolution
+
+Full design recorded as [ADR 0009](../../../docs/adr/0009-batch-audit-log-exports-delivered-as-one-zip.md).
+
+- Zip assembly extends `maybeSendAuditLogExportBatchEmail` in place
+  (same advisory-lock transaction), using `archiver` (ticket 01) piped
+  into the existing S3 `Upload` sink.
+- The "already emailed" claim (`batchEmailedAt`) moves from before the
+  slow work to after it succeeds — the locked transaction becomes
+  read-only, zip-build/upload/send happen outside it, and the claim is
+  written in a follow-up update only once send succeeds. **This exposes a
+  real gap for ticket 06**: batch email dispatch is only triggered as a
+  side effect of a sibling row going terminal, not on its own cron
+  cadence — once every sibling is terminal, nothing will naturally retry
+  a failed attempt on "the next tick" without a dedicated sweep. Ticket 06
+  must add that sweep, not just assume reprocessing will happen.
+- New `AuditLogExportBatch` table (keyed by `batchId`: `zipObjectKey`,
+  `zipSizeInBytes`, `emailedAt`) instead of redundant columns on every
+  sibling row.
+- S3 key: `audit-log-exports/batch/{batchId}/{reportType}-{rangeSlug}.zip`.
+- `sizeInBytes` read via `HeadObject` post-upload.
+- `uploadAuditLogExport` (`apps/studio/src/lib/s3.ts`) needs a
+  `contentType` param (default `text/csv`) to also accept
+  `application/zip`.
+- Confirmed stacking dependency: this and everything downstream builds on
+  the not-yet-merged batching feature (`batchId`/`batchEmailedAt`/
+  `maybeSendAuditLogExportBatchEmail`), which exists only on
+  `fix/batch-audit-logs`, not `main`. Implementation must branch from
+  there.

--- a/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
+++ b/.scratch/audit-log-zip-delivery/tickets/04-zip-assembly-storage-design.md
@@ -4,7 +4,7 @@ title: Design zip assembly, storage, and its interaction with existing CSV reuse
 label: wayfinder:grilling
 status: open
 assignee: null
-blocked_by: [01-zip-library-research, 02-postman-attachment-research]
+blocked_by: []  # was [01-zip-library-research, 02-postman-attachment-research], both closed — see their Resolutions
 map: ../MAP.md
 ---
 

--- a/.scratch/audit-log-zip-delivery/tickets/05-download-token-flow-for-batch-zip.md
+++ b/.scratch/audit-log-zip-delivery/tickets/05-download-token-flow-for-batch-zip.md
@@ -1,0 +1,41 @@
+---
+id: 05-download-token-flow-for-batch-zip
+title: Extend the sealed Download Token flow to resolve a shared batch zip
+label: wayfinder:grilling
+status: open
+assignee: null
+blocked_by: [04-zip-assembly-storage-design]
+map: ../MAP.md
+---
+
+## Question
+
+Today's Download Token (`docs/adr/0006-sealed-download-tokens-for-audit-exports.md`)
+carries `{purpose: "audit-log-export", requestId}`, is unsealed at
+`apps/studio/src/pages/api/audit-log-exports/download.ts`, re-reads the
+`AuditLogExportRequest` row, and 302-redirects to a freshly-presigned URL
+for that row's single CSV object.
+
+With one zip now shared across every site in a batch, decide:
+
+- What does the token payload identify instead — `batchId`? A new
+  dedicated identifier for the zip object from ticket 04's S3 key design?
+- Does this need a new `purpose` discriminator (e.g.
+  `"audit-log-export-batch"`) alongside the existing one, so the unseal
+  logic can tell single-CSV and batch-zip tokens apart and 400 cleanly on
+  a shape mismatch (per ADR 0006's existing "strict payload-shape
+  validation" pattern) — or does one payload shape cover both?
+- What re-read at click time replaces "row is `Done` and within its
+  Download Window" for a batch — presumably: every sibling row for the
+  `batchId` is terminal and the shared zip object exists, but confirm
+  what "the batch's Download Window" anchors to (today: `completedAt` of
+  the individual row — ADR 0006 explicitly chose per-request windows
+  because of ADR 0005 reuse; a batch has no single `completedAt`).
+- Revocation: ADR 0006 notes "flip the row or delete the object and every
+  outstanding link dies" — what's the equivalent guarantee for a batch
+  zip shared by N rows?
+
+This is the ADR-bearing decision ticket 04 sets up; write the outcome into
+the same ADR (or a clearly-linked follow-on section) rather than a
+separate document, since token semantics and zip storage are one design,
+not two.

--- a/.scratch/audit-log-zip-delivery/tickets/05-download-token-flow-for-batch-zip.md
+++ b/.scratch/audit-log-zip-delivery/tickets/05-download-token-flow-for-batch-zip.md
@@ -2,9 +2,9 @@
 id: 05-download-token-flow-for-batch-zip
 title: Extend the sealed Download Token flow to resolve a shared batch zip
 label: wayfinder:grilling
-status: open
-assignee: null
-blocked_by: [04-zip-assembly-storage-design]
+status: closed
+assignee: claude
+blocked_by: []  # was [04-zip-assembly-storage-design], closed
 map: ../MAP.md
 ---
 
@@ -39,3 +39,26 @@ This is the ADR-bearing decision ticket 04 sets up; write the outcome into
 the same ADR (or a clearly-linked follow-on section) rather than a
 separate document, since token semantics and zip storage are one design,
 not two.
+
+## Resolution
+
+Resolved directly during implementation (PR [feat: deliver batch audit log
+exports as a single zip file](https://github.com/opengovsg/isomer/pull/3367));
+outcome folded into [ADR 0009](../../../docs/adr/0009-batch-audit-log-exports-delivered-as-one-zip.md)
+per this ticket's own instruction, not a separate doc.
+
+- Payload identifies `batchId` — `{purpose: "audit-log-export-batch", batchId}`.
+- New `purpose` discriminator, `audit-log-export-batch`, alongside the
+  existing `audit-log-export` one. `unsealAuditLogExportToken` now returns
+  a tagged union (`{kind: "request", requestId} | {kind: "batch", batchId}`)
+  instead of a bare string, so the download route branches on kind.
+- Click-time re-read: `AuditLogExportBatch.zipObjectKey !== null &&
+  emailedAt !== null`, replacing the per-request `status === Done` check.
+- Window anchor: `AuditLogExportBatch.emailedAt` (stamped only once the
+  zip is built and the email sent) — the batch equivalent of a single
+  request's `completedAt`, exactly as this ticket anticipated.
+- Revocation: nulling `AuditLogExportBatch.zipObjectKey` or deleting the
+  zip object kills every outstanding link for that batch in one place —
+  the same guarantee ADR 0006 describes for a single request, now scoped
+  to the batch's one shared row instead of duplicated across N sibling
+  rows.

--- a/.scratch/audit-log-zip-delivery/tickets/06-zip-build-failure-retry-handling.md
+++ b/.scratch/audit-log-zip-delivery/tickets/06-zip-build-failure-retry-handling.md
@@ -2,9 +2,9 @@
 id: 06-zip-build-failure-retry-handling
 title: Design zip-build failure and retry handling in the cron job
 label: wayfinder:grilling
-status: open
-assignee: null
-blocked_by: [04-zip-assembly-storage-design]
+status: closed
+assignee: claude
+blocked_by: []  # was [04-zip-assembly-storage-design], closed
 map: ../MAP.md
 ---
 
@@ -37,3 +37,34 @@ the zip is assembled:
 - Does a zip-build failure need its own logging/alerting distinct from
   per-site CSV generation failures, so a stuck batch is visible to an
   operator?
+
+## Resolution
+
+Resolved directly during implementation (PR [feat: deliver batch audit log
+exports as a single zip file](https://github.com/opengovsg/isomer/pull/3367)).
+This ticket's real substance turned out bigger than "mechanics": ticket 04's
+own resolution had already surfaced that moving the "already emailed" claim
+to after the slow work (S3 + email) makes `maybeSendAuditLogExportBatchEmail`
+no longer self-triggering once a batch is fully terminal — a genuinely new
+retry mechanism was needed, not just a state-shape decision.
+
+- **State**: `AuditLogExportBatch.claimedAt` — a lease (mirrors
+  `PROCESSING_LEASE_MS`'s role for individual rows), stamped the moment an
+  attempt starts, distinct from `emailedAt` (stamped only on full success).
+  "Not built yet" = no row; "claimed, in flight or dead" = `claimedAt` set,
+  `emailedAt` null; "done" = `emailedAt` set.
+- **Avoiding wasted re-triggers**: a new `processPendingAuditLogExportBatchEmails`
+  sweep (wired into the existing cron job alongside `processPendingAuditLogExports`)
+  finds batches that are fully terminal AND not yet emailed, skipping any
+  batch still in-progress (a sibling row not yet terminal) via a cheap
+  distinct-batchId query. `maybeSendAuditLogExportBatchEmail`'s own claim
+  check (fresh `claimedAt` → back off) prevents this sweep from duplicating
+  a still-running attempt.
+- **Retry cap**: none — retries indefinitely until success, matching this
+  job's existing posture (confirmed against `processAuditLogExportRequest`'s
+  own MAX_ATTEMPTS-free stale-reclaim pattern for the row-level lease).
+  `BATCH_EMAIL_LEASE_MS` reuses the same 15-minute value as
+  `PROCESSING_LEASE_MS`.
+- **Alerting**: no new alerting infra — a retry attempt logs at `error`
+  level with the `batchId`, using the existing logger, consistent with how
+  per-site failures are already surfaced.

--- a/.scratch/audit-log-zip-delivery/tickets/06-zip-build-failure-retry-handling.md
+++ b/.scratch/audit-log-zip-delivery/tickets/06-zip-build-failure-retry-handling.md
@@ -1,0 +1,39 @@
+---
+id: 06-zip-build-failure-retry-handling
+title: Design zip-build failure and retry handling in the cron job
+label: wayfinder:grilling
+status: open
+assignee: null
+blocked_by: [04-zip-assembly-storage-design]
+map: ../MAP.md
+---
+
+## Question
+
+The map's Notes already settle the high-level answer: a zip-build failure
+(e.g. an S3 read error mid-stream while assembling the archive) retries on
+the next cron tick, and per-site rows already `Done` are left untouched —
+zip assembly is a separate, idempotent, retry-safe step layered on top of
+`maybeSendAuditLogExportBatchEmail`, matching the job's existing
+retry-safe design (`apps/studio/src/server/cron/jobs/auditLogExportJob.ts`,
+`processPendingAuditLogExports`).
+
+This ticket works out the mechanics, once ticket 04 has fixed where/how
+the zip is assembled:
+
+- What state (if any) needs to be persisted to know "the zip for this
+  batch hasn't been built yet" vs. "built, email not yet sent" vs. "email
+  sent" — a new column on some row, or is this derivable from what
+  already exists (e.g. absence of the zip object in S3, or absence of a
+  `batchEmailedAt` timestamp)?
+- How does the cron sweep avoid re-triggering zip assembly (and wasted S3
+  reads) on every tick for a batch that's still legitimately in-progress
+  (not every sibling site row terminal yet) vs. one that's stuck retrying
+  a failed zip build?
+- Is there a retry cap / backoff, or does it retry indefinitely until it
+  succeeds (same posture as the rest of this job today — confirm by
+  reading how `processPendingAuditLogExports` currently handles stale/
+  failed rows)?
+- Does a zip-build failure need its own logging/alerting distinct from
+  per-site CSV generation failures, so a stuck batch is visible to an
+  operator?

--- a/.scratch/audit-log-zip-delivery/tickets/07-batch-email-template-rework.md
+++ b/.scratch/audit-log-zip-delivery/tickets/07-batch-email-template-rework.md
@@ -1,0 +1,37 @@
+---
+id: 07-batch-email-template-rework
+title: Rework the batch-ready email template for a single zip link
+label: wayfinder:grilling
+status: open
+assignee: null
+blocked_by: [05-download-token-flow-for-batch-zip, 06-zip-build-failure-retry-handling]
+map: ../MAP.md
+---
+
+## Question
+
+`auditLogExportBatchReadyTemplate`
+(`apps/studio/src/features/mail/templates/templates.ts:337-369`) currently
+renders one `<li><b>{siteName}</b>: <a>...</a></li>` per successful site,
+plus a failed-sites list, backed by
+`AuditLogExportBatchReadyEmailTemplateData`
+(`apps/studio/src/features/mail/templates/types.ts:87-95`):
+`{month, reportLabel, links: {siteName, url, sizeInBytes}[], failedSiteNames}`.
+
+Once tickets 05 (token/link shape) and 06 (failure/retry semantics) are
+settled, rework:
+
+- **Template data shape**: replace the per-site `links` array with
+  whatever ticket 05 produces (a single zip download URL) plus enough
+  data to still list which sites are included — the recipient can't
+  preview zip contents before downloading, so the email body should still
+  name every site whose CSV made it in, even though they now share one
+  link.
+- **Copy**: the email needs new wording — no longer "here are your N
+  links", but "here is one zip containing N sites' reports"; failed sites
+  keep their own listing (unchanged from today).
+- **Size display**: swap per-site `sizeInBytes` for the zip's total size
+  (from ticket 04).
+- Whether a **prototype** pass (the `prototype` skill) is worth running
+  first to sanity-check the new copy/layout before locking the type
+  change — recommended given this is user-facing copy, not just plumbing.

--- a/.scratch/audit-log-zip-delivery/tickets/07-batch-email-template-rework.md
+++ b/.scratch/audit-log-zip-delivery/tickets/07-batch-email-template-rework.md
@@ -2,9 +2,9 @@
 id: 07-batch-email-template-rework
 title: Rework the batch-ready email template for a single zip link
 label: wayfinder:grilling
-status: open
-assignee: null
-blocked_by: [05-download-token-flow-for-batch-zip, 06-zip-build-failure-retry-handling]
+status: closed
+assignee: claude
+blocked_by: []  # was [05, 06], both closed
 map: ../MAP.md
 ---
 
@@ -35,3 +35,25 @@ settled, rework:
 - Whether a **prototype** pass (the `prototype` skill) is worth running
   first to sanity-check the new copy/layout before locking the type
   change — recommended given this is user-facing copy, not just plumbing.
+
+## Resolution
+
+Resolved directly during implementation (PR [feat: deliver batch audit log
+exports as a single zip file](https://github.com/opengovsg/isomer/pull/3367)),
+once the user asked to move from design straight to code — the recommended
+prototype pass on copy was skipped for that reason, not overruled; the
+copy below is a reasonable first cut, not a validated one.
+
+- `AuditLogExportBatchReadyEmailTemplateData.links` replaced with
+  `zipLink?: {url, sizeInBytes}` (optional — undefined when every site
+  failed, see below) plus `includedSiteNames: string[]`, naming every site
+  whose CSV made it into the zip since the recipient can't preview the
+  archive before downloading.
+- Copy: "You requested ... logs for all your sites for {month}, bundled
+  into a single zip file", one download line, then an "This zip includes
+  ... logs for:" list, then the existing failed-sites section unchanged.
+- Size: `zipLink.sizeInBytes` is the zip's total size (read via
+  `HeadObject` after upload, per ADR 0009), not a per-site figure.
+- Edge case this ticket didn't originally flag: a batch where **every**
+  site failed has nothing to zip at all — `zipLink` is `undefined` in that
+  case and the template renders no download line, just the failure list.

--- a/docs/adr/0009-batch-audit-log-exports-delivered-as-one-zip.md
+++ b/docs/adr/0009-batch-audit-log-exports-delivered-as-one-zip.md
@@ -1,0 +1,102 @@
+---
+status: accepted
+extends: 0006-sealed-download-tokens-for-audit-exports.md
+---
+
+# Batch Audit Log Exports are delivered as one zip archive behind one Download Token
+
+A **batch** (all-sites) Audit Log Export email delivers **one zip archive**
+containing every successfully-generated site's CSV — named so the source
+site is unambiguous — behind **one** sealed Download Token, instead of the
+current N per-site download links in one email body. Single-site,
+single-report exports are unchanged: they keep their existing one-CSV,
+one-link email.
+
+The zip stays link-based, not a literal email attachment: it is assembled
+server-side and uploaded to S3 as a single object, delivered the same way
+CSVs already are (ADR 0006's sealed Download Token, redeemed at
+`apps/studio/src/pages/api/audit-log-exports/download.ts`, minting a
+short-lived presigned URL at click time).
+
+## Why not a real email attachment
+
+Postman.gov.sg's transactional email API does support attachments, but two
+things rule it out for this feature: attachments require a custom "from"
+sending domain that Isomer hasn't provisioned for this mail pipeline (the
+current integration sends plain JSON, not the `multipart/form-data`
+attachments require), and the binding size limit is 2MB per attachment —
+a hard, non-graceful (`413`) ceiling against a batch scope that's
+explicitly unbounded in code ("every site on the platform" for an Isomer
+Admin, via `getAdminSiteIds`, no cap). A zip-behind-a-link has no such
+ceiling.
+
+## Decisions and their reasons
+
+- **Zip assembly extends `maybeSendAuditLogExportBatchEmail` in place**
+  (`apps/studio/src/server/modules/audit/auditLogExport.service.ts`),
+  rather than a new separate step. That function already holds the
+  per-batch advisory lock and the "are all siblings terminal" check this
+  needs; a separate step would have to re-derive both.
+- **`archiver`** (MIT, streaming) assembles the zip. Its `Archiver`
+  instance is itself a `Readable`, so each site's existing
+  `createCsvTransform()` output is `.append()`-ed as a named entry and the
+  archive's output pipes directly into the same `@aws-sdk/lib-storage`
+  `Upload` sink `uploadAuditLogExport` already uses — no stage in the
+  pipeline (Postgres cursor → CSV → zip entry → S3 multipart part) ever
+  buffers a full file or the full archive in memory. `jszip` was rejected
+  for buffering the whole archive before emitting anything, which directly
+  conflicts with that never-buffer property; `yazl` is a viable but
+  lower-level alternative with no material advantage here.
+- **The zip is rebuilt fresh every time a batch completes; no new
+  reuse/caching layer.** A `batchId` is minted fresh (`randomUUID()`) for
+  every "allSites" ask, so there's no second identical ask that would
+  benefit from reusing a previous zip the way ADR 0005's per-site CSV
+  reuse benefits repeated single-site asks. Per-site CSV reuse is
+  completely unaffected — the zip step just streams whatever CSVs exist
+  (freshly generated or ADR-0005-reused) into a new zip object every time.
+- **The "already emailed" claim moves from before the slow work to after
+  it.** Today `batchEmailedAt` is stamped inside the advisory-lock
+  transaction, before links are built or mail is sent. With zip assembly
+  now sitting in that gap, the claim must move to *after* the zip is
+  built, uploaded, and the email actually sends — otherwise a failed zip
+  build would look "already handled" forever and the batch would never
+  retry. Concretely: the locked transaction becomes read-only (checks "all
+  terminal, not yet emailed"); zip-build, upload, and send happen outside
+  it; the claim is written in a short follow-up update only once send
+  succeeds. This surfaces a gap for a follow-on ticket to close: batch
+  email dispatch today is only triggered as a side effect of a sibling row
+  transitioning to terminal, not on a cron cadence of its own — once every
+  sibling is already terminal, nothing will naturally re-invoke this on a
+  later tick. A dedicated sweep for "batch fully terminal, not yet
+  emailed" is needed to make the retry real, not just theoretical.
+- **A new `AuditLogExportBatch` table, keyed by `batchId`**, holds
+  `zipObjectKey`, `zipSizeInBytes`, and `emailedAt` — not new columns
+  repeated across every sibling `AuditLogExportRequest` row. This data is
+  inherently per-batch, not per-site-row; redundant N-way writes invite
+  partial-write drift, and it gives the Download Token flow one
+  unambiguous row to key off instead of picking an arbitrary sibling and
+  trusting it.
+- **S3 key**: `audit-log-exports/batch/{batchId}/{reportType}-{rangeSlug}.zip`.
+  `batchId` alone already guarantees uniqueness; `reportType`/`rangeSlug`
+  are included purely for human-readability in the S3 console, mirroring
+  the existing per-CSV key's spirit.
+- **Failed sites stay outside the zip.** The zip contains only
+  successfully-generated CSVs; failed site names continue to be listed as
+  plain text in the email body, unchanged from today's batch email.
+- **`sizeInBytes`** is read back with a `HeadObject` once the upload
+  completes, rather than tracked manually through the `archiver` stream.
+
+## Consequences
+
+- `uploadAuditLogExport` (`apps/studio/src/lib/s3.ts`) needs a
+  `contentType` parameter (defaulting to `text/csv`) since it currently
+  hardcodes the CSV content type; the zip upload passes
+  `application/zip`.
+- The Download Token's payload and the download route's re-read logic
+  need a batch-shaped path alongside the existing single-request path
+  (tracked as a follow-on decision, not solved by this ADR).
+- This stacks on top of the not-yet-merged batching feature (`batchId`,
+  `batchEmailedAt`, `maybeSendAuditLogExportBatchEmail` — currently only
+  on `fix/batch-audit-logs`, not `main`); it cannot be implemented or
+  reviewed independently of that branch landing first, or without basing
+  this work on top of it.


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 10 | +757 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 1 | +102 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary

Charts a wayfinder planning map for delivering **batch** (all-sites) audit-log-export emails as a single zip archive (with siteName + siteId embedded in each CSV's filename) instead of a list of per-site download links, per request. This is planning only — no production code changes yet.

- Map + 7 child tickets under `.scratch/audit-log-zip-delivery/` (no GitHub/GitLab tracker is configured for this repo yet, so this uses the wayfinder skill's local-markdown fallback — see `.scratch/audit-log-zip-delivery/MAP.md`).
- Destination: a locked technical design (tickets + a new ADR) ready for a separate implementation pass. Scope is the batch email only; the single-site/single-report email is unchanged.
- Two research tickets (zip library selection, Postman.gov.sg attachment-support confirmation) are running in the background and will land as follow-up commits on this branch.

## Test plan

- [ ] N/A — planning artifacts only, no code changes