### PR TITLE
fix(resource): reject RootPage delete before audit log is written

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -715,6 +715,14 @@ export const resourceRouter = router({
             message: "The search page cannot be deleted",
           })
         }
+        // prevents user from deleting root page(issue #2387)
+        if (before.type===ResourceType.RootPage) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "The root page cannot be deleted",
+            })
+        }
+
 
         await logResourceEvent(tx, {
           siteId,


### PR DESCRIPTION
## Problem

Closes #2387

When you try to delete a `RootPage` resource, `logResourceEvent` runs before the actual `deleteFrom` query. The `deleteFrom` has a `.where("Resource.type", "!=", ResourceType.RootPage)` guard that silently returns `undefined` (no rows matched), so nothing gets deleted — but the audit log entry already got committed. You end up with a `BAD_REQUEST` on the caller side and a phantom delete event in the audit trail.

## Solution

Added a type check for `RootPage` before the audit log call, same pattern as the existing search page guard above it. If someone tries to delete a root page, we just throw `BAD_REQUEST` right away so the audit log never gets touched.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Root page delete requests no longer leave behind a fake `ResourceDelete` audit log entry

## Before & After Screenshots

N/A, backend only.

## Tests

**Manual Verification Steps**:

- [ ] Try deleting a `RootPage` resource as a site admin
- [ ]  Should get a `BAD_REQUEST` error saying "The root page cannot be deleted"
- [ ] Check that no `ResourceDelete` entry shows up in the audit log

**New scripts**:

None

**New dependencies**:

None

**New dev dependencies**:

None




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63035344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The behavioral fix and its regression test are sound, but the explicit server-layer ownership requirement must be satisfied before merging.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fresource%2Fresource.router.ts%3A718-724%0AThe%20new%20RootPage%20deletion%20guard%20adds%20domain%20validation%20directly%20inside%20the%20router%20callback.%20This%20violates%20the%20server%20directive%20that%20routers%20contain%20endpoints%20and%20permission%20checks%20while%20resource%20business%20rules%20belong%20in%20the%20service%20layer.%20Move%20this%20invariant%20into%20the%20resource%20service%20and%20have%20the%20router%20delegate%20to%20it.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3399&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Business Logic Inside Router** <a href="https://github.com/opengovsg/isomer/pull/3399#discussion_r4011808219">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/studio/src/server/modules/resource/resource.router.ts:718-724
The new RootPage deletion guard adds domain validation directly inside the router callback. This violates the server directive that routers contain endpoints and permission checks while resource business rules belong in the service layer. Move this invariant into the resource service and have the router delegate to it. This repository requirement must be satisfied before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

This PR prevents rejected RootPage deletions from creating phantom audit events and corrects the regression test so it waits for the mutation to settle before inspecting the audit spy.
- Rejects RootPage deletion before `logResourceEvent` executes.
- Verifies the `BAD_REQUEST` rejection before asserting that no audit call occurred.
- The prior regression-test finding is fully fixed.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Delete request] --> B[Permission check]
    B --> C{RootPage?}
    C -- Yes --> D[Return BAD_REQUEST]
    D --> E[No audit event]
    C -- No --> F[Audit and delete transaction]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["Merge branch &#39;opengovsg:main&#39; into fix/r..."](https://github.com/opengovsg/isomer/commit/8688b4506492d9a2a2e08e5c53255a93c6e7ad6a)</sub>

<!-- /greptile_comment -->