### PR TITLE
feat(components): support optional CTA button on article page header

### DIFF
--- a/packages/components/src/interfaces/internal/ArticlePageHeader.ts
+++ b/packages/components/src/interfaces/internal/ArticlePageHeader.ts
@@ -1,5 +1,7 @@
 import type { Static } from "@sinclair/typebox"
+import type { IsomerSiteProps } from "~/types"
 import { Type } from "@sinclair/typebox"
+import { LINK_HREF_PATTERN } from "~/utils/validation"
 
 import type { BreadcrumbProps } from "./Breadcrumb"
 import type { CollectionCardProps } from "./CollectionCard"
@@ -11,6 +13,21 @@ export const ArticlePageHeaderSchema = Type.Object({
     format: "textarea",
     maxLength: 500,
   }),
+  buttonLabel: Type.Optional(
+    Type.String({
+      title: "Button label",
+      description:
+        "A descriptive text. Avoid generic text like “Here”, “Click here”, or “Learn more”",
+    }),
+  ),
+  buttonUrl: Type.Optional(
+    Type.String({
+      title: "Button destination",
+      description: "When this is clicked, open:",
+      format: "link",
+      pattern: LINK_HREF_PATTERN,
+    }),
+  ),
 })
 
 export type ArticlePageHeaderProps = Static<typeof ArticlePageHeaderSchema> & {
@@ -19,4 +36,5 @@ export type ArticlePageHeaderProps = Static<typeof ArticlePageHeaderSchema> & {
   title: string
   plaintextTags?: CollectionCardProps["plaintextTags"]
   date?: string
+  site: IsomerSiteProps
 }

--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import type { ArticlePageHeaderProps } from "~/interfaces"
+import { generateSiteConfig } from "~/stories/helpers"
 
 import { ArticlePageHeader } from "./ArticlePageHeader"
 
@@ -11,6 +12,9 @@ const meta: Meta<ArticlePageHeaderProps> = {
     themes: {
       themeOverride: "Isomer Next",
     },
+  },
+  args: {
+    site: generateSiteConfig(),
   },
 }
 export default meta
@@ -75,5 +79,13 @@ export const ArticleWithTags: Story = {
         selected: ["NParks Happenings", "Wild dinosaur"],
       },
     ],
+  },
+}
+
+export const WithButton: Story = {
+  args: {
+    ...ARTICLE,
+    buttonLabel: "Report wildlife crime",
+    buttonUrl: "https://www.nparks.gov.sg/report-wildlife-crime",
   },
 }

--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -1,7 +1,9 @@
 import type { ArticlePageHeaderProps } from "~/interfaces"
 import { getFormattedDate } from "~/utils/getFormattedDate"
+import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
 import { Breadcrumb } from "../Breadcrumb"
+import { LinkButton } from "../LinkButton"
 import { PillTags, PlaintextTags } from "../Tags"
 
 export const ArticlePageHeader = ({
@@ -11,6 +13,9 @@ export const ArticlePageHeader = ({
   date,
   summary,
   pillTags,
+  buttonLabel,
+  buttonUrl,
+  site,
 }: ArticlePageHeaderProps) => {
   return (
     <div className="mx-auto w-full">
@@ -44,6 +49,21 @@ export const ArticlePageHeader = ({
           <p className="prose-title-lg whitespace-pre-wrap text-base-content-light">
             {summary}
           </p>
+        )}
+
+        {buttonLabel && buttonUrl && (
+          <div className="mt-4">
+            <LinkButton
+              href={getReferenceLinkHref(
+                buttonUrl,
+                site.siteMapArray,
+                site.assetsBaseUrl,
+              )}
+              isWithFocusVisibleHighlight
+            >
+              {buttonLabel}
+            </LinkButton>
+          </div>
         )}
       </div>
     </div>

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -43,6 +43,7 @@ export const ArticleLayout = ({
           title={page.title}
           date={page.date}
           pillTags={pillTags}
+          site={site}
         />
 
         <div className="mx-auto w-full gap-10 pb-20">


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +39 | -0 |
| 🧪 Test | 1 | +12 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The article page header currently has no way to surface a call-to-action — editors can add a summary, tags, and a date, but nothing that drives readers to a next action (e.g. "Register for this event", "Download the report").

## Solution

Adds an optional CTA button to the article page header, mirroring the existing single-CTA pattern already used by `ContentPageHeader`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- `ArticlePageHeaderSchema` gains two new optional fields, `buttonLabel` and `buttonUrl` (same shape, copy, and `LINK_HREF_PATTERN` validation as `ContentPageHeader`'s equivalent fields), surfaced automatically in the Studio editor via the shared JSON Schema — no Studio-side code changes needed.
- `ArticlePageHeader` renders a single `LinkButton` below the summary when both `buttonLabel` and `buttonUrl` are present; internal `[resource:id:id]` references are resolved via `getReferenceLinkHref`, consistent with how `ContentPageHeader` resolves its button link.

**Improvements**:

- N/A

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] In Studio, open an Article page's page settings and confirm a new optional "Button label" and "Button destination" field appear alongside the existing "Article summary" field.
- [ ] Leave both fields empty, publish/preview the article, and confirm the header renders exactly as before (no button, no layout shift).
- [ ] Fill in only one of the two fields (e.g. label but no URL), publish/preview, and confirm no button renders (both fields are required together).
- [ ] Fill in both fields with an external URL (e.g. `https://www.google.com`), publish/preview, and confirm the button renders below the summary and navigates correctly, including showing the external-link icon.
- [ ] Fill in both fields with an internal reference link (pick another page via the link picker), publish/preview, and confirm the button resolves to the correct internal permalink.
- [ ] Confirm the new `WithButton` story renders correctly in Storybook (`Next/Internal Components/ArticlePageHeader`).

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62975909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the optional CTA data flowing correctly from the schema through the article layout to the rendered button.

<details><summary><h3>Summary</h3></summary>

- Extends the backward-compatible article header schema with optional button label and destination fields.
- Passes site configuration into the header for internal resource and asset URL resolution.
- Adds a Storybook example covering an external CTA.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Studio article header fields] --> B[ArticlePageHeaderSchema]
    B --> C[page.articlePageHeader]
    C --> D[ArticleLayout]
    D --> E[ArticlePageHeader]
    F[Site configuration] --> D
    E --> G[getReferenceLinkHref]
    F --> G
    G --> H[LinkButton]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(components): support optional CTA b..."](https://github.com/opengovsg/isomer/commit/a9b081963828c0ac945d7da53ba50c5080a3ba8f)</sub>

<!-- /greptile_comment -->