### PR TITLE
docs(components): clarify monorepo release sequence for new blocks

### DIFF
--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -31,7 +31,7 @@ Things that violate the contract:
 - A component that branches behaviour on a Studio-internal feature flag.
 - Studio importing a private (un-exported) symbol from `packages/components/src/`.
 
-If you need new data on the rendering side, add it to the **schema and interfaces first**, ship that PR, then update Studio to produce the new shape in a follow-up PR. The schema PR must remain backward-compatible (new fields are optional) so Studio doesn't break in between.
+If you need new data on the rendering side, add it to the **schema and interfaces first**, then update Studio to produce the new shape in the same PR. New fields must remain backward-compatible (optional) so existing published content still validates.
 
 ## No UI logic in JSONForms components
 

--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -74,7 +74,13 @@ src/
 3. Add the schema entry under `src/schemas/` — must be backward compatible.
 4. Add a Storybook story under `src/stories/` covering the new variants.
 5. Export from `src/index.ts` (or the relevant sub-index) so Studio can consume it.
-6. Bump the package version and update Studio in a follow-up PR.
+6. Register the block in Studio (picker entry, default content, layout allowlists) in the same PR.
+
+### Versioning
+
+Studio depends on this package via `workspace:*` in the monorepo. Ship new blocks and their Studio integration together in one PR — do **not** bump `packages/components/package.json` or split Studio changes into a follow-up PR for monorepo work.
+
+Bump the package version only when preparing an npm release for consumers outside this repo.
 
 ## Conventions
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 0 | +0 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 1 | +8 | -2 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Greptile flagged [#3356](https://github.com/opengovsg/isomer/pull/3356) for not following the documented release sequence in `packages/components/CLAUDE.md` ("Bump the package version and update Studio in a follow-up PR"). @adriangohjw confirmed that guidance is outdated — Studio consumes this package via `workspace:*`, and recent feature PRs ship components and Studio integration together without a separate version bump.

Ref: [Greptile review comment on `Steps.ts`](https://github.com/opengovsg/isomer/pull/3356#discussion_r3977754898)

## Solution

Update `packages/components/CLAUDE.md` to reflect current practice:

- New blocks register Studio integration (picker, defaults, layout allowlists) in the **same PR**
- No `package.json` version bump or follow-up PR is required for monorepo work
- Version bumps are only needed when preparing an npm release for external consumers
- Schema/interface changes also ship with Studio updates in the same PR (reconciles the earlier contract section with the new-block guidance)

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

## Tests

Documentation-only change — no runtime tests required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6330813-1a26-4b96-9629-2dbe664ea374?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6330813-1a26-4b96-9629-2dbe664ea374&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62925600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The documentation change is non-blocking, but its conflicting sequencing instructions should be reconciled to avoid inconsistent component and Studio contribution workflows.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcomponents%2FCLAUDE.md%3A77-81%0AThe%20new%20guidance%20says%20to%20register%20new%20blocks%20in%20Studio%20in%20the%20same%20PR%20and%20not%20split%20the%20work%20into%20a%20follow-up.%20However%2C%20line%2034%20still%20says%20to%20ship%20schema%20and%20interface%20changes%20first%2C%20then%20update%20Studio%20in%20a%20follow-up%20PR.%20New%20blocks%20introduce%20schema-backed%20data%2C%20so%20these%20instructions%20conflict%20and%20may%20lead%20contributors%20to%20follow%20different%20release%20sequences.%20Please%20update%20line%2034%20or%20narrow%20the%20new%20guidance%20so%20the%20intended%20sequence%20is%20clear.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3396&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Conflicting Release Instructions** <a href="https://github.com/opengovsg/isomer/pull/3396#discussion_r3985703412">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/components/CLAUDE.md:77-81
The new guidance says to register new blocks in Studio in the same PR and not split the work into a follow-up. However, line 34 still says to ship schema and interface changes first, then update Studio in a follow-up PR. New blocks introduce schema-backed data, so these instructions conflict and may lead contributors to follow different release sequences. Please update line 34 or narrow the new guidance so the intended sequence is clear.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Requires new blocks and their Studio registration to land together.
- Clarifies that monorepo changes do not require a package version bump.
- Reserves version bumps for external package releases.
- Leaves an older, contradictory follow-up-PR instruction elsewhere in the same guide.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(components): clarify monorepo relea..."](https://github.com/opengovsg/isomer/commit/b6d55d6421fb0573fc5702871d04e0348f89d841)</sub>

<!-- /greptile_comment -->