### PR TITLE
fix: align publish toast copy with publishing delay

### DIFF
--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -64,7 +64,8 @@ const SuspendablePublishButton = ({
       fireContentEditSurveyEvent(PUBLISHED_AFTER_EDITING_EVENT)
       toast({
         status: "success",
-        title: "Page published successfully",
+        title: "Publishing in progress",
+        description: "Changes will be live on your site in 5-10 minutes.",
         ...BRIEF_TOAST_SETTINGS,
       })
       if (publishNowDisclosure.isOpen) publishNowDisclosure.onClose()


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +2 | -1 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
- The success toast fired right after clicking Publish said "Page published successfully", while the confirm dialog warns changes take ~5-10 minutes to go live — misleading users into thinking it's already done.
- Updated the toast title to "Publishing in progress" with a description matching the delay copy already used elsewhere in the app (`SETTINGS_TOAST_MESSAGES`, `PageSettingsModal`).

Fixes [ISOM-2565](https://linear.app/ogp/issue/ISOM-2565/align-publish-toast-copy-with-publishing-delay)

## Test plan
- [x] `PublishButton.browser.test.tsx` passes
- [x] Oxlint clean on changed file
- [ ] Manual check: click Publish on a page, confirm toast reads "Publishing in progress" / "Changes will be live on your site in 5-10 minutes."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62984207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The copy change is behaviorally sound, but the repository’s explicit bug-fix verification requirement should be satisfied before merging.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2FPublishButton.tsx%3A66-68%0AThis%20bug%20fix%20changes%20the%20exact%20user-facing%20publish%20confirmation%2C%20but%20the%20existing%20%60PublishButton%60%20test%20only%20checks%20permission%20gating.%20It%20never%20invokes%20the%20mutation's%20%60onSuccess%60%20callback%20or%20verifies%20the%20toast.%20Add%20a%20focused%20assertion%20for%20both%20the%20%E2%80%9CPublishing%20in%20progress%E2%80%9D%20title%20and%20the%205%E2%80%9310%20minute%20description%20so%20the%20misleading%20completed-state%20copy%20cannot%20return%20unnoticed.%20The%20repository%20requires%20bug%20fixes%20to%20include%20the%20smallest%20regression%20test%20that%20demonstrates%20the%20reported%20failure%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0AGreptile%20automatically%20discovered%20a%20related%20ticket%20stating%20that%20the%20toast%20must%20not%20imply%20publication%20has%20completed%20while%20changes%20are%20still%20being%20updated%2C%20which%20informed%20this%20comment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3398&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Publish copy lacks coverage** <a href="https://github.com/opengovsg/isomer/pull/3398#discussion_r3987037350">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/studio/src/features/editing-experience/components/PublishButton.tsx:66-68
This bug fix changes the exact user-facing publish confirmation, but the existing `PublishButton` test only checks permission gating. It never invokes the mutation's `onSuccess` callback or verifies the toast. Add a focused assertion for both the “Publishing in progress” title and the 5–10 minute description so the misleading completed-state copy cannot return unnoticed. The repository requires bug fixes to include the smallest regression test that demonstrates the reported failure, so this requirement must be satisfied before merging.

Greptile automatically discovered a related ticket stating that the toast must not imply publication has completed while changes are still being updated, which informed this comment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Changes the title to “Publishing in progress.”
- Adds a description explaining when changes should become live.
- Leaves publishing behavior and mutation handling unchanged.
- The changed copy still needs focused regression coverage.

Greptile automatically discovered a related ticket that helped explain the purpose of this PR: prevent the immediate toast from claiming publication is complete while site updates are still propagating.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix: align publish toast copy with publi..."](https://github.com/opengovsg/isomer/commit/127cfc003c9a8031fec6f9c29d14df5da119dac5)</sub>

<!-- /greptile_comment -->