### PR TITLE
📆 feat(studio): tag dates on collection items

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -4,6 +4,7 @@ export const JSON_FORMS_RANKING = {
   TagCategoryControl: 5,
   TagCategoryOptionsControl: 5,
   DateFilterStatusLabelsControl: 5,
+  DateFilterValuesControl: 4,
   TaggedControl: 4,
   BooleanControl: 2,
   ConstControl: 2,

--- a/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
@@ -63,7 +63,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         if (type === ResourceType.CollectionPage) {
-          void utils.collection.countTagOptionsUsage.invalidate()
+          void utils.collection.countFilterUsage.invalidate()
         }
         toast({
           status: "success",

--- a/apps/studio/src/features/editing-experience/components/Drawer/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/LinkEditorDrawer.tsx
@@ -15,6 +15,7 @@ import { trpc } from "~/utils/trpc"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
 import { useCollectionTags } from "../../hooks/useCollectionTags"
+import { validateRequiredDateFilters } from "../../utils/validateRequiredDateFilters"
 import { validateRequiredTags } from "../../utils/validateRequiredTags"
 import { ActivateRawJsonEditorMode } from "../ActivateRawJsonEditorMode"
 import { ErrorProvider, useBuilderErrors } from "../form-builder/ErrorProvider"
@@ -56,10 +57,15 @@ const InnerDrawer = ({
       resourceId: linkId,
       siteId,
     })
-  const { isValid: isTagsValid } = validateRequiredTags(
+  const { isValid: isTaggedValid } = validateRequiredTags(
     collectionTags,
     previewPageState.tagged,
   )
+  const { isValid: isDateTaggedValid } = validateRequiredDateFilters(
+    collectionTags,
+    previewPageState.dateTagged,
+  )
+  const isTagsValid = isTaggedValid && isDateTaggedValid
 
   return (
     <Flex flexDir="column" position="relative" h="100%" w="100%">
@@ -194,7 +200,7 @@ export const LinkEditorDrawer = ({
     trpc.collection.updateCollectionLink.useMutation({
       onSuccess: () => {
         void utils.collection.readCollectionLink.invalidate()
-        void utils.collection.countTagOptionsUsage.invalidate()
+        void utils.collection.countFilterUsage.invalidate()
         void utils.page.readPage.invalidate()
         toast({
           title: "Link updated!",

--- a/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
@@ -1,4 +1,7 @@
-import type { IsomerSchema } from "@opengovsg/isomer-components"
+import type {
+  ArticlePagePageProps,
+  IsomerSchema,
+} from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
 import { Box, Flex, Text, useDisclosure } from "@chakra-ui/react"
 import { Button, Infobox, useToast } from "@opengovsg/design-system-react"
@@ -20,6 +23,7 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 import type { CollectionTags } from "../../hooks/useCollectionTags"
 import { useCollectionTags } from "../../hooks/useCollectionTags"
 import { pageSchema } from "../../schema"
+import { validateRequiredDateFilters } from "../../utils/validateRequiredDateFilters"
 import { validateRequiredTags } from "../../utils/validateRequiredTags"
 import { CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE } from "../constants"
 import { DiscardChangesModal } from "../DiscardChangesModal"
@@ -204,6 +208,14 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
                 onClick={handleSaveChanges}
                 tags={collectionTags}
                 tagged={(previewPageState.page as { tagged?: string[] }).tagged}
+                dateTagged={
+                  (
+                    previewPageState.page as Pick<
+                      ArticlePagePageProps,
+                      "dateTagged"
+                    >
+                  ).dateTagged
+                }
               />
             ) : (
               <SaveButton
@@ -247,15 +259,25 @@ const TagsAwareSaveButton = ({
   isLoading,
   tags,
   tagged,
+  dateTagged,
 }: {
   onClick: () => void
   isLoading: boolean
   tags: CollectionTags
   tagged: string[] | undefined
+  dateTagged: ArticlePagePageProps["dateTagged"]
 }) => {
-  const { isValid } = validateRequiredTags(tags, tagged)
+  const { isValid: isTaggedValid } = validateRequiredTags(tags, tagged)
+  const { isValid: isDateTaggedValid } = validateRequiredDateFilters(
+    tags,
+    dateTagged,
+  )
 
   return (
-    <SaveButton isLoading={isLoading} onClick={onClick} isTagsValid={isValid} />
+    <SaveButton
+      isLoading={isLoading}
+      onClick={onClick}
+      isTagsValid={isTaggedValid && isDateTaggedValid}
+    />
   )
 }

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -254,7 +254,7 @@ export default function RootStateDrawer() {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         if (type === ResourceType.CollectionPage) {
-          void utils.collection.countTagOptionsUsage.invalidate()
+          void utils.collection.countFilterUsage.invalidate()
         }
         toast({
           status: "success",

--- a/apps/studio/src/features/editing-experience/components/Drawer/__tests__/RootStateDrawer.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/__tests__/RootStateDrawer.browser.test.tsx
@@ -43,7 +43,7 @@ vi.mock("~/utils/trpc", () => ({
         readPageAndBlob: { invalidate: noop },
       },
       collection: {
-        countTagOptionsUsage: { invalidate: noop },
+        countFilterUsage: { invalidate: noop },
       },
     }),
   },

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -33,6 +33,8 @@ import {
   jsonFormsDateControlTester,
   JsonFormsDateFilterStatusLabelsControl,
   jsonFormsDateFilterStatusLabelsControlTester,
+  JsonFormsDateFilterValuesControl,
+  jsonFormsDateFilterValuesControlTester,
   JsonFormsDgsDatasetIdControl,
   jsonFormsDgsDatasetIdControlTester,
   JsonFormsEmbedControl,
@@ -124,6 +126,10 @@ export const renderers: JsonFormsRendererRegistryEntry[] = [
   },
   { renderer: JsonFormsUuidControl, tester: jsonFormsUuidControlTester },
   { renderer: JsonFormsTaggedControl, tester: jsonFormsTaggedControlTester },
+  {
+    renderer: JsonFormsDateFilterValuesControl,
+    tester: jsonFormsDateFilterValuesControlTester,
+  },
   {
     renderer: JsonFormsChildrenPagesOrderingControl,
     tester: jsonFormsChildrenPagesOrderingControlTester,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDateFilterValuesControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDateFilterValuesControl.tsx
@@ -1,0 +1,129 @@
+import type { ControlProps, RankedTester } from "@jsonforms/core"
+import type { DateRangeValue } from "@opengovsg/design-system-react"
+import type { ArticlePagePageProps } from "@opengovsg/isomer-components"
+import { FormControl, Skeleton, VStack } from "@chakra-ui/react"
+import { rankWith, schemaMatches } from "@jsonforms/core"
+import { withJsonFormsControlProps } from "@jsonforms/react"
+import {
+  DateRangePicker,
+  FormErrorMessage,
+  FormLabel,
+} from "@opengovsg/design-system-react"
+import { isDateFilter } from "@opengovsg/isomer-components"
+import { format, parseISO } from "date-fns"
+import Suspense from "~/components/Suspense"
+import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { useSuspenseCollectionTags } from "~/features/editing-experience/hooks/useCollectionTags"
+import { collectionItemSchema } from "~/features/editing-experience/schema"
+import { useQueryParse } from "~/hooks/useQueryParse"
+
+export const jsonFormsDateFilterValuesControlTester: RankedTester = rankWith(
+  JSON_FORMS_RANKING.DateFilterValuesControl,
+  schemaMatches((schema) => schema.format === "date-tagged"),
+)
+
+interface DateFilterValuesControlProps extends Omit<ControlProps, "data"> {
+  data: ArticlePagePageProps["dateTagged"]
+}
+
+export function JsonFormsDateFilterValuesControl({
+  data,
+  path,
+  description,
+  handleChange,
+}: DateFilterValuesControlProps) {
+  return (
+    <Suspense fallback={<Skeleton />}>
+      <SuspendableJsonFormsDateFilterValuesControl
+        data={data}
+        path={path}
+        description={description}
+        handleChange={handleChange}
+      />
+    </Suspense>
+  )
+}
+
+type SuspendableJsonFormsDateFilterValuesControlProps = Pick<
+  DateFilterValuesControlProps,
+  "data" | "handleChange" | "description" | "path"
+>
+
+// No separate single/range toggle: DateRangePicker's own value shape
+// ([Date,Date] | [Date,null] | [null,null]) already models "only a start
+// picked so far" — picking a second date is what promotes an entry to a
+// range. See wayfinder ticket 007.
+const SuspendableJsonFormsDateFilterValuesControl = ({
+  path,
+  data,
+  handleChange,
+  description,
+}: SuspendableJsonFormsDateFilterValuesControlProps) => {
+  const { siteId, linkId, pageId } = useQueryParse(collectionItemSchema)
+  // NOTE: Since this is only rendered inside a collection page or collection link,
+  // we should always have the `resourceId` specifier
+  const resourceId = linkId ?? pageId ?? 1
+  const [tags] = useSuspenseCollectionTags({ resourceId, siteId })
+
+  const dateFilters = tags.filter(isDateFilter)
+
+  // NOTE: Because we render according to the schema, this will also be
+  // rendered for Article pages that are not part of a collection. Hence, we
+  // render iff there is at least 1 date filter.
+  return (
+    dateFilters.length > 0 && (
+      <VStack spacing="1.25rem">
+        {dateFilters.map(({ id, label, isRequired: dateIsRequired }) => {
+          const existing = data?.find((value) => value.id === id)
+          const value: DateRangeValue = existing
+            ? [
+                parseISO(existing.date),
+                existing.endDate ? parseISO(existing.endDate) : null,
+              ]
+            : [null, null]
+
+          const isInvalid = !!dateIsRequired && !existing?.date
+
+          const handleDateChange = ([start, end]: DateRangeValue) => {
+            const others = data?.filter((value) => value.id !== id) ?? []
+
+            if (!start) {
+              handleChange(path, others)
+              return
+            }
+
+            handleChange(path, [
+              ...others,
+              {
+                id,
+                date: format(start, "yyyy-MM-dd"),
+                ...(end ? { endDate: format(end, "yyyy-MM-dd") } : {}),
+              },
+            ])
+          }
+
+          return (
+            <FormControl
+              key={id}
+              isRequired={dateIsRequired ?? false}
+              isInvalid={isInvalid}
+              gap="0.5rem"
+            >
+              <FormLabel description={description}>{label}</FormLabel>
+              <DateRangePicker
+                value={value}
+                onChange={handleDateChange}
+                monthsToDisplay={1}
+              />
+              {isInvalid && (
+                <FormErrorMessage>A date must be selected</FormErrorMessage>
+              )}
+            </FormControl>
+          )
+        })}
+      </VStack>
+    )
+  )
+}
+
+export default withJsonFormsControlProps(JsonFormsDateFilterValuesControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -8,6 +8,7 @@ import {
   FormLabel,
   MultiSelect,
 } from "@opengovsg/design-system-react"
+import { isTextFilter } from "@opengovsg/isomer-components"
 import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { useSuspenseCollectionTags } from "~/features/editing-experience/hooks/useCollectionTags"
@@ -66,6 +67,9 @@ const SuspendableJsonFormsTaggedControl = ({
     tags.length > 0 && (
       <VStack spacing="1.25rem">
         {tags
+          // NOTE: date filters have no `options`/`tagged` membership — their
+          // value is edited by JsonFormsDateFilterValuesControl instead.
+          .filter(isTextFilter)
           .filter(({ options }) => options.length > 0)
           .map(({ label, options, isRequired: tagIsRequired }) => {
             const currentTagCategoryOptions = options.filter(({ id }) =>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -113,6 +113,10 @@ export {
   jsonFormsDateFilterStatusLabelsControlTester,
 } from "./JsonFormsDateFilterStatusLabelsControl"
 export {
+  default as JsonFormsDateFilterValuesControl,
+  jsonFormsDateFilterValuesControlTester,
+} from "./JsonFormsDateFilterValuesControl"
+export {
   default as JsonFormsNavbarControl,
   jsonFormsNavbarControlTester,
 } from "./JsonFormsNavbarControl"

--- a/apps/studio/src/features/editing-experience/utils/__tests__/validateRequiredDateFilters.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/validateRequiredDateFilters.test.ts
@@ -1,0 +1,105 @@
+import { TAG_CATEGORY_TYPE } from "@opengovsg/isomer-components"
+
+import type { CollectionTags } from "../../hooks/useCollectionTags"
+import { validateRequiredDateFilters } from "../validateRequiredDateFilters"
+
+const REQUIRED_DATE_FILTER_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+const OPTIONAL_DATE_FILTER_ID = "a58bd21c-69dd-5483-b678-1f13c3d4e580"
+const OTHER_REQUIRED_DATE_FILTER_ID = "b69ce32d-7aee-6594-c789-2g24d4e5f691"
+
+const requiredDateFilter: CollectionTags[number] = {
+  id: REQUIRED_DATE_FILTER_ID,
+  label: "Event Date",
+  type: TAG_CATEGORY_TYPE.Date,
+  isRequired: true,
+  statusLabels: {
+    ENDED: "Event ended",
+    ONGOING: "Ongoing",
+    UPCOMING: "Upcoming",
+  },
+}
+
+const optionalDateFilter: CollectionTags[number] = {
+  ...requiredDateFilter,
+  id: OPTIONAL_DATE_FILTER_ID,
+  label: "Registration Deadline",
+  isRequired: false,
+}
+
+const otherRequiredDateFilter: CollectionTags[number] = {
+  ...requiredDateFilter,
+  id: OTHER_REQUIRED_DATE_FILTER_ID,
+  label: "Booth Setup",
+}
+
+const requiredTextCategory: CollectionTags[number] = {
+  id: "c70df43e-8bff-76a5-d89a-3h35e5f6g702",
+  label: "Topic",
+  isRequired: true,
+  options: [{ id: "some-option-id", label: "Technology" }],
+}
+
+describe("validateRequiredDateFilters", () => {
+  it("returns valid when there are no date filters", () => {
+    const result = validateRequiredDateFilters([], undefined)
+
+    expect(result.isValid).toBe(true)
+    expect(result.unfilledRequiredDateFilters).toEqual([])
+  })
+
+  it("returns valid when no date filters are required", () => {
+    const result = validateRequiredDateFilters([optionalDateFilter], undefined)
+
+    expect(result.isValid).toBe(true)
+    expect(result.unfilledRequiredDateFilters).toEqual([])
+  })
+
+  it("returns valid when a required date filter has a value", () => {
+    const result = validateRequiredDateFilters(
+      [requiredDateFilter],
+      [{ id: REQUIRED_DATE_FILTER_ID, date: "2026-06-15" }],
+    )
+
+    expect(result.isValid).toBe(true)
+    expect(result.unfilledRequiredDateFilters).toEqual([])
+  })
+
+  it("returns invalid when a required date filter has no value at all", () => {
+    const result = validateRequiredDateFilters([requiredDateFilter], undefined)
+
+    expect(result.isValid).toBe(false)
+    expect(result.unfilledRequiredDateFilters).toEqual([requiredDateFilter])
+  })
+
+  it("returns invalid when the value exists but has no date filled in", () => {
+    const result = validateRequiredDateFilters(
+      [requiredDateFilter],
+      [{ id: REQUIRED_DATE_FILTER_ID, date: "" }],
+    )
+
+    expect(result.isValid).toBe(false)
+    expect(result.unfilledRequiredDateFilters).toEqual([requiredDateFilter])
+  })
+
+  it("ignores text-type tag categories entirely", () => {
+    const result = validateRequiredDateFilters(
+      [requiredTextCategory],
+      undefined,
+    )
+
+    expect(result.isValid).toBe(true)
+    expect(result.unfilledRequiredDateFilters).toEqual([])
+  })
+
+  it("returns only unfilled required date filters when multiple are configured", () => {
+    const result = validateRequiredDateFilters(
+      [requiredDateFilter, otherRequiredDateFilter, optionalDateFilter],
+      [{ id: REQUIRED_DATE_FILTER_ID, date: "2026-06-15" }],
+    )
+
+    expect(result.isValid).toBe(false)
+    expect(result.unfilledRequiredDateFilters).toEqual([
+      otherRequiredDateFilter,
+    ])
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/__tests__/validateRequiredTags.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/validateRequiredTags.test.ts
@@ -1,3 +1,5 @@
+import { TAG_CATEGORY_TYPE } from "@opengovsg/isomer-components"
+
 import type { CollectionTags } from "../../hooks/useCollectionTags"
 import { validateRequiredTags } from "../validateRequiredTags"
 
@@ -117,6 +119,31 @@ describe("validateRequiredTags", () => {
     // Assert
     expect(result.isValid).toBe(false)
     expect(result.unfilledRequiredCategories).toEqual([requiredCategory])
+  })
+
+  it("ignores date-type tag categories entirely, even if required", () => {
+    // Arrange
+    const requiredDateFilter: CollectionTags[number] = {
+      id: "e92f065f-0dhh-98c7-f0bc-5j57g7h8i924",
+      label: "Event Date",
+      type: TAG_CATEGORY_TYPE.Date,
+      isRequired: true,
+      statusLabels: {
+        ENDED: "Event ended",
+        ONGOING: "Ongoing",
+        UPCOMING: "Upcoming",
+      },
+    }
+
+    // Act
+    const result = validateRequiredTags(
+      [requiredDateFilter, requiredCategory],
+      [REQUIRED_OPTION_ID],
+    )
+
+    // Assert
+    expect(result.isValid).toBe(true)
+    expect(result.unfilledRequiredCategories).toEqual([])
   })
 
   it("treats isRequired as false when omitted on a category", () => {

--- a/apps/studio/src/features/editing-experience/utils/validateRequiredDateFilters.ts
+++ b/apps/studio/src/features/editing-experience/utils/validateRequiredDateFilters.ts
@@ -1,0 +1,25 @@
+import type { ArticlePagePageProps } from "@opengovsg/isomer-components"
+import { isDateFilter } from "@opengovsg/isomer-components"
+
+import type { CollectionTags } from "../hooks/useCollectionTags"
+
+// Mirrors validateRequiredTags, but for date filters: `isRequired` is
+// satisfied by the item having a `dateTagged` entry (with a `date`
+// filled in) for that filter's id, rather than a `tagged` option id.
+export function validateRequiredDateFilters(
+  tags: CollectionTags,
+  dateTagged: ArticlePagePageProps["dateTagged"],
+) {
+  const unfilledRequiredDateFilters = tags
+    .filter(isDateFilter)
+    .filter(
+      ({ id, isRequired }) =>
+        isRequired &&
+        !dateTagged?.some((value) => value.id === id && value.date),
+    )
+
+  return {
+    unfilledRequiredDateFilters,
+    isValid: unfilledRequiredDateFilters.length === 0,
+  }
+}

--- a/apps/studio/src/features/editing-experience/utils/validateRequiredTags.ts
+++ b/apps/studio/src/features/editing-experience/utils/validateRequiredTags.ts
@@ -1,4 +1,5 @@
 import type { ArticlePagePageProps } from "@opengovsg/isomer-components"
+import { isTextFilter } from "@opengovsg/isomer-components"
 
 import type { CollectionTags } from "../hooks/useCollectionTags"
 
@@ -6,12 +7,14 @@ export function validateRequiredTags(
   tags: CollectionTags,
   tagged: ArticlePagePageProps["tagged"],
 ) {
-  const unfilledRequiredCategories = tags.filter(
-    ({ isRequired, options }) =>
-      isRequired &&
-      options.length > 0 &&
-      !options.some(({ id }) => tagged?.includes(id)),
-  )
+  const unfilledRequiredCategories = tags
+    .filter(isTextFilter)
+    .filter(
+      ({ isRequired, options }) =>
+        isRequired &&
+        options.length > 0 &&
+        !options.some(({ id }) => tagged?.includes(id)),
+    )
 
   return {
     unfilledRequiredCategories,

--- a/apps/studio/src/features/gazettes/contexts/GazetteSubcategoriesContext.tsx
+++ b/apps/studio/src/features/gazettes/contexts/GazetteSubcategoriesContext.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react"
+import { isTextFilter } from "@opengovsg/isomer-components"
 import { filter } from "lodash-es"
 import { createContext, useContext, useMemo } from "react"
 import { trpc } from "~/utils/trpc"
@@ -39,12 +40,12 @@ export const GazetteSubcategoriesProvider = ({
   })
 
   const value = useMemo(() => {
-    const subcategoryCategory = tagCategories?.find(
-      (cat) => cat.label === GAZETTE_SUBCATEGORY_LABEL,
-    )
+    const subcategoryCategory = tagCategories
+      ?.filter(isTextFilter)
+      .find((cat) => cat.label === GAZETTE_SUBCATEGORY_LABEL)
 
     const subcategories =
-      subcategoryCategory?.options?.map((option) => ({
+      subcategoryCategory?.options.map((option) => ({
         label: option.label,
         value: option.id,
       })) ?? []

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -36,6 +36,12 @@ const slashDateSchema = z
     return format(d, SLASH_DATE_FORMAT)
   })
 
+const dateTaggedEntrySchema = z.object({
+  id: z.string().uuid(),
+  date: z.string().min(1),
+  endDate: z.string().optional(),
+})
+
 export const editLinkSchema = z.object({
   date: slashDateSchema.optional(),
   category: z.string(),
@@ -52,6 +58,7 @@ export const editLinkSchema = z.object({
     )
     .optional(),
   tagged: z.array(z.string()).optional(),
+  dateTagged: z.array(dateTaggedEntrySchema).optional(),
   image: z
     .object({
       src: z.string(),

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1614,6 +1614,34 @@ describe("collection.router", async () => {
       await expect(result).rejects.toMatchObject({ code: "BAD_REQUEST" })
     })
 
+    it("should persist dateTagged on the collection link page blob", async () => {
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+
+      const dateTagged = [
+        {
+          id: "550e8400-e29b-41d4-a716-446655440000",
+          date: "2026-01-15",
+          endDate: "2026-01-20",
+        },
+      ]
+
+      const expected = await caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "1",
+        linkId: Number(page.id),
+        dateTagged,
+      })
+
+      expect(
+        (expected.content.page as { dateTagged?: typeof dateTagged })
+          .dateTagged,
+      ).toEqual(dateTagged)
+    })
+
     it.skip("should throw when trying to update to a deleted `ref`")
 
     it.skip("should throw when trying to update to an invalid `ref`")

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -469,6 +469,13 @@ export const getLocalisedSitemap = async (
       ELSE NULL
     END
 `.as("tagged")
+  const dateTaggedSql = sql<string | null>`
+    CASE
+      WHEN (published.content ->> 'layout') IN ('article','link')
+      THEN (published.content -> 'page' ->> 'dateTagged')
+      ELSE NULL
+    END
+`.as("dateTagged")
 
   // Get the actual resource first
   const resource = await getById(db, { resourceId, siteId })
@@ -492,6 +499,7 @@ export const getLocalisedSitemap = async (
           dateSql,
           firstImageSql,
           taggedSql,
+          dateTaggedSql,
           ...defaultResourceSelect,
         ])
         .unionAll((fb) =>
@@ -513,6 +521,7 @@ export const getLocalisedSitemap = async (
                 .cast<FirstImage | null>(eb.val(null), "jsonb")
                 .as("firstImage"),
               eb.cast<string | null>(eb.val(null), "text").as("tagged"),
+              eb.cast<string | null>(eb.val(null), "text").as("dateTagged"),
               ...defaultResourceSelect,
             ]),
         ),
@@ -541,6 +550,7 @@ export const getLocalisedSitemap = async (
           dateSql,
           firstImageSql,
           taggedSql,
+          dateTaggedSql,
           ...defaultResourceSelect,
         ]),
     )
@@ -564,6 +574,7 @@ export const getLocalisedSitemap = async (
           dateSql,
           firstImageSql,
           eb.cast<string | null>(eb.val(null), "text").as("tagged"),
+          eb.cast<string | null>(eb.val(null), "text").as("dateTagged"),
           ...defaultResourceSelect,
         ])
         .unionAll((fb) =>
@@ -590,6 +601,7 @@ export const getLocalisedSitemap = async (
               dateSql,
               firstImageSql,
               eb.cast<string | null>(eb.val(null), "text").as("tagged"),
+              eb.cast<string | null>(eb.val(null), "text").as("dateTagged"),
               ...defaultResourceSelect,
             ]),
         ),
@@ -603,6 +615,7 @@ export const getLocalisedSitemap = async (
       "date",
       "firstImage",
       "tagged",
+      "dateTagged",
       ...defaultResourceSelect,
     ])
     .union((eb) =>
@@ -615,6 +628,7 @@ export const getLocalisedSitemap = async (
           "date",
           "firstImage",
           "tagged",
+          "dateTagged",
           ...defaultResourceSelect,
         ]),
     )
@@ -628,6 +642,7 @@ export const getLocalisedSitemap = async (
           "date",
           "firstImage",
           "tagged",
+          "dateTagged",
           ...defaultResourceSelect,
         ]),
     )

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -165,3 +165,25 @@ export const WithTags: Story = {
     await userEvent.click(button)
   },
 }
+
+// Shows the date filter's date picker within the collection item's metadata
+// drawer, when the parent collection index page has a date filter enabled.
+export const WithDateFilter: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.getCollectionTags.withDateFilter(),
+        sitesHandlers.getLocalisedSitemap.collection(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const button = await canvas.findByRole("button", {
+      name: /article page header/i,
+    })
+
+    await userEvent.click(button)
+  },
+}

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -33,6 +33,7 @@ type ResourceDto = Omit<
   thumbnail?: string
   category?: string
   tagged?: string | null
+  dateTagged?: string | null
   date?: string
   firstImage?: FirstImage | null
 }
@@ -42,6 +43,20 @@ const parseTagged = (raw: string | null | undefined): string[] | undefined => {
   try {
     const parsed = JSON.parse(raw) as unknown
     return Array.isArray(parsed) ? (parsed as string[]) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const parseDateTagged = (
+  raw: string | null | undefined,
+): ArticlePagePageProps["dateTagged"] => {
+  if (!raw) return undefined
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed)
+      ? (parsed as ArticlePagePageProps["dateTagged"])
+      : undefined
   } catch {
     return undefined
   }
@@ -122,6 +137,7 @@ const getSitemapTreeFromArray = (
         permalink,
         category: resource.category ?? "Others",
         tagged: parseTagged(resource.tagged),
+        dateTagged: parseDateTagged(resource.dateTagged),
         date: resource.date ?? "",
         image: {
           src: resource.thumbnail ?? "",
@@ -140,6 +156,7 @@ const getSitemapTreeFromArray = (
         permalink,
         category: resource.category ?? "Others",
         tagged: parseTagged(resource.tagged),
+        dateTagged: parseDateTagged(resource.dateTagged),
         date: resource.date ?? "",
         image: {
           src: resource.thumbnail ?? "",
@@ -281,6 +298,7 @@ export const injectTagMappings = async (
     // we cast to all the possible `page` props
     // of a collection item
     childPageProps.tagged,
+    childPageProps.dateTagged,
     collectionPageProps.tagCategories,
     resource.id,
     resource.parentId,
@@ -291,6 +309,7 @@ export const injectTagMappings = async (
 const _injectTagMappings = (
   sitemap: IsomerSitemap,
   tagged: ArticlePagePageProps["tagged"],
+  dateTagged: ArticlePagePageProps["dateTagged"],
   tagCategories: CollectionPagePageProps["tagCategories"],
   childId: CollectionItemResourceDto["id"],
   collectionId: CollectionItemResourceDto["parentId"],
@@ -298,7 +317,7 @@ const _injectTagMappings = (
   // NOTE: If the child id matches,
   // inject the tags
   if (sitemap.id === childId) {
-    return { ...sitemap, tagged }
+    return { ...sitemap, tagged, dateTagged }
   }
 
   // NOTE: If the collection id matches,
@@ -314,7 +333,14 @@ const _injectTagMappings = (
         tagCategories,
       },
       children: sitemap.children?.map((child) =>
-        _injectTagMappings(child, tagged, tagCategories, childId, collectionId),
+        _injectTagMappings(
+          child,
+          tagged,
+          dateTagged,
+          tagCategories,
+          childId,
+          collectionId,
+        ),
       ),
     }
   }
@@ -324,7 +350,14 @@ const _injectTagMappings = (
   return {
     ...sitemap,
     children: sitemap.children?.map((child) =>
-      _injectTagMappings(child, tagged, tagCategories, childId, collectionId),
+      _injectTagMappings(
+        child,
+        tagged,
+        dateTagged,
+        tagCategories,
+        childId,
+        collectionId,
+      ),
     ),
   }
 }

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -1,7 +1,11 @@
 import type { DelayMode } from "msw"
 import type { getPageById } from "~/server/modules/resource/resource.service"
 import type { RouterOutput } from "~/utils/trpc"
-import { DEFAULT_TAG_CATEGORY_DISPLAY } from "@opengovsg/isomer-components"
+import {
+  DEFAULT_DATE_FILTER_STATUS_LABELS,
+  DEFAULT_TAG_CATEGORY_DISPLAY,
+  TAG_CATEGORY_TYPE,
+} from "@opengovsg/isomer-components"
 import { delay } from "msw"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
@@ -245,6 +249,19 @@ export const pageHandlers = {
                 id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
               },
             ],
+          },
+        ]
+      })
+    },
+    withDateFilter: () => {
+      return trpcMsw.collection.getCollectionTags.query(() => {
+        return [
+          {
+            label: "Event date",
+            id: "f47ac10b-58cc-4372-a567-0e02b2c3d480",
+            type: TAG_CATEGORY_TYPE.Date,
+            isRequired: true,
+            statusLabels: DEFAULT_DATE_FILTER_STATUS_LABELS,
           },
         ]
       })


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 15 | +276 | -20 |
| 🧪 Test | 6 | +201 | -2 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Once date filters exist on a collection index page, editors need to enter dates on individual collection pages and links, with required-field validation and persistence into the sitemap pipeline.

**PR 4b of the date-filters stack**, stacked on `feat/date-filters-studio-config`.

Stack: … → `feat/date-filters-studio-config` → **4b (this PR)** → `cursor/date-filter-visibility-toggles-1d14` → …

part of https://github.com/opengovsg/isomer/pull/3158 originally but i split it into 2 to improve reviewability


## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- `JsonFormsDateFilterValuesControl` — per-item date/date-range inputs on collection pages and links.
- `validateRequiredDateFilters` — required-field validation mirroring `validateRequiredTags`.
- `resource.service.ts` / `sitemap.ts` — read `dateTagged` from page blobs for sitemap generation.

**Improvements**:

- `MetadataEditorStateDrawer`, `LinkEditorDrawer` — save blocked when required date filters are empty.
- Query cache invalidation for filter usage counts when item editors save.

## Tests

**Manual Verification Steps**:

- [ ] Create a date filter on a collection index page (requires 4a merged or stacked), then open a child page — confirm date input fields appear
- [ ] Enter a date (and optional end date) on a child page, save — confirm no validation errors
- [ ] Leave a required date filter blank on a child page, save — confirm validation error
- [ ] Edit a collection link with date filters — confirm dates persist on save
- [ ] Confirm `dateTagged` appears in localised sitemap output for items with dates entered


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62231634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/opengovsg/-/pull-requests/opengovsg/isomer/3380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because collection-link inputs can persist malformed dates that break downstream date rendering.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fschemas%2Fcollection.ts%3A39%0AThe%20new%20input%20schema%20accepts%20any%20non-empty%20%60date%60%20and%20any%20string%20for%20%60endDate%60%2C%20even%20though%20the%20shared%20content%20schema%20requires%20date-formatted%20values.%20An%20authenticated%20API%20caller%20or%20raw%20JSON%20editor%20can%20therefore%20persist%20a%20value%20such%20as%20%60%22invalid%22%60%3B%20collection%20rendering%20later%20passes%20it%20through%20%60parseISO%60%20and%20%60format%60%2C%20which%20can%20throw%20and%20break%20collection%20cards%20or%20article%20headers.%20Constrain%20both%20fields%20to%20valid%20ISO%20calendar%20dates.%20Also%20add%20a%20user-facing%20message%20to%20the%20new%20%60.min%281%29%60%20constraint%2C%20as%20required%20for%20schema%20validators%20in%20this%20repository.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3380&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Malformed Dates Reach Rendering** <a href="https://github.com/opengovsg/isomer/pull/3380#discussion_r3971550495">▶</a>

<details><summary><h3>Summary</h3></summary>

- Adds schema-driven date and date-range controls for collection pages and links.
- Blocks normal saves when required date filters are unfilled.
- Persists collection-link date tags and propagates page-blob values into localised sitemap entries.
- Refreshes the consolidated filter-usage query after collection-item edits.
- The collection-link write schema still needs to enforce the shared calendar-date contract before the change is safe to merge.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Collection date-filter configuration] --> B[Studio item editor]
  B --> C[Required-field validation]
  C -->|Valid| D[Draft page blob]
  D --> E[Localised sitemap query]
  E --> F[Parse dateTagged]
  F --> G[Collection filters and date display]
  C -->|Invalid| H[Save disabled]
```
</details>

<!-- /greptile_comment -->

## /show-me to help explain what this PR does

This PR wires the **per-item side** of date filters: collection pages/links gain a `dateTagged` field, a date-picker control to fill it in, required-field validation, and a path for it to reach the localised sitemap.

### What changed, file by file

```
apps/studio/src/schemas/collection.ts
  + dateTaggedEntrySchema = { id: uuid, date: string, endDate?: string }
  + editLinkSchema.dateTagged?: dateTaggedEntrySchema[]

apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/
  JsonFormsDateFilterValuesControl.tsx   NEW  — renders a DateRangePicker per date-filter tag
  JsonFormsTaggedControl.tsx                  — now .filter(isTextFilter): date filters skip this control

apps/studio/src/features/editing-experience/utils/
  validateRequiredDateFilters.ts         NEW  — mirrors validateRequiredTags, but for dateTagged
  validateRequiredTags.ts                     — now .filter(isTextFilter), same category split

apps/studio/src/features/editing-experience/components/Drawer/
  LinkEditorDrawer.tsx, MetadataEditorStateDrawer.tsx
    isTagsValid = isTaggedValid && isDateTaggedValid
    countTagOptionsUsage.invalidate() -> countFilterUsage.invalidate()

apps/studio/src/server/modules/resource/resource.service.ts
  getLocalisedSitemap: + dateTaggedSql pulling content->'page'->>'dateTagged'
                         (added to every draft/published/collection/non-collection branch)

apps/studio/src/utils/sitemap.ts
  + parseDateTagged(raw) -> ArticlePagePageProps["dateTagged"] | undefined
    threaded through _injectTagMappings(child, tagged, dateTagged, ...)
```

### How one tag category becomes two controls

```mermaid
flowchart TD
    CT["CollectionTags (getCollectionTags)"]
    CT -->|isTextFilter| TC[JsonFormsTaggedControl]
    CT -->|isDateFilter| DC["JsonFormsDateFilterValuesControl (format === 'date-tagged')"]

    TC -->|writes| TAGGED["page.tagged: string[]"]
    DC -->|writes| DTAGGED["page.dateTagged: {id,date,endDate?}[]"]

    TAGGED --> V1[validateRequiredTags]
    DTAGGED --> V2[validateRequiredDateFilters]

    V1 --> SAVE{"isTagsValid = isTaggedValid && isDateTaggedValid"}
    V2 --> SAVE
    SAVE -->|enabled| tRPC["updateCollectionLink / updatePage"]

    tRPC --> BLOB[("content JSON blob")]
    BLOB -->|"resource.service.ts: dateTaggedSql"| SITEMAP[getLocalisedSitemap]
    SITEMAP -->|"sitemap.ts: parseDateTagged"| TREE["sitemap tree: item.dateTagged"]
```

### The new control's upsert logic (`JsonFormsDateFilterValuesControl.tsx`)

```diff
  for each dateFilter in tags.filter(isDateFilter):
    existing = data?.find(v => v.id === dateFilter.id)
    value: DateRangeValue = existing
      ? [parseISO(existing.date), existing.endDate ? parseISO(existing.endDate) : null]
      : [null, null]

    <DateRangePicker value={value} onChange={([start, end]) => {
+     others = data?.filter(v => v.id !== dateFilter.id) ?? []
+     if (!start) return handleChange(path, others)          // cleared -> drop entry
+     handleChange(path, [...others, {
+       id: dateFilter.id,
+       date: format(start, "yyyy-MM-dd"),
+       ...(end ? { endDate: format(end, "yyyy-MM-dd") } : {}),
+     }])
    }} />
```

No separate single-date/range toggle: picking just a start date yields a single-date entry, picking a second date promotes it to a range — this rides on `DateRangePicker`'s own `[Date,Date] | [Date,null] | [null,null]` value shape.
